### PR TITLE
Split lines in Markdown files for readability from terminal

### DIFF
--- a/allergies.md
+++ b/allergies.md
@@ -1,4 +1,6 @@
-An allergy test produces a single numeric score which contains the information about all the allergies the person has (that they were tested for).
+An allergy test produces a single numeric score which contains the
+information about all the allergies the person has (that they were
+tested for).
 
 The list of items (and their value) that were tested are:
 

--- a/anagram.md
+++ b/anagram.md
@@ -1,1 +1,3 @@
-Given `"listen"` and a list of candidates like `"enlists" "google" "inlets" "banana"` the program should return a list containing `"inlets"`.
+Given `"listen"` and a list of candidates like `"enlists" "google"
+"inlets" "banana"` the program should return a list containing
+`"inlets"`.

--- a/atbash-cipher.md
+++ b/atbash-cipher.md
@@ -1,5 +1,7 @@
-The Atbash cipher is a simple substitution cipher that relies on transposing all the letters in the alphabet such that the resulting alphabet is backwards. The first letter is replaced with the last letter, the second with the
-second-last, and so on.
+The Atbash cipher is a simple substitution cipher that relies on
+transposing all the letters in the alphabet such that the resulting
+alphabet is backwards. The first letter is replaced with the last
+letter, the second with the second-last, and so on.
 
 An Atbash cipher for the Latin alphabet would be as follows:
 
@@ -8,9 +10,10 @@ Plain:  abcdefghijklmnopqrstuvwxyz
 Cipher: zyxwvutsrqponmlkjihgfedcba
 ```
 
-It is a very weak cipher because it only has one possible key, and it is a
-simple monoalphabetic substitution cipher. However, this may not have been an issue in the cipher's time.
+It is a very weak cipher because it only has one possible key, and it is
+a simple monoalphabetic substitution cipher. However, this may not have
+been an issue in the cipher's time.
 
 ## Examples
-- Encoding "test" gives "gvhg"
-- Decoding "gvhg" gives "test"
+- Encoding `test` gives `gvhg`
+- Decoding `gvhg` gives `test`

--- a/bank-account.md
+++ b/bank-account.md
@@ -1,20 +1,23 @@
-A bank account can be accessed in multiple ways. Clients can make deposits and
-withdrawals using the internet, mobile phones, etc. Shops can charge against the
-account.
+A bank account can be accessed in multiple ways. Clients can make
+deposits and withdrawals using the internet, mobile phones, etc. Shops
+can charge against the account.
 
 Create an account that can be accessed from multiple threads/processes
 (terminology depends on your programming language).
 
-The account only needs to be available when the bank is open, though it may be
-available at all times. You will get notified when the bank opens and closes.
+The account only needs to be available when the bank is open, though it
+may be available at all times. You will get notified when the bank opens
+and closes.
 
 ## Instructions
 
-Run the test file, and fix each of the errors in turn. When you get the first
-test to pass, go to the first pending or skipped test, and make that pass as
-well. When all of the tests are passing, feel free to submit.
+Run the test file, and fix each of the errors in turn. When you get the
+first test to pass, go to the first pending or skipped test, and make
+that pass as well. When all of the tests are passing, feel free to
+submit.
 
-Remember that passing code is just the first step. The goal is to work towards a
-solution that is as readable and expressive as you can make it.
+Remember that passing code is just the first step. The goal is to work
+towards a solution that is as readable and expressive as you can make
+it.
 
 Have fun!

--- a/beer-song.md
+++ b/beer-song.md
@@ -304,11 +304,14 @@ Go to the store and buy some more, 99 bottles of beer on the wall.
 
 ## For bonus points
 
-Did you get the tests passing and the code clean? If you want to, these are some additional things you could try:
+Did you get the tests passing and the code clean? If you want to, these
+are some additional things you could try:
 
 * Remove as much duplication as you possibly can.
 * Optimize for readability, even if it means introducing duplication.
-* If you've removed all the duplication, do you have a lot of conditionals? Try replacing the conditionals with polymorphism, if it applies in this language. How readable is it?
+* If you've removed all the duplication, do you have a lot of
+  conditionals? Try replacing the conditionals with polymorphism, if it
+  applies in this language. How readable is it?
 
-Then please share your thoughts in a comment on the submission. Did this experiment make the code better? Worse? Did you learn anything from it?
-
+Then please share your thoughts in a comment on the submission. Did this
+experiment make the code better? Worse? Did you learn anything from it?

--- a/binary-search-tree.md
+++ b/binary-search-tree.md
@@ -1,12 +1,26 @@
-When we need to represent sorted data, an array does not make a good data structure.
+When we need to represent sorted data, an array does not make a good
+data structure.
 
-Say we have the array `[1, 3, 4, 5]`, and we add 2 to it so it becomes `[1, 3, 4, 5, 2]` now we must sort the entire array again! We can improve on this by realizing that we only need to make space for the new item `[1, nil, 3, 4, 5]`, and then adding the item in the space we added. But this still requires us to shift many elements down by one.
+Say we have the array `[1, 3, 4, 5]`, and we add 2 to it so it becomes
+`[1, 3, 4, 5, 2]` now we must sort the entire array again! We can
+improve on this by realizing that we only need to make space for the new
+item `[1, nil, 3, 4, 5]`, and then adding the item in the space we
+added. But this still requires us to shift many elements down by one.
 
-Binary Search Trees, however, can operate on sorted data much more efficiently.
+Binary Search Trees, however, can operate on sorted data much more
+efficiently.
 
-A binary search tree consists of a series of connected nodes. Each node contains a piece of data (e.g. the number 3), a variable named `left`, and a variable named `right`. The `left` and `right` variables point at `nil`, or other nodes. Since these other nodes in turn have other nodes beneath them, we say that the left and right variables are pointing at subtrees. All data in the left subtree is less than or equal to the current node's data, and all data in the right subtree is greater than the current node's data.
+A binary search tree consists of a series of connected nodes. Each node
+contains a piece of data (e.g. the number 3), a variable named `left`,
+and a variable named `right`. The `left` and `right` variables point at
+`nil`, or other nodes. Since these other nodes in turn have other nodes
+beneath them, we say that the left and right variables are pointing at
+subtrees. All data in the left subtree is less than or equal to the
+current node's data, and all data in the right subtree is greater than
+the current node's data.
 
-For example, if we had a node containing the data 4, and we added the data 2, our tree would look like this:
+For example, if we had a node containing the data 4, and we added the
+data 2, our tree would look like this:
 
       4
      /

--- a/binary-search.md
+++ b/binary-search.md
@@ -1,15 +1,31 @@
-Searching a sorted collection is a common task. A dictionary is a sorted list of word definitions. Given a word, one can find its definition. A telephone book is a sorted list of people's names, addresses, and telephone numbers. Knowing someone's name allows one to quickly find their telephone number and address.
+Searching a sorted collection is a common task. A dictionary is a sorted
+list of word definitions. Given a word, one can find its definition. A
+telephone book is a sorted list of people's names, addresses, and
+telephone numbers. Knowing someone's name allows one to quickly find
+their telephone number and address.
 
-If the list to be searched contains more than a few items (a dozen, say) a binary search will require far fewer comparisons than a linear search, but it imposes the requirement that the list be sorted.
+If the list to be searched contains more than a few items (a dozen, say)
+a binary search will require far fewer comparisons than a linear search,
+but it imposes the requirement that the list be sorted.
 
-In computer science, a binary search or half-interval search algorithm finds the position of a specified input value (the search "key") within an array sorted by key value.
+In computer science, a binary search or half-interval search algorithm
+finds the position of a specified input value (the search "key") within
+an array sorted by key value.
 
-In each step, the algorithm compares the search key value with the key value of the middle element of the array.
+In each step, the algorithm compares the search key value with the key
+value of the middle element of the array.
 
-If the keys match, then a matching element has been found and its index, or position, is returned.
+If the keys match, then a matching element has been found and its index,
+or position, is returned.
 
-Otherwise, if the search key is less than the middle element's key, then the algorithm repeats its action on the sub-array to the left of the middle element or, if the search key is greater, on the sub-array to the right.
+Otherwise, if the search key is less than the middle element's key, then
+the algorithm repeats its action on the sub-array to the left of the
+middle element or, if the search key is greater, on the sub-array to the
+right.
 
-If the remaining array to be searched is empty, then the key cannot be found in the array and a special "not found" indication is returned.
+If the remaining array to be searched is empty, then the key cannot be
+found in the array and a special "not found" indication is returned.
 
-A binary search halves the number of items to check with each iteration, so locating an item (or determining its absence) takes logarithmic time. A binary search is a dichotomic divide and conquer search algorithm.
+A binary search halves the number of items to check with each iteration,
+so locating an item (or determining its absence) takes logarithmic time.
+A binary search is a dichotomic divide and conquer search algorithm.

--- a/binary.md
+++ b/binary.md
@@ -1,7 +1,7 @@
 Write a program passing the tests.
 
-You will be guided to implement binary to decimal conversion.
-Given a binary input string, your program should be able to produce a decimal
+You will be guided to implement binary to decimal conversion.  Given a
+binary input string, your program should be able to produce a decimal
 output.
 
 ## Note

--- a/bob.md
+++ b/bob.md
@@ -2,17 +2,25 @@ Bob answers 'Sure.' if you ask him a question.
 
 He answers 'Woah, chill out!' if you yell at him.
 
-He says 'Fine. Be that way!' if you address him without actually saying anything.
+He says 'Fine. Be that way!' if you address him without actually saying
+anything.
 
 He answers 'Whatever.' to anything else.
 
 ## Instructions
 
-Run the test file, and fix each of the errors in turn. When you get the first test to pass, go to the first pending or skipped test, and make that pass as well. When all of the tests are passing, feel free to submit.
+Run the test file, and fix each of the errors in turn. When you get the
+first test to pass, go to the first pending or skipped test, and make
+that pass as well. When all of the tests are passing, feel free to
+submit.
 
-Remember that passing code is just the first step. The goal is to work towards a solution that is as readable and expressive as you can make it.
+Remember that passing code is just the first step. The goal is to work
+towards a solution that is as readable and expressive as you can make
+it.
 
-Please make your solution as general as possible. Good code doesn't just pass the test suite, it works with any input that fits the specification.
+Please make your solution as general as possible. Good code doesn't just
+pass the test suite, it works with any input that fits the
+specification.
 
 Have fun!
 

--- a/bowling.md
+++ b/bowling.md
@@ -1,26 +1,27 @@
-Scoring Bowling
----------------
+## Scoring Bowling
 
-The game consists of 10 frames. In each frame the player has
-two opportunities to knock down 10 pins.  The score for the frame is the total
-number of pins knocked down, plus bonuses for strikes and spares.
+The game consists of 10 frames. In each frame the player has two
+opportunities to knock down 10 pins.  The score for the frame is the
+total number of pins knocked down, plus bonuses for strikes and spares.
 
-A spare is when the player knocks down all 10 pins in two tries.  The bonus for
-that frame is the number of pins knocked down by the next roll.  So in frame 3
-above, the score is 10 (the total number knocked down) plus a bonus of 5 (the
-number of pins knocked down on the next roll.)
+A spare is when the player knocks down all 10 pins in two tries.  The
+bonus for that frame is the number of pins knocked down by the next
+roll.  So in frame 3 above, the score is 10 (the total number knocked
+down) plus a bonus of 5 (the number of pins knocked down on the next
+roll.)
 
-A strike is when the player knocks down all 10 pins on his first try. The bonus
-for that frame is the value of the next two balls rolled.
+A strike is when the player knocks down all 10 pins on his first try.
+The bonus for that frame is the value of the next two balls rolled.
 
-In the tenth frame a player who rolls a spare or strike is allowed to roll the extra
-balls to complete the frame.  However no more than three balls can be rolled in
-tenth frame.
+In the tenth frame a player who rolls a spare or strike is allowed to
+roll the extra balls to complete the frame.  However no more than three
+balls can be rolled in tenth frame.
 
-Requirements
-------------
+## Requirements
 
 Write a class named “Game” that has two methods:
 
-* _roll(pins : int)_ is called each time the player rolls a ball.  The argument is the number of pins knocked down.
-* _score() : int_ is called only at the very end of the game.  It returns the total score for that game.
+* `roll(pins : int)` is called each time the player rolls a ball.  The
+  argument is the number of pins knocked down.
+* `score() : int` is called only at the very end of the game.  It
+  returns the total score for that game.

--- a/change.md
+++ b/change.md
@@ -1,5 +1,10 @@
-Write a program that will correctly determine the least number of coins to be given to the user such that the sum of the coins' value would equal the correct amount of change.
+Write a program that will correctly determine the least number of coins
+to be given to the user such that the sum of the coins' value would
+equal the correct amount of change.
 
-For example
-An input of 15 with [1, 5, 10, 25, 100] should return one nickel (5) and one dime (10) or [0, 1, 1, 0, 0]
-An input of 40 with [1, 5, 10, 25, 100] should return one nickel (5) and one dime (10) and one quarter (25) or [0, 1, 1, 1, 0]
+## For example
+
+- An input of 15 with [1, 5, 10, 25, 100] should return one nickel (5)
+  and one dime (10) or [0, 1, 1, 0, 0]
+- An input of 40 with [1, 5, 10, 25, 100] should return one nickel (5)
+  and one dime (10) and one quarter (25) or [0, 1, 1, 1, 0]

--- a/circular-buffer.md
+++ b/circular-buffer.md
@@ -1,24 +1,42 @@
-A circular buffer, cyclic buffer or ring buffer is a data structure that uses a single, fixed-size buffer as if it were connected end-to-end. 
+A circular buffer, cyclic buffer or ring buffer is a data structure that
+uses a single, fixed-size buffer as if it were connected end-to-end.
 
-A circular buffer first starts empty and of some predefined length. For example, this is a 7-element buffer:
-[ ][ ][ ][ ][ ][ ][ ]
+A circular buffer first starts empty and of some predefined length. For
+example, this is a 7-element buffer:
 
-Assume that a 1 is written into the middle of the buffer (exact starting location does not matter in a circular buffer):
-[ ][ ][ ][1][ ][ ][ ]
+    [ ][ ][ ][ ][ ][ ][ ]
 
-Then assume that two more elements are added — 2 & 3 — which get appended after the 1:
-[ ][ ][ ][1][2][3][ ]
+Assume that a 1 is written into the middle of the buffer (exact starting
+location does not matter in a circular buffer):
 
-If two elements are then removed from the buffer, the oldest values inside the buffer are removed. The two elements removed, in this case, are 1 & 2, leaving the buffer with just a 3:
-[ ][ ][ ][ ][ ][3][ ]
+    [ ][ ][ ][1][ ][ ][ ]
+
+Then assume that two more elements are added — 2 & 3 — which get
+appended after the 1:
+
+    [ ][ ][ ][1][2][3][ ]
+
+If two elements are then removed from the buffer, the oldest values
+inside the buffer are removed. The two elements removed, in this case,
+are 1 & 2, leaving the buffer with just a 3:
+
+    [ ][ ][ ][ ][ ][3][ ]
 
 If the buffer has 7 elements then it is completely full:
-[6][7][8][9][3][4][5]
 
-When the buffer is full an error will be raised, alerting the client that further writes are blocked until a slot becomes free.
+    [6][7][8][9][3][4][5]
 
-The client can opt to overwrite the oldest data with a forced write. In this case, two more elements — A & B — are added and they overwrite the 3 & 4:
-[6][7][8][9][A][B][5]
+When the buffer is full an error will be raised, alerting the client
+that further writes are blocked until a slot becomes free.
 
-Finally, if two elements are now removed then what would be returned is not 3 & 4 but 5 & 6 because A & B overwrote the 3 & the 4 yielding the buffer with:
-[ ][7][8][9][A][B][ ]
+The client can opt to overwrite the oldest data with a forced write. In
+this case, two more elements — A & B — are added and they overwrite the
+3 & 4:
+
+    [6][7][8][9][A][B][5]
+
+Finally, if two elements are now removed then what would be returned is
+not 3 & 4 but 5 & 6 because A & B overwrote the 3 & the 4 yielding the
+buffer with:
+
+    [ ][7][8][9][A][B][ ]

--- a/crypto-square.md
+++ b/crypto-square.md
@@ -1,9 +1,8 @@
-The input is first normalized: The spaces and punctuation are removed from the
-English text and the message is downcased.
+The input is first normalized: The spaces and punctuation are removed
+from the English text and the message is downcased.
 
-Then, the normalized characters are broken into rows.
-These rows can be regarded as forming a rectangle
-when printed with intervening newlines.
+Then, the normalized characters are broken into rows.  These rows can be
+regarded as forming a rectangle when printed with intervening newlines.
 
 For example, the sentence
 
@@ -25,7 +24,8 @@ vegivenu
 sroots
 ```
 
-The coded message is obtained by reading down the columns going left to right.
+The coded message is obtained by reading down the columns going left to
+right.
 
 For example, the message above is coded as:
 
@@ -35,22 +35,25 @@ oanou uiont nnlvt wttdd
 esaoh ghnss eoau
 ```
 
-Write a program that, given an English text, outputs the encoded version of
-that text.
+Write a program that, given an English text, outputs the encoded version
+of that text.
 
-The size of the square (number of columns) should be decided by the length of the message.
+The size of the square (number of columns) should be decided by the
+length of the message.
 
-If the message is a length that creates a perfect square (e.g. 4, 9, 16, 25,
-36, etc), use that number of columns.
+If the message is a length that creates a perfect square (e.g. 4, 9, 16,
+25, 36, etc), use that number of columns.
 
-If the message doesn't fit neatly into a square, choose the number of columns
-that corresponds to the smallest square that is larger than the number of
-characters in the message.
+If the message doesn't fit neatly into a square, choose the number of
+columns that corresponds to the smallest square that is larger than the
+number of characters in the message.
 
-For example, a message 4 characters long should use a 2 x 2 square. A message
-that is 81 characters long would use a square that is 9 colums wide.
+For example, a message 4 characters long should use a 2 x 2 square. A
+message that is 81 characters long would use a square that is 9 colums
+wide.
 
-A message between 5 and 8 characters long should use a rectangle 3 characters wide.
+A message between 5 and 8 characters long should use a rectangle 3
+characters wide.
 
 Output the encoded text in groups of five letters.
 

--- a/custom-set.md
+++ b/custom-set.md
@@ -1,3 +1,4 @@
-Sometimes it is necessary to define a custom data structure of some type, like a
-set. In this exercise you will define your own set. How it works internally
-doesn't matter, as long as it behaves like a set of unique elements.
+Sometimes it is necessary to define a custom data structure of some
+type, like a set. In this exercise you will define your own set. How it
+works internally doesn't matter, as long as it behaves like a set of
+unique elements.

--- a/difference-of-squares.md
+++ b/difference-of-squares.md
@@ -1,9 +1,10 @@
 The sum of the squares of the first ten natural numbers is,
 
-1**2 + 2**2 + ... + 10**2 = 385
+    1**2 + 2**2 + ... + 10**2 = 385
 
 The square of the sum of the first ten natural numbers is,
 
-(1 + 2 + ... + 10)**2 = 55**2 = 3025
+    (1 + 2 + ... + 10)**2 = 55**2 = 3025
 
-Hence the difference between the sum of the squares of the first ten natural numbers and the square of the sum is 3025 - 385 = 2640.
+Hence the difference between the sum of the squares of the first ten
+natural numbers and the square of the sum is 3025 - 385 = 2640.

--- a/diffie-hellman.md
+++ b/diffie-hellman.md
@@ -1,4 +1,6 @@
-Alice and Bob use Diffie-Hellman key exchange to share secrets.  They start with prime numbers, pick private keys, generate and share public keys, and then generate a shared secret key.
+Alice and Bob use Diffie-Hellman key exchange to share secrets.  They
+start with prime numbers, pick private keys, generate and share public
+keys, and then generate a shared secret key.
 
 ## Step 0
 
@@ -6,7 +8,8 @@ The test program supplies prime numbers p and g.
 
 ## Step 1
 
-Alice picks a private key, a, greater than 1 and less than p.  Bob does the same to pick a private key b.
+Alice picks a private key, a, greater than 1 and less than p.  Bob does
+the same to pick a private key b.
 
 ## Step 2
 
@@ -14,7 +17,8 @@ Alice calcuates a public key A.
 
     A = g**a mod p
 
-Using the same p and g, Bob similarly calculates a public key B from his private key b.
+Using the same p and g, Bob similarly calculates a public key B from his
+private key b.
 
 ## Step 3
 
@@ -26,4 +30,5 @@ Bob calculates
 
     s = A**b mod p
 
-The calculations produce the same result!  Alice and Bob now share secret s.
+The calculations produce the same result!  Alice and Bob now share
+secret s.

--- a/dot-dsl.md
+++ b/dot-dsl.md
@@ -1,9 +1,11 @@
-A [Domain Specific Language (DSL)](https://en.wikipedia.org/wiki/Domain-specific_language)
-is a small language optimized for a specific domain.
+A [Domain Specific Language
+(DSL)](https://en.wikipedia.org/wiki/Domain-specific_language) is a
+small language optimized for a specific domain.
 
-For example the dot language of [Graphviz](http://graphviz.org) allows you to
-write a textual description of a graph which is then transformed into a picture
-by one of the graphviz tools (such as `dot`). A simple graph looks like this:
+For example the dot language of [Graphviz](http://graphviz.org) allows
+you to write a textual description of a graph which is then transformed
+into a picture by one of the graphviz tools (such as `dot`). A simple
+graph looks like this:
 
     graph {
         graph [bgcolor="yellow"]
@@ -12,7 +14,8 @@ by one of the graphviz tools (such as `dot`). A simple graph looks like this:
         a -- b [color="green"]
     }
 
-Putting this in a file `example.dot` and running `dot example.dot -T png -o example.png`
-creates an image `example.png` with red and blue circle connected by a green line on a yellow background.
+Putting this in a file `example.dot` and running `dot example.dot -T png
+-o example.png` creates an image `example.png` with red and blue circle
+connected by a green line on a yellow background.
 
 Create a DSL similar to the dot language.

--- a/etl.md
+++ b/etl.md
@@ -1,10 +1,10 @@
-This is a fancy way of saying, "We have some crufty, legacy data over in this
-system, and now we need it in this shiny new system over here, so we're going
-to migrate this."
+This is a fancy way of saying, "We have some crufty, legacy data over in
+this system, and now we need it in this shiny new system over here, so
+we're going to migrate this."
 
-(Typically, this is followed by, "We're only going to need to run this once."
-That's then typically followed by much forehead slapping and moaning about
-how stupid we could possibly be.)
+(Typically, this is followed by, "We're only going to need to run this
+once." That's then typically followed by much forehead slapping and
+moaning about how stupid we could possibly be.)
 
 We're going to extract some scrabble scores from a legacy system.
 
@@ -18,10 +18,10 @@ The old system stored a list of letters per score:
 - 8 points: "J", "X",
 - 10 points: "Q", "Z",
 
-The shiny new scrabble system instead stores the score per letter,
-which makes it much faster and easier to calculate the score for a
-word. It also stores the letters in lower-case regardless of the
-case of the input letters:
+The shiny new scrabble system instead stores the score per letter, which
+makes it much faster and easier to calculate the score for a word. It
+also stores the letters in lower-case regardless of the case of the
+input letters:
 
 - "a" is worth 1 point.
 - "b" is worth 3 points.
@@ -33,4 +33,5 @@ Your mission, should you choose to accept it, is to write a program that
 transforms the legacy data format to the shiny new format.
 
 Note that both the old and the new system use strings to represent
-letters, even in languages that have a separate data type for characters.
+letters, even in languages that have a separate data type for
+characters.

--- a/hamming.md
+++ b/hamming.md
@@ -1,8 +1,18 @@
-A mutation is simply a mistake that occurs during the creation or copying of a nucleic acid, in particular DNA. Because nucleic acids are vital to cellular functions, mutations tend to cause a ripple effect throughout the cell. Although mutations are technically mistakes, a very rare mutation may equip the cell with a beneficial attribute. In fact, the macro effects of evolution are attributable by the accumulated result of beneficial microscopic mutations over many generations.
+A mutation is simply a mistake that occurs during the creation or
+copying of a nucleic acid, in particular DNA. Because nucleic acids are
+vital to cellular functions, mutations tend to cause a ripple effect
+throughout the cell. Although mutations are technically mistakes, a very
+rare mutation may equip the cell with a beneficial attribute. In fact,
+the macro effects of evolution are attributable by the accumulated
+result of beneficial microscopic mutations over many generations.
 
-The simplest and most common type of nucleic acid mutation is a point mutation, which replaces one base with another at a single nucleotide.
+The simplest and most common type of nucleic acid mutation is a point
+mutation, which replaces one base with another at a single nucleotide.
 
-By counting the number of differences between two homologous DNA strands taken from different genomes with a common ancestor, we get a measure of the minimum number of point mutations that could have occurred on the evolutionary path between the two strands.
+By counting the number of differences between two homologous DNA strands
+taken from different genomes with a common ancestor, we get a measure of
+the minimum number of point mutations that could have occurred on the
+evolutionary path between the two strands.
 
 This is called the 'Hamming distance'
 
@@ -11,4 +21,3 @@ This is called the 'Hamming distance'
     ^ ^ ^  ^ ^    ^^
 
 The Hamming distance between these two DNA strands is 7.
-

--- a/sum-of-multiples.md
+++ b/sum-of-multiples.md
@@ -1,3 +1,5 @@
-If we list all the natural numbers below 10 that are multiples of 3 or 5, we get 3, 5, 6 and 9. The sum of these multiples is 23.
+If we list all the natural numbers below 10 that are multiples of 3 or
+5, we get 3, 5, 6 and 9. The sum of these multiples is 23.
 
-Allow the program to be configured to find the sum of multiples of numbers other than 3 and 5.
+Allow the program to be configured to find the sum of multiples of
+numbers other than 3 and 5.

--- a/triangle.md
+++ b/triangle.md
@@ -4,4 +4,6 @@ Tests are provided, delete one `skip` at a time.
 
 ## Hint
 
-The sum of the lengths of any two sides of a triangle always exceeds the length of the third side, a principle known as the _triangle inequality_.
+The sum of the lengths of any two sides of a triangle always exceeds the
+length of the third side, a principle known as the _triangle
+inequality_.

--- a/trinary.md
+++ b/trinary.md
@@ -1,8 +1,10 @@
-The program should consider strings specifying an invalid trinary as the value 0.
+The program should consider strings specifying an invalid trinary as the
+value 0.
 
 Trinary numbers contain three symbols: 0, 1, and 2.
 
-The last place in a trinary number is the 1's place. The second to last is the 3's place, the third to last is the 9's place, etc.
+The last place in a trinary number is the 1's place. The second to last
+is the 3's place, the third to last is the 9's place, etc.
 
 ```bash
 # "102012"


### PR DESCRIPTION
When reading the README.md files from the command line (e.g., `less README.md`), it helps readability if the line lengths are kept at 80 characters or less.
