### PR TITLE
Add titles to exercises with non-default capitalisation/punctuation

### DIFF
--- a/exercises/dot-dsl/metadata.yml
+++ b/exercises/dot-dsl/metadata.yml
@@ -1,2 +1,3 @@
 ---
+title: "DOT DSL"
 blurb: "Write a Domain Specific Language similar to the Graphviz dot language"

--- a/exercises/etl/metadata.yml
+++ b/exercises/etl/metadata.yml
@@ -1,4 +1,5 @@
 ---
+title: "ETL"
 blurb: "We are going to do the `Transform` step of an Extract-Transform-Load."
 source: "The Jumpstart Lab team"
 source_url: "http://jumpstartlab.com"

--- a/exercises/ocr-numbers/metadata.yml
+++ b/exercises/ocr-numbers/metadata.yml
@@ -1,4 +1,5 @@
 ---
+title: "OCR Numbers"
 blurb: "Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is represented, or whether it is garbled."
 source: "Inspired by the Bank OCR kata"
 source_url: "http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR"

--- a/exercises/pascals-triangle/metadata.yml
+++ b/exercises/pascals-triangle/metadata.yml
@@ -1,4 +1,5 @@
 ---
+title: "Pascal's Triangle"
 blurb: "Compute Pascal's triangle up to a given number of rows."
 source: "Pascal's Triangle at Wolfram Math World"
 source_url: "http://mathworld.wolfram.com/PascalsTriangle.html"

--- a/exercises/pov/metadata.yml
+++ b/exercises/pov/metadata.yml
@@ -1,4 +1,5 @@
 ---
+title: "POV"
 blurb: "Reparent a graph on a selected node"
 source: "Adaptation of exercise from 4clojure"
 source_url: "https://www.4clojure.com/"

--- a/exercises/rna-transcription/metadata.yml
+++ b/exercises/rna-transcription/metadata.yml
@@ -1,4 +1,5 @@
 ---
+title: "RNA Transcription"
 blurb: "Given a DNA strand, return its RNA complement (per RNA transcription)."
 source: "Rosalind"
 source_url: "http://rosalind.info/problems/rna"

--- a/exercises/sgf-parsing/metadata.yml
+++ b/exercises/sgf-parsing/metadata.yml
@@ -1,2 +1,3 @@
 ---
+title: "SGF Parsing"
 blurb: "Parsing a Smart Game Format string."


### PR DESCRIPTION
In generated READMEs, the rule for converting an exercise slug to a
human-readable form is to capitalise only the first letter of each
hyphen-separated word. For example, `lorem-ipsum` will become "Lorem
Ipsum". This is true of both the Trackler and Configlet README
generators.

Trackler's README generator (see `name` function):
https://github.com/exercism/trackler/blob/master/lib/trackler/specification.rb

Configlet's README generator (see `Name` function):
https://github.com/exercism/configlet/blob/master/track/problem_specification.go

For some exercises this is not the best possible title. For example see
http://exercism.io/exercises/haskell/rna-transcription/readme and
observe that the title is "Rna Transcription", whereas "RNA
Transcription" seems more faithful to the rules (RNA, as an initialism,
should be in all caps).

If we would like the README generator to generate these non-default
titles, it seems to make the most sense to add it in
problem-specifications. The alternative of adding the exceptions to
configlet has the disadvantage of requiring an update to configlet for
any new exercise that desires a non-default title.

The proposal is a `title` field in metadata.yml that overrides the
default capitalisation or punctuation. For those exercises for which the
default title is appropriate, it is recommend that this field be
omitted, to avoid unnecessary configuration.

Please receive confirmation from
https://github.com/exercism/configlet/issues/76 that this proposal is
appropriate on the configlet side before merging.

Please prepare a corresponding update to
https://github.com/exercism/docs/blob/master/language-tracks/exercises/anatomy/readmes.md
before merging.