### PR TITLE
difference-of-squares: test >32 bit results

### DIFF
--- a/exercises/difference-of-squares/canonical-data.json
+++ b/exercises/difference-of-squares/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "difference-of-squares",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "cases": [
     {
       "description": "Square the sum of the numbers up to the given number",
@@ -22,6 +22,12 @@
           "property": "squareOfSum",
           "number": 100,
           "expected": 25502500
+        },
+        {
+          "description": "square of sum 2000",
+          "property": "squareOfSum",
+          "number": 2000,
+          "expected": 4004001000000
         }
       ]
     },
@@ -45,6 +51,12 @@
           "property": "sumOfSquares",
           "number": 100,
           "expected": 338350
+        },
+        {
+          "description": "sum of squares 2000",
+          "property": "sumOfSquares",
+          "number": 2000,
+          "expected": 2668667000
         }
       ]
     },
@@ -68,6 +80,12 @@
           "property": "differenceOfSquares",
           "number": 100,
           "expected": 25164150
+        },
+        {
+          "description": "difference of squares 2000",
+          "property": "differenceOfSquares",
+          "number": 2000,
+          "expected": 4001332333000
         }
       ]
     }


### PR DESCRIPTION
For an input value of 2000, the square of the sum (4004001000000), sum of the squares (2668667000), and difference of squares (4001332333000) all exceed the largest (signed) value that can be represented using 32 bits (2147483647). The proposed test cases here exercise this case and should guide implementors to learn more about the numerical types available in their language of choice.

[Discussion in xjava](https://github.com/exercism/xjava/issues/331).

Thoughts about including this change in the `x-common` tests? I think `xjava` will retain the tests regardless, but am interested in perspectives based on languages that have alternative and/or unusual numerical types.