### PR TITLE
sum-of-multiples: Add up to 7 test case

### DIFF
--- a/exercises/sum-of-multiples/canonical-data.json
+++ b/exercises/sum-of-multiples/canonical-data.json
@@ -1,27 +1,20 @@
 {
   "exercise": "sum-of-multiples",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "cases": [
     {
-      "description": "multiples of 3 up to 1",
+      "description": "multiples of 3 or 5 up to 1",
       "property": "sum",
-      "factors": [3],
+      "factors": [3, 5],
       "limit": 1,
       "expected": 0
     },
     {
-      "description": "multiples of 3 up to 4",
+      "description": "multiples of 3 or 5 up to 4",
       "property": "sum",
-      "factors": [3],
+      "factors": [3, 5],
       "limit": 4,
       "expected": 3
-    },
-    {
-      "description": "multiples of 3 up to 7",
-      "property": "sum",
-      "factors": [3],
-      "limit": 7,
-      "expected": 9
     },
     {
       "description": "multiples of 3 or 5 up to 10",

--- a/exercises/sum-of-multiples/canonical-data.json
+++ b/exercises/sum-of-multiples/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "sum-of-multiples",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "cases": [
     {
       "description": "multiples of 3 or 5 up to 1",
@@ -15,6 +15,13 @@
       "factors": [3, 5],
       "limit": 4,
       "expected": 3
+    },
+    {
+      "description": "multiples of 3 up to 7",
+      "property": "sum",
+      "factors": [3],
+      "limit": 7,
+      "expected": 9
     },
     {
       "description": "multiples of 3 or 5 up to 10",

--- a/exercises/sum-of-multiples/canonical-data.json
+++ b/exercises/sum-of-multiples/canonical-data.json
@@ -1,20 +1,27 @@
 {
   "exercise": "sum-of-multiples",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "cases": [
     {
-      "description": "multiples of 3 or 5 up to 1",
+      "description": "multiples of 3 up to 1",
       "property": "sum",
-      "factors": [3, 5],
+      "factors": [3],
       "limit": 1,
       "expected": 0
     },
     {
-      "description": "multiples of 3 or 5 up to 4",
+      "description": "multiples of 3 up to 4",
       "property": "sum",
-      "factors": [3, 5],
+      "factors": [3],
       "limit": 4,
       "expected": 3
+    },
+    {
+      "description": "multiples of 3 up to 7",
+      "property": "sum",
+      "factors": [3],
+      "limit": 7,
+      "expected": 9
     },
     {
       "description": "multiples of 3 or 5 up to 10",


### PR DESCRIPTION
I'd like to propose adding an additional test case to this exercise (as well as simplify the earlier ones). I believe these test cases would be a more logical approach when tackling this problem using TDD.

Currently, for the 3rd step, it takes a bit of a leap. It's the first time we actually have to worry about the 5 (since in previous cases it could never be possible) as well as having to sum 3 multiple times to return a result of 23. 

This new test case is a little more gentle in the sense that we don't need to worry about another factor, we just need to worry about 3 + 6.

After that, we can introduce 5 (and other factors) because the student should have accomplished summing 3 multiple times, allowing them to move onto a test case that leverages multiple factors.