### PR TITLE
isogram: Update canonical-data.json as in #919

### DIFF
--- a/exercises/isogram/canonical-data.json
+++ b/exercises/isogram/canonical-data.json
@@ -3,7 +3,7 @@
   "comments": [
     "An isogram is a word or phrase without a repeating letter."
   ],
-  "version": "1.1.0",
+  "version": "1.2.0",
   "cases": [
     {
       "description": "Check if the given string is an isogram",

--- a/exercises/isogram/canonical-data.json
+++ b/exercises/isogram/canonical-data.json
@@ -48,9 +48,9 @@
           "expected": true
         },
         {
-          "description": "isogram with duplicated non letter character",
+          "description": "isogram with duplicated hyphen",
           "property": "isIsogram",
-          "input": "Hjelmqvist-Gryb-Zock-Pfund-Wax",
+          "input": "six-year-old",
           "expected": true
         },
         {


### PR DESCRIPTION
Changed test description "isogram with duplicated non-letter character" to "isogram with duplicated hyphen", and changed the associated canonical data from "Hjelmqvist-Gryb-Zock-Pfund-Wax" to "six-year-old". This was suggested in issue #919.