### PR TITLE
Bowling: wrap paragraphs and fix some minor grammar

### DIFF
--- a/exercises/bowling/description.md
+++ b/exercises/bowling/description.md
@@ -1,18 +1,28 @@
 Score a bowling game.
 
-Bowling is game where players roll a heavy ball to knock down pins
+Bowling is a game where players roll a heavy ball to knock down pins
 arranged in a triangle. Write code to keep track of the score
 of a game of bowling.
 
 ## Scoring Bowling
 
-The game consists of 10 frames. A frame is composed of one or two ball throws with 10 pins standing at frame initialization. There are three cases for the tabulation of a frame.
+The game consists of 10 frames. A frame is composed of one or two ball
+throws with 10 pins standing at frame initialization. There are three
+cases for the tabulation of a frame.
 
-* An open frame is where a score of less than 10 is recorded for the frame. In this case the score for the frame is the number of pins knocked down.
+* An open frame is where a score of less than 10 is recorded for the
+  frame. In this case the score for the frame is the number of pins
+  knocked down.
 
-* A spare is where all ten pins are knocked down after the second throw. The total value of a spare is 10 plus the number of pins knocked down in their next throw.
+* A spare is where all ten pins are knocked down by the second
+  throw. The total value of a spare is 10 plus the number of pins
+  knocked down in their next throw.
 
-* A strike is where all ten pins are knocked down after the first throw. The total value of a strike is 10 plus the number of pins knocked down in their next two throws. If a strike is immediately followed by a second strike, then we can not total the value of first strike until they throw the ball one more time.
+* A strike is where all ten pins are knocked down by the first
+  throw. The total value of a strike is 10 plus the number of pins
+  knocked down in the next two throws. If a strike is immediately
+  followed by a second strike, then the value of the first strike
+  cannot be determined until the ball is thrown one more time.
 
 Here is a three frame example:
 
@@ -28,7 +38,11 @@ Frame 3 is (9 + 0) = 9
 
 This means the current running total is 48.
 
-The tenth frame in the game is a special case. If someone throws a strike or a spare then they get a fill ball. Fill balls exist to calculate the total of the 10th frame. Scoring a strike or spare on the fill ball does not give the player more fill balls. The total value of the 10th frame is the total number of pins knocked down.
+The tenth frame in the game is a special case. If someone throws a
+strike or a spare then they get a fill ball. Fill balls exist to
+calculate the total of the 10th frame. Scoring a strike or spare on
+the fill ball does not give the player more fill balls. The total
+value of the 10th frame is the total number of pins knocked down.
 
 For a tenth frame of X1/ (strike and a spare), the total value is 20.
 


### PR DESCRIPTION
The paragraphs rambled without newlines. They are now line wrapped to match
the other exercises.

There was a missing article 'a' in the beginning. The phrasing "after the
throw" is a little confusing. Does this mean either the 2nd or 3rd throws?
No, it means they are knocked down by THIS throw. Update accordingly.