### PR TITLE
zipper: add canonical data

### DIFF
--- a/exercises/zipper/canonical-data.json
+++ b/exercises/zipper/canonical-data.json
@@ -1,0 +1,671 @@
+{
+  "exercise": "zipper",
+  "version": "1.0.0",
+  "comments": [
+    " The test cases for this exercise include an initial tree and a     ",
+    " series of operations to perform on the initial tree.               ",
+    "                                                                    ",
+    " Trees are encoded as nested objects. Each node in the tree has     ",
+    " three members: 'value', 'left', and 'right'. Each value is a       ",
+    " number (for simplicity). Left and right are trees. An empty node   ",
+    " is encoded as null.                                                ",
+    "                                                                    ",
+    " Each operation in the operations list is an object. The function   ",
+    " name is listed under 'operation'. If the function requires         ",
+    " arguments, the argument is listed under 'item'. Some functions     ",
+    " require values (i.e.  numbers), while others require trees.        ",
+    " Comments are always optional and can be used almost anywhere.      "
+  ],
+  "cases": [
+    {
+      "description": "data is retained",
+      "property": "expectedValue",
+      "initialTree": {
+        "value": 1,
+        "left": {
+          "value": 2,
+          "left": null,
+          "right": {
+            "value": 3,
+            "left": null,
+            "right": null
+          }
+        },
+        "right": {
+          "value": 4,
+          "left": null,
+          "right": null
+        }
+      },
+      "operations": [
+        {
+          "operation": "to_tree"
+        }
+      ],
+      "expected": {
+        "type": "tree",
+        "value": {
+          "value": 1,
+          "left": {
+            "value": 2,
+            "left": null,
+            "right": {
+              "value": 3,
+              "left": null,
+              "right": null
+            }
+          },
+          "right": {
+            "value": 4,
+            "left": null,
+            "right": null
+          }
+        }
+      }
+    },
+    {
+      "description": "left, right and value",
+      "property": "expectedValue",
+      "initialTree": {
+        "value": 1,
+        "left": {
+          "value": 2,
+          "left": null,
+          "right": {
+            "value": 3,
+            "left": null,
+            "right": null
+          }
+        },
+        "right": {
+          "value": 4,
+          "left": null,
+          "right": null
+        }
+      },
+      "operations": [
+        {
+          "operation": "left"
+        },
+        {
+          "operation": "right"
+        },
+        {
+          "operation": "value"
+        }
+      ],
+      "expected": {
+        "type": "int",
+        "value": 3
+      }
+    },
+    {
+      "description": "dead end",
+      "property": "expectedValue",
+      "initialTree": {
+        "value": 1,
+        "left": {
+          "value": 2,
+          "left": null,
+          "right": {
+            "value": 3,
+            "left": null,
+            "right": null
+          }
+        },
+        "right": {
+          "value": 4,
+          "left": null,
+          "right": null
+        }
+      },
+      "operations": [
+        {
+          "operation": "left"
+        },
+        {
+          "operation": "left"
+        }
+      ],
+      "expected": {
+        "type": "zipper",
+        "value": null
+      }
+    },
+    {
+      "description": "tree from deep focus",
+      "property": "expectedValue",
+      "initialTree": {
+        "value": 1,
+        "left": {
+          "value": 2,
+          "left": null,
+          "right": {
+            "value": 3,
+            "left": null,
+            "right": null
+          }
+        },
+        "right": {
+          "value": 4,
+          "left": null,
+          "right": null
+        }
+      },
+      "operations": [
+        {
+          "operation": "left"
+        },
+        {
+          "operation": "right"
+        },
+        {
+          "operation": "to_tree"
+        }
+      ],
+      "expected": {
+        "type": "tree",
+        "value": {
+          "value": 1,
+          "left": {
+            "value": 2,
+            "left": null,
+            "right": {
+              "value": 3,
+              "left": null,
+              "right": null
+            }
+          },
+          "right": {
+            "value": 4,
+            "left": null,
+            "right": null
+          }
+        }
+      }
+    },
+    {
+      "description": "traversing up from top",
+      "property": "expectedValue",
+      "initialTree": {
+        "value": 1,
+        "left": {
+          "value": 2,
+          "left": null,
+          "right": {
+            "value": 3,
+            "left": null,
+            "right": null
+          }
+        },
+        "right": {
+          "value": 4,
+          "left": null,
+          "right": null
+        }
+      },
+      "operations": [
+        {
+          "operation": "up"
+        }
+      ],
+      "expected": {
+        "type": "zipper",
+        "value": null
+      }
+    },
+    {
+      "description": "left, right, and up",
+      "property": "expectedValue",
+      "initialTree": {
+        "value": 1,
+        "left": {
+          "value": 2,
+          "left": null,
+          "right": {
+            "value": 3,
+            "left": null,
+            "right": null
+          }
+        },
+        "right": {
+          "value": 4,
+          "left": null,
+          "right": null
+        }
+      },
+      "operations": [
+        {
+          "operation": "left"
+        },
+        {
+          "operation": "up"
+        },
+        {
+          "operation": "right"
+        },
+        {
+          "operation": "up"
+        },
+        {
+          "operation": "left"
+        },
+        {
+          "operation": "right"
+        },
+        {
+          "operation": "value"
+        }
+      ],
+      "expected": {
+        "type": "int",
+        "value": 3
+      }
+    },
+    {
+      "description": "set_value",
+      "property": "expectedValue",
+      "initialTree": {
+        "value": 1,
+        "left": {
+          "value": 2,
+          "left": null,
+          "right": {
+            "value": 3,
+            "left": null,
+            "right": null
+          }
+        },
+        "right": {
+          "value": 4,
+          "left": null,
+          "right": null
+        }
+      },
+      "operations": [
+        {
+          "operation": "left"
+        },
+        {
+          "operation": "set_value",
+          "item": 5
+        },
+        {
+          "operation": "to_tree"
+        }
+      ],
+      "expected": {
+        "type": "tree",
+        "value": {
+          "value": 1,
+          "left": {
+            "value": 5,
+            "left": null,
+            "right": {
+              "value": 3,
+              "left": null,
+              "right": null
+            }
+          },
+          "right": {
+            "value": 4,
+            "left": null,
+            "right": null
+          }
+        }
+      }
+    },
+    {
+      "description": "set_value after traversing up",
+      "property": "expectedValue",
+      "initialTree": {
+        "value": 1,
+        "left": {
+          "value": 2,
+          "left": null,
+          "right": {
+            "value": 3,
+            "left": null,
+            "right": null
+          }
+        },
+        "right": {
+          "value": 4,
+          "left": null,
+          "right": null
+        }
+      },
+      "operations": [
+        {
+          "operation": "left"
+        },
+        {
+          "operation": "right"
+        },
+        {
+          "operation": "up"
+        },
+        {
+          "operation": "set_value",
+          "item": 5
+        },
+        {
+          "operation": "to_tree"
+        }
+      ],
+      "expected": {
+        "type": "tree",
+        "value": {
+          "value": 1,
+          "left": {
+            "value": 5,
+            "left": null,
+            "right": {
+              "value": 3,
+              "left": null,
+              "right": null
+            }
+          },
+          "right": {
+            "value": 4,
+            "left": null,
+            "right": null
+          }
+        }
+      }
+    },
+    {
+      "description": "set_left with leaf",
+      "property": "expectedValue",
+      "initialTree": {
+        "value": 1,
+        "left": {
+          "value": 2,
+          "left": null,
+          "right": {
+            "value": 3,
+            "left": null,
+            "right": null
+          }
+        },
+        "right": {
+          "value": 4,
+          "left": null,
+          "right": null
+        }
+      },
+      "operations": [
+        {
+          "operation": "left"
+        },
+        {
+          "operation": "set_left",
+          "item": {
+            "value": 5,
+            "left": null,
+            "right": null
+          }
+        },
+        {
+          "operation": "to_tree"
+        }
+      ],
+      "expected": {
+        "type": "tree",
+        "value": {
+          "value": 1,
+          "left": {
+            "value": 2,
+            "left": {
+              "value": 5,
+              "left": null,
+              "right": null
+            },
+            "right": {
+              "value": 3,
+              "left": null,
+              "right": null
+            }
+          },
+          "right": {
+            "value": 4,
+            "left": null,
+            "right": null
+          }
+        }
+      }
+    },
+    {
+      "description": "set_right with null",
+      "property": "expectedValue",
+      "initialTree": {
+        "value": 1,
+        "left": {
+          "value": 2,
+          "left": null,
+          "right": {
+            "value": 3,
+            "left": null,
+            "right": null
+          }
+        },
+        "right": {
+          "value": 4,
+          "left": null,
+          "right": null
+        }
+      },
+      "operations": [
+        {
+          "operation": "left"
+        },
+        {
+          "operation": "set_right",
+          "item": null
+        },
+        {
+          "operation": "to_tree"
+        }
+      ],
+      "expected": {
+        "type": "tree",
+        "value": {
+          "value": 1,
+          "left": {
+            "value": 2,
+            "left": null,
+            "right": null
+          },
+          "right": {
+            "value": 4,
+            "left": null,
+            "right": null
+          }
+        }
+      }
+    },
+    {
+      "description": "set_right with subtree",
+      "property": "expectedValue",
+      "initialTree": {
+        "value": 1,
+        "left": {
+          "value": 2,
+          "left": null,
+          "right": {
+            "value": 3,
+            "left": null,
+            "right": null
+          }
+        },
+        "right": {
+          "value": 4,
+          "left": null,
+          "right": null
+        }
+      },
+      "operations": [
+        {
+          "operation": "set_right",
+          "item": {
+            "value": 6,
+            "left": {
+              "value": 7,
+              "left": null,
+              "right": null
+            },
+            "right": {
+              "value": 8,
+              "left": null,
+              "right": null
+            }
+          }
+        },
+        {
+          "operation": "to_tree"
+        }
+      ],
+      "expected": {
+        "type": "tree",
+        "value": {
+          "value": 1,
+          "left": {
+            "value": 2,
+            "left": null,
+            "right": {
+              "value": 3,
+              "left": null,
+              "right": null
+            }
+          },
+          "right": {
+            "value": 6,
+            "left": {
+              "value": 7,
+              "left": null,
+              "right": null
+            },
+            "right": {
+              "value": 8,
+              "left": null,
+              "right": null
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "set_value on deep focus",
+      "property": "expectedValue",
+      "initialTree": {
+        "value": 1,
+        "left": {
+          "value": 2,
+          "left": null,
+          "right": {
+            "value": 3,
+            "left": null,
+            "right": null
+          }
+        },
+        "right": {
+          "value": 4,
+          "left": null,
+          "right": null
+        }
+      },
+      "operations": [
+        {
+          "operation": "left"
+        },
+        {
+          "operation": "right"
+        },
+        {
+          "operation": "set_value",
+          "item": 5
+        },
+        {
+          "operation": "to_tree"
+        }
+      ],
+      "expected": {
+        "type": "tree",
+        "value": {
+          "value": 1,
+          "left": {
+            "value": 2,
+            "left": null,
+            "right": {
+              "value": 5,
+              "left": null,
+              "right": null
+            }
+          },
+          "right": {
+            "value": 4,
+            "left": null,
+            "right": null
+          }
+        }
+      }
+    },
+    {
+      "description": "different paths to same zipper",
+      "property": "sameResultFromOperations",
+      "initialTree": {
+        "value": 1,
+        "left": {
+          "value": 2,
+          "left": null,
+          "right": {
+            "value": 3,
+            "left": null,
+            "right": null
+          }
+        },
+        "right": {
+          "value": 4,
+          "left": null,
+          "right": null
+        }
+      },
+      "operations": [
+        {
+          "operation": "left"
+        },
+        {
+          "operation": "up"
+        },
+        {
+          "operation": "right"
+        }
+      ],
+      "expected": {
+        "type": "zipper",
+        "initialTree": {
+          "value": 1,
+          "left": {
+            "value": 2,
+            "left": null,
+            "right": {
+              "value": 3,
+              "left": null,
+              "right": null
+            }
+          },
+          "right": {
+            "value": 4,
+            "left": null,
+            "right": null
+          }
+        },
+        "operations": [
+          {
+            "operation": "right"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #593.

Of the five tracks that had already implemented this exercise, five had the exact same test cases, and the other two had the same test cases plus a few more (identical) test cases. I opted to simply list all of the test cases I found in the order they were in.

I ran the test against the `canonical-schema.json` and it said the file is valid.