### PR TITLE
pangram: character set issue, closes #842

### DIFF
--- a/exercises/pangram/description.md
+++ b/exercises/pangram/description.md
@@ -2,5 +2,5 @@ Determine if a sentence is a pangram. A pangram (Greek: παν γράμμα, pan
 "every letter") is a sentence using every letter of the alphabet at least once.
 The best known English pangram is "The quick brown fox jumps over the lazy dog."
 
-The alphabet used is ASCII, and case insensitive, from 'a' to 'z'
-inclusively.
+The alphabet used consists of ASCII letters `a` to `z`, inclusive, and is case
+insensitive. Input will not contain non-ASCII symbols.


### PR DESCRIPTION
An update for https://github.com/exercism/problem-specifications/issues/842. Clarifies that non-ASCII symbols should not be present at all, compared to them being present, but ignored.