### PR TITLE
new exercise diffie-hellman

### DIFF
--- a/diffie-hellman.md
+++ b/diffie-hellman.md
@@ -1,0 +1,29 @@
+Alice and Bob use Diffie-Hellman key exchange to share secrets.  They start with prime numbers, pick private keys, generate and share public keys, and then generate a shared secret key.
+
+## Step 0
+
+The test program supplies prime numbers p and g.
+
+## Step 1
+
+Alice picks a private key, a, greater than 1 and less than p.  Bob does the same to pick a private key b.
+
+## Step 2
+
+Alice calcuates a public key A.
+
+    A = g**a mod p
+
+Using the same p and g, Bob similarly calculates a public key B from his private key b.
+
+## Step 3
+
+Alice and Bob exchange public keys.  Alice calculates secret key s.
+
+    s = B**a mod p
+
+Bob calculates
+
+    s = A**b mod p
+
+The calculations produce the same result!  Alice and Bob now share secret s.

--- a/diffie-hellman.yml
+++ b/diffie-hellman.yml
@@ -1,0 +1,4 @@
+---
+blurb: "Diffie-Hellman key exchange."
+source: "Wikipedia, 1024 bit key from www.cryptopp.com/wiki."
+source_url: "http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange"


### PR DESCRIPTION
Addresses https://github.com/exercism/xgo/issues/78.

It's an exercise in using big numbers.  For a language like Go that has big numbers, a random big number generator, and a modular exponentiation function, the solution doesn't require much code.  Still, I thought this exercise breaks down logically into steps.  The Go test program actually has an extra step (KeyPair) but I thought that step might seem redundant in object oriented languages so I left it out of the readme.  Also in the readme I used *\* to indicate exponentiation.  Alternatives I considered were ^ and `<sup>` but I thought ^ might be slightly less well understood and `<sup>` wouldn't render in all contexts.

The Wikipedia URL in the .yml has a non-ASCII dash in it.  You might check that the escaping is okay the way it is.
