### PR TITLE
Correct `test-one` instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,6 @@ npm test
 
 Run for single exercise:
 ```shell
-npm test-one exercises/<exercise>/canonical-data.json
+npm run test-one exercises/<exercise>/canonical-data.json
 ```
 Replace `<exercise>` by the name of exercise which you want to check.


### PR DESCRIPTION
`npm test` will work as described, because it's an alias for `npm run test`, but `test-one` requires the user to type `npm run test-one`

I realized this when (after making my last PR) I read the docs for the repo  ☺️