### PR TITLE
fix pangram test for duplicate mixed-case chars

### DIFF
--- a/exercises/pangram/canonical-data.json
+++ b/exercises/pangram/canonical-data.json
@@ -3,7 +3,7 @@
   "comments": [
     "A pangram is a sentence using every letter of the alphabet at least once."
   ],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "cases": [
     {
       "description": "Check if the given string is an pangram",
@@ -62,7 +62,7 @@
         {
           "description": "upper and lower case versions of the same character should not be counted separately",
           "property": "isPangram",
-          "input": "the quick brown fox jumped over the lazy FOX",
+          "input": "the quick brown fox jumps over with lazy FX",
           "expected": false
         }
       ]


### PR DESCRIPTION
From what I can see, the last test case is inteded to catch incorrect
programs such as this, which don't take into account different-cased
duplicates:

```haskell
isPangram = (== 26) . length . nub . filter isAlpha
```

However the above program passed the final test as the count of distinct
upper and lower case characters is 27, rather than 26.

This commit changes the test text to a non-pangram that has exactly 26
distinct upper and lower case characters, which causes the above,
incorrect program to fail.

Similar incorrect programs that checked if the count of distinct letters was >=, rather than exactly = to 26, would have correctly failed the existing test.