### PR TITLE
topics: "style" category & entries

### DIFF
--- a/TOPICS.txt
+++ b/TOPICS.txt
@@ -63,7 +63,6 @@ Parsing
 Pattern recognition
 Performance
 Randomness
-Reactive programming
 Refactoring
 Regular Expressions
 Searching
@@ -71,3 +70,11 @@ Security
 Sorting
 Text formatting
 Transforming
+
+Programming Style
+---
+Behavior driven development
+Functional programming
+Object oriented programming
+Reactive programming
+Test driven development

--- a/TOPICS.txt
+++ b/TOPICS.txt
@@ -73,8 +73,8 @@ Transforming
 
 Programming Style
 ---
-Behavior driven development
+Behavior-driven development
 Functional programming
-Object oriented programming
+Object-oriented programming
 Reactive programming
-Test driven development
+Test-driven development


### PR DESCRIPTION
Moved "reactive programming" to its own section along with
alternatives like OOP and functional. Added two test styles
test driven development and behavior driven development.

These all have a place in the exercises. "functional programming" will
hopefully replace a the higher-order functions topics and functional in dlang
and ocaml.

TDD is a lot of what Exercism does. I propose to limit it to the
exercise that benefit specifically from incremental development like
[sum-of-multiples](https://github.com/exercism/problem-specifications/tree/master/exercises/sum-of-multiples). That
being said, should a track use BDD that should be available in TOPICS as well.

See #884