### PR TITLE
crypto-square: Fix description copy and example

### DIFF
--- a/exercises/crypto-square/description.md
+++ b/exercises/crypto-square/description.md
@@ -43,12 +43,14 @@ The message above is coded as:
 imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau
 ```
 
-Output the encoded text in chunks.  Phrases that fill perfect squares
-`(r X r)` should be output in `r`-length chunks separated by spaces.
-Imperfect squares will have `n` empty spaces.  Those spaces should be distributed evenly across the last `n` rows.
+Output the encoded text in chunks.  Phrases that fill perfect rectangles
+`(r X c)` should be output `c` chunks of `r` length, separated by spaces.
+Phrases that do not fill perfect rectangles will have `n` empty spaces.
+Those spaces should be distributed evenly, added to the end of the last
+`n` chunks.
 
 ```text
-imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn sseoau
+imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau 
 ```
 
 Notice that were we to stack these, we could visually decode the


### PR DESCRIPTION
The final example in the crypto-square description is inconsistent with the source of the exercise, the canonical data, and itself. This change does a few things to correct that:

- While the encoding method is called a "square code," we're really dealing with all sorts of rectangles, squares included. The description gets this right up until the copy before the last example, and this change clarifies that.

- In both the [source of the exercise](http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html) and [the canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/crypto-square/canonical-data.json#L47), when a "chunk" is shorter than the length of a row, a blank space is added to the end of that chunk. This change fixes that in the final example.

- The copy before the final example says that "spaces should be distributed evenly across the last `n` rows," but it doesn't explain how. This change specifies that the spaces should be added to the end of each chunk.

Here's a related discussion: https://github.com/exercism/problem-specifications/issues/356