### PR TITLE
queen-attack: represent positions as objects

### DIFF
--- a/exercises/queen-attack/canonical-data.json
+++ b/exercises/queen-attack/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "queen-attack",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "comments": [
     "Testing invalid positions will vary by language. The expected",
     "value of -1 is there to indicate some sort of failure should",
@@ -18,39 +18,54 @@
           "description": "queen with a valid position",
           "property": "create",
           "queen": {
-            "position": "(2,2)"
+            "position": {
+              "row": 2,
+              "column": 2
+            }
           },
           "expected": 0
         },
         {
-          "description": "queen must have positive rank",
+          "description": "queen must have positive row",
           "property": "create",
           "queen": {
-            "position": "(-2,2)"
+            "position": {
+              "row": -2,
+              "column": 2
+            }
           },
           "expected": -1
         },
         {
-          "description": "queen must have rank on board",
+          "description": "queen must have row on board",
           "property": "create",
           "queen": {
-            "position": "(8,4)"
+            "position": {
+              "row": 8,
+              "column": 4
+            }
           },
           "expected": -1
         },
         {
-          "description": "queen must have positive file",
+          "description": "queen must have positive column",
           "property": "create",
           "queen": {
-            "position": "(2,-2)"
+            "position": {
+              "row": 2,
+              "column": -2
+            }
           },
           "expected": -1
         },
         {
-          "description": "queen must have file on board",
+          "description": "queen must have column on board",
           "property": "create",
           "queen": {
-            "position": "(4,8)"
+            "position": {
+              "row": 4,
+              "column": 8
+            }
           },
           "expected": -1
         }
@@ -63,32 +78,50 @@
           "description": "can not attack",
           "property": "canAttack",
           "white_queen": {
-            "position": "(2,4)"
+            "position": {
+              "row": 2,
+              "column": 4
+            }
           },
           "black_queen": {
-            "position": "(6,6)"
+            "position": {
+              "row": 6,
+              "column": 6
+            }
           },
           "expected": false
         },
         {
-          "description": "can attack on same rank",
+          "description": "can attack on same row",
           "property": "canAttack",
           "white_queen": {
-            "position": "(2,4)"
+            "position": {
+              "row": 2,
+              "column": 4
+            }
           },
           "black_queen": {
-            "position": "(2,6)"
+            "position": {
+              "row": 2,
+              "column": 6
+            }
           },
           "expected": true
         },
         {
-          "description": "can attack on same file",
+          "description": "can attack on same column",
           "property": "canAttack",
           "white_queen": {
-            "position": "(4,5)"
+            "position": {
+              "row": 4,
+              "column": 5
+            }
           },
           "black_queen": {
-            "position": "(2,5)"
+            "position": {
+              "row": 2,
+              "column": 5
+            }
           },
           "expected": true
         },
@@ -96,10 +129,16 @@
           "description": "can attack on first diagonal",
           "property": "canAttack",
           "white_queen": {
-            "position": "(2,2)"
+            "position": {
+              "row": 2,
+              "column": 2
+            }
           },
           "black_queen": {
-            "position": "(0,4)"
+            "position": {
+              "row": 0,
+              "column": 4
+            }
           },
           "expected": true
         },
@@ -107,10 +146,16 @@
           "description": "can attack on second diagonal",
           "property": "canAttack",
           "white_queen": {
-            "position": "(2,2)"
+            "position": {
+              "row": 2,
+              "column": 2
+            }
           },
           "black_queen": {
-            "position": "(3,1)"
+            "position": {
+              "row": 3,
+              "column": 1
+            }
           },
           "expected": true
         },
@@ -118,10 +163,16 @@
           "description": "can attack on third diagonal",
           "property": "canAttack",
           "white_queen": {
-            "position": "(2,2)"
+            "position": {
+              "row": 2,
+              "column": 2
+            }
           },
           "black_queen": {
-            "position": "(1,1)"
+            "position": {
+              "row": 1,
+              "column": 1
+            }
           },
           "expected": true
         },
@@ -129,10 +180,16 @@
           "description": "can attack on fourth diagonal",
           "property": "canAttack",
           "white_queen": {
-            "position": "(2,2)"
+            "position": {
+              "row": 2,
+              "column": 2
+            }
           },
           "black_queen": {
-            "position": "(5,5)"
+            "position": {
+              "row": 5,
+              "column": 5
+            }
           },
           "expected": true
         }


### PR DESCRIPTION
Closes #721.

I decided to use objects, since it seems like most people were agreeing it was more explicit. I will also be using objects to encode the position for #722, which is deals with a similar issue.