### PR TITLE
contributing.md: fix broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -347,7 +347,7 @@ Please review the details in [README.md](https://github.com/exercism/problem-spe
 
 ### Anatomy of an Exercise
 
-See the [anatomy of an exercise](https://github.com/exercism/docs/tree/master/maintaining-a-track/anatomy-of-an-exercise.md) in the docs repository.
+See the [anatomy of an exercise](https://github.com/exercism/docs/tree/master/language-tracks/exercises/anatomy) in the docs repository.
 
 ### Track configuration file
 


### PR DESCRIPTION
Closes: #914 
Note that the readme.md the new link points to is not complete.  It would be nice to know what happened to the old doc that the broken link pointed to.  Could that old doc be used to fill in missing information in the incomplete readme.md?