### PR TITLE
Simplify control flow topics

### DIFF
--- a/TOPICS.txt
+++ b/TOPICS.txt
@@ -2,14 +2,14 @@ Basic concepts
 --------------
 Abstract classes
 Callbacks
-Control-flow (conditionals)
-Control-flow (loops)
+Conditionals
 Events
 Equality
 Exception handling
 Generics
 Inheritance
 Interfaces
+Loops
 Pattern matching
 Polymorphism
 Recursion


### PR DESCRIPTION
See https://github.com/exercism/meta/issues/83#issuecomment-324048581

From that conversation...

@robphoenix

> Be good to also consider what to do with topics such as Control-flow (conditionals) - control_flow_(conditionals) or control_flow_conditionals?

@ihiD

> For "control_flow_conditionals" can we just have "conditionals" please?

@kytrinyx

> I think it's worth sorting this out at the TOPICS level. Configlet could do it, but it would seem more like a dark art if it's not listed the way we want it up front.