### PR TITLE
Rename twofer property to name

### DIFF
--- a/exercises/two-fer/canonical-data.json
+++ b/exercises/two-fer/canonical-data.json
@@ -1,22 +1,22 @@
 {
   "exercise": "two-fer",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "cases": [
     {
       "description": "no name given",
-      "property": "twoFer",
+      "property": "name",
       "input": null,
       "expected": "One for you, one for me."
     },
     {
       "description": "a name given",
-      "property": "twoFer",
+      "property": "name",
       "input": "Alice",
       "expected": "One for Alice, one for me."
     },
     {
       "description": "another name given",
-      "property": "twoFer",
+      "property": "name",
       "input": "Bob",
       "expected": "One for Bob, one for me."
     }


### PR DESCRIPTION
I'd like to propose to rename the twofer property to instead use name. I noticed this because the C# track really can't follow the canonical data. 

For this exercise, following proper casing and convention, the call becomes TwoFer.TwoFer() which isn't legal as the method matches the name of the class.