### PR TITLE
kindergarten-garden: Remove tests not specified in the description

### DIFF
--- a/exercises/kindergarten-garden/canonical-data.json
+++ b/exercises/kindergarten-garden/canonical-data.json
@@ -82,43 +82,6 @@
           "expected": ["grass", "violets", "clover", "violets"]
         }
       ]
-    },
-    {
-      "description": "non-alphabetical student list",
-      "cases": [
-        {
-          "description": "first student's garden",
-          "property": "plants",
-          "students": ["Samantha", "Patricia", "Xander", "Roger"],
-          "diagram": "VCRRGVRG\nRVGCCGCV",
-          "student": "Patricia",
-          "expected": ["violets", "clover", "radishes", "violets"]
-        },
-        {
-          "description": "second student's garden",
-          "property": "plants",
-          "students": ["Samantha", "Patricia", "Xander", "Roger"],
-          "diagram": "VCRRGVRG\nRVGCCGCV",
-          "student": "Roger",
-          "expected": ["radishes", "radishes", "grass", "clover"]
-        },
-        {
-          "description": "third student's garden",
-          "property": "plants",
-          "students": ["Samantha", "Patricia", "Xander", "Roger"],
-          "diagram": "VCRRGVRG\nRVGCCGCV",
-          "student": "Samantha",
-          "expected": ["grass", "violets", "clover", "grass"]
-        },
-        {
-          "description": "fourth (last) student's garden",
-          "property": "plants",
-          "students": ["Samantha", "Patricia", "Xander", "Roger"],
-          "diagram": "VCRRGVRG\nRVGCCGCV",
-          "student": "Xander",
-          "expected": ["radishes", "grass", "clover", "violets"]
-        }
-      ]
     }
   ]
 }


### PR DESCRIPTION
Adds a disclaimer in Kindergarten-garden that names of students may differ.
Completed Issue #659.

Edit: 

There has been further discussion about what needs to happen to this problem so this PR has changed from its initial version.

The current proposal is to remove the tests for different student names. These are not specified in the description which is otherwise explicit about the names and ordering of students in the class.

Closes #659