### PR TITLE
Moved anatomy of an exercise from CONTRIBUTING.md to docs repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -363,29 +363,7 @@ solution.
 
 ### Anatomy of an Exercise
 
-TODO: expand on notes below.
-
-#### README
-
-TODO
-
-#### Test Suite
-
-TODO
-
-#### Supporting Files
-
-TODO (boilerplate, header files, etc)
-
-#### Reference Solution
-
-The reference solution is named something with `example` or `Example` in the path.
-
-The solution does not need to be particularly great code, it is only used to verify
-that the exercise is coherent.
-
-If you change the test suite, then make sure the reference solution is fixed
-to pass the updated tests.
+See the [anatomy of an exercise](https://github.com/exercism/docs/tree/master/maintaining-a-track/anatomy-of-an-exercise.md) in the docs repository.
 
 ### Track configuration file
 


### PR DESCRIPTION
I want to resolve [#26](https://github.com/exercism/docs/issues/26) in the docs repo with this PR. 

This will remove the Anatomy of an Exercise section (keeping the heading) that will be moved to the docs repo. Also, I added a (currently broken) link to what I assume will be the new location in the docs repo.