### PR TITLE
Note expected accuracy in space-age description

### DIFF
--- a/exercises/space-age/description.md
+++ b/exercises/space-age/description.md
@@ -10,7 +10,8 @@ Given an age in seconds, calculate how old someone would be on:
    - Neptune: orbital period 164.79132 Earth years
 
 So if you were told someone were 1,000,000,000 seconds old, you should
-be able to say that they're 31 Earth-years old.
+be able to say that they're 31.69 Earth-years old. Round all ages to
+the nearest hundredth of a year.
 
 If you're wondering why Pluto didn't make the cut, go watch [this
 youtube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).


### PR DESCRIPTION
Inspired by https://github.com/exercism/kotlin/pull/100.

Consistent with the rounding policy used by the [canonical data](https://github.com/exercism/problem-specifications/blob/281497b21dd032fbf22449dc82272df74f026305/exercises/space-age/canonical-data.json).