### PR TITLE
lens-person: fix minor typo in description.md

### DIFF
--- a/exercises/lens-person/description.md
+++ b/exercises/lens-person/description.md
@@ -3,5 +3,5 @@ Use lenses to update nested records (specific to languages with immutable data).
 Updating fields of nested records is kind of annoying in Haskell. One solution
 is to use [lenses](https://wiki.haskell.org/Lens).  Implement several record
 accessing functions using lenses, you may use any library you want. The test
-suite also allows you to avoid lenses alltogether so you can experiment with
+suite also allows you to avoid lenses altogether so you can experiment with
 different approaches.


### PR DESCRIPTION
Changed spelling from "alltogether" to "altogether" This is my very first contribution to anything, anywhere so be gentle.  I'm still learning github and git.