### PR TITLE
accumulate: remove Lisp-specific portion

### DIFF
--- a/exercises/accumulate/description.md
+++ b/exercises/accumulate/description.md
@@ -22,6 +22,3 @@ Check out the test suite to see the expected function signature.
 Keep your hands off that collect/map/fmap/whatchamacallit functionality
 provided by your standard library!
 Solve this one yourself using other basic tools instead.
-
-Lisp specific: it's perfectly fine to use `MAPCAR` or the equivalent,
-as this is idiomatic Lisp, not a library function.


### PR DESCRIPTION
Elixir-specific portion added:
https://github.com/exercism/exercism.io/pull/1136

Lisp-specific portion added:
https://github.com/exercism/problem-specifications/pull/98

Elixir-specific portion removed because the `Enum.reduce` was not
necessary:
https://github.com/exercism/problem-specifications/pull/274

The reason to suggest removing this Lisp-specific now is slightly
different:
It doesn't seem to make much sense to include this Lisp-specific
sentence in non-Lisp tracks.

See that http://x.exercism.io/problems/accumulate indicates this
exercise is only implemented by one Lisp-like language (Clojure) and 19
non-Lisp-like languages.

It could be possible for the tracks that desire this clause to place it
in .meta/HINTS.md. It is easy to **add** content to the description.md,
but it is not easy to **remove** content. Leaving the content in
description.md is potentially asking 19 different tracks to take custom
measures to remove it (an exercise-specific template), unless we come up
with a better way to **remove** content (a .patch to be applied to each
description.md, perhaps).

It is acknowledged that
https://github.com/exercism/problem-specifications/issues/129 indicates
the exercise will be deprecated at a point in the future. Nevertheless,
it is still true that the exercise exists, and that new implementations
for it are being contributed (https://github.com/exercism/rust/pull/332)
and that this README change benefits those tracks that have this
exercise.