### PR TITLE
protein-translation: Update description.md with correct fact as in #810

### DIFF
--- a/exercises/protein-translation/description.md
+++ b/exercises/protein-translation/description.md
@@ -12,7 +12,7 @@ Protein: `"Methionine", "Phenylalanine", "Serine"`
 There are 64 codons which in turn correspond to 20 amino acids; however, all of the codon sequences and resulting amino acids are not important in this exercise.  If it works for one codon, the program should work for all of them.
 However, feel free to expand the list in the test suite to include them all.  
 
-There are also four terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the protein is terminated.
+There are also three terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the protein is terminated.
 
 All subsequent codons after are ignored, like this:
 


### PR DESCRIPTION
Corrected "four stop codons" to "three stop codons" as described in issue #810