### PR TITLE
nucleotide-count: Remove reference to RNA from description

### DIFF
--- a/exercises/nucleotide-count/description.md
+++ b/exercises/nucleotide-count/description.md
@@ -10,4 +10,3 @@ Here is an analogy:
 - legos are to lego houses as
 - words are to sentences as...
 
-In RNA the thymine is substituted with 'U' for uracil, while the remainder stay the same; A, U, C, G.

--- a/exercises/nucleotide-count/description.md
+++ b/exercises/nucleotide-count/description.md
@@ -9,4 +9,3 @@ Here is an analogy:
 - nucleotides are to DNA as
 - legos are to lego houses as
 - words are to sentences as...
-


### PR DESCRIPTION
In #913 the description of DNA was made more scientifically accurate.

However the reference to RNA is not relevant to this problem and is likely to cause confusion, so I have removed it from the description.


