### PR TITLE
nucleotide-count: refactoring tests (discussion)

### DIFF
--- a/exercises/nucleotide-count/canonical-data.json
+++ b/exercises/nucleotide-count/canonical-data.json
@@ -1,12 +1,19 @@
 {
   "exercise": "nucleotide-count",
+  "comments": [
+    "Given a string of nucleotides, the count of each nucleotide is returned."
+  ],
   "version": "1.1.0",
   "cases": [
     {
-      "description": "nucleotideCounts counts all DNA-nucleotides in the input strand and returns an object with properties A, C, G and T holding their respective amounts.",
+      "description": "counts all nucleotides in a provided strand.",
+      "comments": [
+        "nucleotideCounts counts all DNA-nucleotides in the input strand and returns an object with properties",
+        "A, C, G and T holding their respective amounts."
+      ],
       "cases": [
         {
-          "description": "counts an empty DNA strand as 0.",
+          "description": "returns zeroes in case of an empty input strand.",
           "property": "nucleotideCounts",
           "strand": "",
           "expected": {
@@ -17,8 +24,10 @@
           }
         },
         {
-          "comments" : ["Should check for null-references and assume an empty input."],
-          "description": "counts an undefined DNA strand as empty strand.",
+          "comments" : [
+            "Should check for null-references and assume an empty input."
+          ],
+          "description": "returns zeroes for an undefined/null strand as argument.",
           "property": "nucleotideCounts",
           "strand": null,
           "expected": {
@@ -29,7 +38,7 @@
           }
         },
         {
-          "description": "counts a single nucleotide correctly.",
+          "description": "returns the counts of nucleotides in a single-character input.",
           "property": "nucleotideCounts",
           "strand": "G",
           "expected": {
@@ -40,7 +49,7 @@
           }
         },
         {
-          "description": "counts a single repetitive nucleotide correctly.",
+          "description": "returns the counts of nucleotides in a strand containing one repeated nucleotide.",
           "property": "nucleotideCounts",
           "strand": "GGGGGGG",
           "expected": {
@@ -51,7 +60,7 @@
           }
         },
         {
-          "description": "counts all nucleotides correctly.",
+          "description": "returns the count of nucleotides in a strand containing all nucleotides.",
           "property": "nucleotideCounts",
           "strand": "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC",
           "expected": {
@@ -62,7 +71,7 @@
           }
         },
         {
-          "description": "counts all nucleotides correctly in mixed case.",
+          "description": "returns the count of nucleotides in a strand containing mixed-case nucleotides.",
           "property": "nucleotideCounts",
           "strand": "aGcTtTtCaTtCtGaCtGcAaCgGgCaAtAtGtCtCtGtGtGgAtTaAaAaAaGaGtGtCtGaTaGcAgC",
           "expected": {
@@ -83,10 +92,10 @@
           "expected" : true
         },
         {
-          "description": "handle incorrect inputs",
+          "description": "handles incorrect inputs.",
           "cases": [
             {
-              "description": "checks if DNA input does not include invalid characters.",
+              "description": "throws error if DNA input does not include anything but ACGT-characters.",
               "property": "nucleotideCounts",
               "strand": "AGUUÄ1+ :'A'}CT",
               "expected": {

--- a/exercises/nucleotide-count/canonical-data.json
+++ b/exercises/nucleotide-count/canonical-data.json
@@ -1,12 +1,12 @@
 {
   "exercise": "nucleotide-count",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "cases": [
     {
-      "description": "count all nucleotides in a strand",
+      "description": "nucleotideCounts counts all DNA-nucleotides in the input strand and returns an object with properties A, C, G and T holding their respective amounts.",
       "cases": [
         {
-          "description": "empty strand",
+          "description": "counts an empty DNA strand as 0.",
           "property": "nucleotideCounts",
           "strand": "",
           "expected": {
@@ -17,7 +17,30 @@
           }
         },
         {
-          "description": "strand with repeated nucleotide",
+          "comments" : ["Should check for null-references and assume an empty input."],
+          "description": "counts an undefined DNA strand as empty strand.",
+          "property": "nucleotideCounts",
+          "strand": null,
+          "expected": {
+            "A": 0,
+            "C": 0,
+            "G": 0,
+            "T": 0
+          }
+        },
+        {
+          "description": "counts a single nucleotide correctly.",
+          "property": "nucleotideCounts",
+          "strand": "G",
+          "expected": {
+            "A": 0,
+            "C": 0,
+            "G": 1,
+            "T": 0
+          }
+        },
+        {
+          "description": "counts a single repetitive nucleotide correctly.",
           "property": "nucleotideCounts",
           "strand": "GGGGGGG",
           "expected": {
@@ -28,7 +51,7 @@
           }
         },
         {
-          "description": "strand with multiple nucleotides",
+          "description": "counts all nucleotides correctly.",
           "property": "nucleotideCounts",
           "strand": "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC",
           "expected": {
@@ -39,12 +62,38 @@
           }
         },
         {
-          "description": "strand with invalid nucleotides",
+          "description": "counts all nucleotides correctly in mixed case.",
           "property": "nucleotideCounts",
-          "strand": "AGXXACT",
+          "strand": "aGcTtTtCaTtCtGaCtGcAaCgGgCaAtAtGtCtCtGtGtGgAtTaAaAaAaGaGtGtCtGaTaGcAgC",
           "expected": {
-            "error": "Invalid nucleotide in strand"
+            "A": 20,
+            "C": 12,
+            "G": 17,
+            "T": 21
           }
+        },
+        {
+          "comments" : [
+            "This should call the property/function at least two times and check if it returns the same",
+            "result. This prevents errors where the call aggregates (sums up) the counts of each call."
+          ],
+          "description": "returns the same amounts for consecutive nucleotideCounts calls.",
+          "property": "nucleotideCounts",
+          "strand": "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC",
+          "expected" : true
+        },
+        {
+          "description": "handle incorrect inputs",
+          "cases": [
+            {
+              "description": "checks if DNA input does not include invalid characters.",
+              "property": "nucleotideCounts",
+              "strand": "AGUUÄ1+ :'A'}CT",
+              "expected": {
+                "error": "Invalid nucleotide in strand"
+              }
+            }
+          ]
         }
       ]
     }

--- a/exercises/nucleotide-count/canonical-data.json
+++ b/exercises/nucleotide-count/canonical-data.json
@@ -1,7 +1,13 @@
 {
   "exercise": "nucleotide-count",
   "comments": [
-    "Given a string of nucleotides, the count of each nucleotide is returned."
+    "Given a string of nucleotides, the count of each nucleotide is returned.",
+    "",
+    "It is the track's responsibility to add further language specific tests like:",
+    "input error handling (null/undefined parameters etc.)",
+    "referential transparency (i.e. evaluating, a function/method gives the same value for same arguments every time.)",
+    "",
+    "'error' and 'null' should be treated according to the languages' specifics and possibilities."
   ],
   "version": "1.1.0",
   "cases": [
@@ -24,21 +30,7 @@
           }
         },
         {
-          "comments" : [
-            "Should check for null-references and assume an empty input."
-          ],
-          "description": "returns zeroes for an undefined/null strand as argument.",
-          "property": "nucleotideCounts",
-          "strand": null,
-          "expected": {
-            "A": 0,
-            "C": 0,
-            "G": 0,
-            "T": 0
-          }
-        },
-        {
-          "description": "returns the counts of nucleotides in a single-character input.",
+          "description": "can count one nucleotide in single-character input.",
           "property": "nucleotideCounts",
           "strand": "G",
           "expected": {
@@ -49,7 +41,7 @@
           }
         },
         {
-          "description": "returns the counts of nucleotides in a strand containing one repeated nucleotide.",
+          "description": "can count one nucleotide in multi-character input.",
           "property": "nucleotideCounts",
           "strand": "GGGGGGG",
           "expected": {
@@ -60,7 +52,7 @@
           }
         },
         {
-          "description": "returns the count of nucleotides in a strand containing all nucleotides.",
+          "description": "can count all nucleotides in a strand containing all nucleotides.",
           "property": "nucleotideCounts",
           "strand": "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC",
           "expected": {
@@ -71,7 +63,7 @@
           }
         },
         {
-          "description": "returns the count of nucleotides in a strand containing mixed-case nucleotides.",
+          "description": "ignores case in a strand of mixed-case nucleotides.",
           "property": "nucleotideCounts",
           "strand": "aGcTtTtCaTtCtGaCtGcAaCgGgCaAtAtGtCtCtGtGtGgAtTaAaAaAaGaGtGtCtGaTaGcAgC",
           "expected": {
@@ -82,22 +74,12 @@
           }
         },
         {
-          "comments" : [
-            "This should call the property/function at least two times and check if it returns the same",
-            "result. This prevents errors where the call aggregates (sums up) the counts of each call."
-          ],
-          "description": "returns the same amounts for consecutive nucleotideCounts calls.",
-          "property": "nucleotideCounts",
-          "strand": "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC",
-          "expected" : true
-        },
-        {
           "description": "handles incorrect inputs.",
           "cases": [
             {
-              "description": "throws error if DNA input does not include anything but ACGT-characters.",
+              "description": "treats an input with anything else than ACGT-characters as error.",
               "property": "nucleotideCounts",
-              "strand": "AGUUÄ1+ :'A'}CT",
+              "strand": "AGUU1+ :'A'}CT",
               "expected": {
                 "error": "Invalid nucleotide in strand"
               }


### PR DESCRIPTION
Hi,

In the same vain as the other PR  #893 here is the discussion about nucleotide-count.

-------------------
### Background:
I'm currently contributing some bits and tits to the JS and ecmascript tracks and while doing so I came across some issues I see with some of the test files. Upon proposing some changes the maintainers asked me to contribute to the canonical track first, before it can be addressed in the particular track. So here I am. :-)

In this PR I'd like to discuss the test spec for the pangram exercise in particular.

First I have some assumptions:

- This is a learning platform, so the 'course material' should be a good example of good practices and (arguably) well designed principles.
- As far as I can tell we utilize TDD with a progression in the tests that evolve the desired implementation one test case at a time. This is called "Fake it till you make it" or "sliming" and is a nice practice to focus on what is essential. (see https://www.youtube.com/watch?v=PhiXo5CWjYU for a short vlog about this concept)
- Because of this, extra special care should be taken in reviewing contributed test cases. Especially, because they are the main reference material for (mostly) inexperienced learners.

----------------------
### Analysis:
The nucleotide-count test spec is another test that I took a closer look at and at least to me there seem to be some things that could be improved.
Here is the current one:
https://github.com/exercism/problem-specifications/blob/fba1aef6b2237f504bfdd0bf575fd49489f12523/exercises/nucleotide-count/canonical-data.json

The following things came to me:

- Some important edge cases are missing. e.g. The null-case or lowercase-cases. Arguably we should even test for wrong input types like objects, arrays etc. in some languages, which is track specific I guess.
- The order of the cases seems to be nice enough for a "sliming"-progression, but could be improved with some steps inbetween. 

-----------------
### Suggestion:
I am far from an expert in this field. To be fair I'm even a learner who needs practise in TDD. However, I am particularly interested in a good TDD design and the clean code movement. And I think I can add some value from experienced talks and tutorials and videos about testable code and clean code in general to this discussion.

Therefore, I have a suggested version of the nucleotide-count test spec you can see in this PR.
Here is the file in a whole:
https://github.com/Vankog/problem-specifications/blob/refactor-nucleotide-count-test/exercises/nucleotide-count/canonical-data.json

I think I provided a good sliming progression, adding one aspect after another. This mandated some intermediate test cases, like testing a single char input before testing a sequence. 
Also I tried to think about the edge cases more carefully and what needs to be tested, adding some and improving the descriptions.


What do you think?