### PR TITLE
list-ops: update foldl/foldr tests

### DIFF
--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "list-ops",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "comments": [
     "Though there are no specifications here for dealing with large lists,",
     "implementers may add tests for handling large lists to ensure that the",
@@ -113,16 +113,24 @@
           "property": "foldl",
           "list": [],
           "initial": 2,
-          "function": "value / accumulator",
+          "function": "(x, y) -> x * y",
           "expected": 2
         },
         {
-          "description": "division of integers",
+          "description": "direction independent function applied to non-empty list",
           "property": "foldl",
           "list": [1, 2, 3, 4],
-          "initial": 24,
-          "function": "value / accumulator",
-          "expected": 64
+          "initial": 5,
+          "function": "(x, y) -> x + y",
+          "expected": 15
+        },
+        {
+          "description": "direction dependent function applied to non-empty list",
+          "property": "foldl",
+          "list": [2, 5],
+          "initial": 5,
+          "function": "(x, y) -> x / y",
+          "expected": 0
         }
       ]
     },
@@ -134,16 +142,24 @@
           "property": "foldr",
           "list": [],
           "initial": 2,
-          "function": "value / accumulator",
+          "function": "(x, y) -> x * y",
           "expected": 2
         },
         {
-          "description": "division of integers",
+          "description": "direction independent function applied to non-empty list",
           "property": "foldr",
           "list": [1, 2, 3, 4],
-          "initial": 24,
-          "function": "value / accumulator",
-          "expected": 9
+          "initial": 5,
+          "function": "(x, y) -> x + y",
+          "expected": 15
+        },
+        {
+          "description": "direction dependent function applied to non-empty list",
+          "property": "foldr",
+          "list": [2, 5],
+          "initial": 5,
+          "function": "(x, y) -> x / y",
+          "expected": 2
         }
       ]
     },


### PR DESCRIPTION
Closes #826.

Note that I bumped the major version of the tests since this is a breaking change; the representation of the accumulation function used in the fold tests was changed to highlight that the _same_ function is being used in the direction-dependent tests. This should help mitigate confusion regarding what is meant when we declare that the given accumulation function is 'direction-dependent'. See e.g. https://github.com/exercism/java/pull/671#discussion_r125188010 for context.

Questions:

- when writing `x / y`, is there a common way to indicate that this represents integer division in particular? I think that would be useful for implementors.
- would it be useful to include a link to https://en.wikipedia.org/wiki/Fold_(higher-order_function)#Linear_folds to help implementors understand the expected signatures of the fold functions (and in particular, the expected interpretation of the accumulation function parameters)?

