### PR TITLE
crypto-square: Don't test intermediate functions

### DIFF
--- a/exercises/crypto-square/canonical-data.json
+++ b/exercises/crypto-square/canonical-data.json
@@ -1,82 +1,27 @@
 {
   "exercise": "crypto-square",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "cases": [
     {
       "description": "the spaces and punctuation are removed from the English text and the message is downcased",
       "cases": [
         {
           "description": "Lowercase",
-          "property": "normalizedPlaintext",
-          "plaintext": "Hello",
-          "expected": "hello"
+          "property": "ciphertext",
+          "plaintext": "A",
+          "expected": "a"
         },
         {
           "description": "Remove spaces",
-          "property": "normalizedPlaintext",
-          "plaintext": "Hi there",
-          "expected": "hithere"
+          "property": "ciphertext",
+          "plaintext": "  b ",
+          "expected": "b"
         },
         {
           "description": "Remove punctuation",
-          "property": "normalizedPlaintext",
-          "plaintext": "@1, 2%, 3 Go!",
-          "expected": "123go"
-        }
-      ]
-    },
-    {
-      "description": "The plaintext should be organized in to a rectangle.  The size of the rectangle (`r x c`) should be decided by the length of the message, such that `c >= r` and `c - r <= 1`, where `c` is the number of columns and `r` is the number of rows.",
-      "cases": [
-        {
-          "description": "empty plaintext results in an empty rectangle",
-          "property": "plaintextSegments",
-          "plaintext": "",
-          "expected": []
-        },
-        {
-          "description": "4 character plaintext results in an 2x2 rectangle",
-          "property": "plaintextSegments",
-          "plaintext": "Ab Cd",
-          "expected": [ "ab",
-                        "cd" ]
-        },
-        {
-          "description": "9 character plaintext results in an 3x3 rectangle",
-          "property": "plaintextSegments",
-          "plaintext": "This is fun!",
-          "expected": [ "thi",
-                        "sis",
-                        "fun" ]
-        },
-        {
-          "description": "54 character plaintext results in an 8x7 rectangle",
-          "property": "plaintextSegments",
-          "plaintext": "If man was meant to stay on the ground, god would have given us roots.",
-          "expected": [ "ifmanwas",
-                        "meanttos",
-                        "tayonthe",
-                        "groundgo",
-                        "dwouldha",
-                        "vegivenu",
-                        "sroots"   ]
-        }
-      ]
-    },
-    {
-      "description": "The coded message is obtained by reading down the columns going left to right.",
-      "cases": [
-        {
-          "description": "empty plaintext results in an empty encode",
-          "property": "encoded",
-          "plaintext": "",
-          "expected": ""
-        },
-        {
-          "description": "Non-empty plaintext results in the combined plaintext segments",
-          "property": "encoded",
-          "plaintext": "If man was meant to stay on the ground, god would have given us roots.",
-          "expected": "imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau"
+          "property": "ciphertext",
+          "plaintext": "@1,%!",
+          "expected": "1"
         }
       ]
     },


### PR DESCRIPTION
We want to remove tests of intermediate functions in crypto-square that pry into implementation details per these issues:
- https://github.com/exercism/discussions/issues/41
- https://github.com/exercism/ruby/issues/422

This rewrites the canonical data for crypto-square so that we're only testing the expected value of the final "ciphertext" property and none of the intermediate properties.