### PR TITLE
Change: Add test for incorrect greedy algorithm

### DIFF
--- a/exercises/change/canonical-data.json
+++ b/exercises/change/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "change",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "comments": [
     "Given an infinite supply of coins with different values, ",
     "find the smallest number of coins needed to make a desired ",
@@ -50,6 +50,13 @@
       "coins": [2, 5, 10, 20, 50],
       "target": 21,
       "expected": [2, 2, 2, 5, 10]
+    },
+    {
+      "description": "another possible change without unit coins available",
+      "property": "findFewestCoins",
+      "coins": [4, 5],
+      "target": 27,
+      "expected": [4, 4, 4, 5, 5, 5]
     },
     {
       "description": "no coins make 0 change",


### PR DESCRIPTION
I'd like to propose adding a missing edgecase test. This test invalidates an incorrect greedy algorithm which takes as many of the larger coins as possible as long as the remainder is greater than or equal to the value or the smallest coin. Currently such an algorithm will pass all of the tests.

If required, I can point to some solutions which fail this test.