### PR TITLE
robot-simulator: encode position as object instead of string

### DIFF
--- a/exercises/robot-simulator/canonical-data.json
+++ b/exercises/robot-simulator/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "robot-simulator",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "comments": [
     "Some tests have two expectations: one for the position, one for the direction",
     "Optionally, you can also test",

--- a/exercises/robot-simulator/canonical-data.json
+++ b/exercises/robot-simulator/canonical-data.json
@@ -16,11 +16,17 @@
           "description": "Robots are created with a position and direction",
           "property": "create",
           "robot": {
-            "position": "(0,0)",
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "north"
           },
           "expected": {
-            "position": "(0,0)",
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "north"
           }
         },
@@ -28,11 +34,17 @@
           "description": "Negative positions are allowed",
           "property": "create",
           "robot": {
-            "position": "(-1,-1)",
+            "position": {
+              "x": -1,
+              "y": -1
+            },
             "direction": "south"
           },
           "expected": {
-            "position": "(-1,-1)",
+            "position": {
+              "x": -1,
+              "y": -1
+            },
             "direction": "south"
           }
         }
@@ -45,18 +57,27 @@
           "description": "does not change the position",
           "property": "turnRight",
           "robot": {
-            "position": "(0,0)",
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "north"
           },
           "expected": {
-            "position": "(0,0)"
+            "position": {
+              "x": 0,
+              "y": 0
+            }
           }
         },
         {
           "description": "changes the direction from north to east",
           "property": "turnRight",
           "robot": {
-            "position": "(0,0)",
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "north"
           },
           "expected": {
@@ -67,7 +88,10 @@
           "description": "changes the direction from east to south",
           "property": "turnRight",
           "robot": {
-            "position": "(0,0)",
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "east"
           },
           "expected": {
@@ -78,7 +102,10 @@
           "description": "changes the direction from south to west",
           "property": "turnRight",
           "robot": {
-            "position": "(0,0)",
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "south"
           },
           "expected": {
@@ -89,7 +116,10 @@
           "description": "changes the direction from west to north",
           "property": "turnRight",
           "robot": {
-            "position": "(0,0)",
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "west"
           },
           "expected": {
@@ -105,18 +135,27 @@
           "description": "does not change the position",
           "property": "turnLeft",
           "robot": {
-            "position": "(0,0)",
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "north"
           },
           "expected": {
-            "position": "(0,0)"
+            "position": {
+              "x": 0,
+              "y": 0
+            }
           }
         },
         {
           "description": "changes the direction from north to west",
           "property": "turnLeft",
           "robot": {
-            "position": "(0,0)",
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "north"
           },
           "expected": {
@@ -127,7 +166,10 @@
           "description": "changes the direction from west to south",
           "property": "turnLeft",
           "robot": {
-            "position": "(0,0)",
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "west"
           },
           "expected": {
@@ -138,7 +180,10 @@
           "description": "changes the direction from south to east",
           "property": "turnLeft",
           "robot": {
-            "position": "(0,0)",
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "south"
           },
           "expected": {
@@ -149,7 +194,10 @@
           "description": "changes the direction from east to north",
           "property": "turnLeft",
           "robot": {
-            "position": "(0,0)",
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "east"
           },
           "expected": {
@@ -165,7 +213,10 @@
           "description": "does not change the direction",
           "property": "advance",
           "robot": {
-            "position": "(0,0)",
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "north"
           },
           "expected": {
@@ -176,44 +227,68 @@
           "description": "increases the y coordinate one when facing north",
           "property": "advance",
           "robot": {
-            "position": "(0,0)",
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "north"
           },
           "expected": {
-            "position": "(0,1)"
+            "position": {
+              "x": 0,
+              "y": 1
+            }
           }
         },
         {
           "description": "decreases the y coordinate by one when facing south",
           "property": "advance",
           "robot": {
-            "position": "(0,0)",
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "south"
           },
           "expected": {
-            "position": "(0,-1)"
+            "position": {
+              "x": 0,
+              "y": -1
+            }
           }
         },
         {
           "description": "increases the x coordinate by one when facing east",
           "property": "advance",
           "robot": {
-            "position": "(0,0)",
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "east"
           },
           "expected": {
-            "position": "(1,0)"
+            "position": {
+              "x": 1,
+              "y": 0
+            }
           }
         },
         {
           "description": "decreases the x coordinate by one when facing west",
           "property": "advance",
           "robot": {
-            "position": "(0,0)",
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "west"
           },
           "expected": {
-            "position": "(-1,0)"
+            "position": {
+              "x": -1,
+              "y": 0
+            }
           }
         }
       ]
@@ -225,12 +300,18 @@
           "description": "instructions to move west and north",
           "property": "instructions",
           "robot": {
-            "position": "(0,0)",
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "north"
           },
           "instructions": "LAAARALA",
           "expected": {
-            "position": "(-4,1)",
+            "position": {
+              "x": -4,
+              "y": 1
+            },
             "direction": "west"
           }
         },
@@ -238,12 +319,18 @@
           "description": "instructions to move west and south",
           "property": "instructions",
           "robot": {
-            "position": "(2,-7)",
+            "position": {
+              "x": 2,
+              "y": -7
+            },
             "direction": "east"
           },
           "instructions": "RRAAAAALA",
           "expected": {
-            "position": "(-3,-8)",
+            "position": {
+              "x": -3,
+              "y": -8
+            },
             "direction": "south"
           }
         },
@@ -251,12 +338,18 @@
           "description": "instructions to move east and north",
           "property": "instructions",
           "robot": {
-            "position": "(8,4)",
+            "position": {
+              "x": 8,
+              "y": 4
+            },
             "direction": "south"
           },
           "instructions": "LAAARRRALLLL",
           "expected": {
-            "position": "(11,5)",
+            "position": {
+              "x": 11,
+              "y": 5
+            },
             "direction": "north"
           }
         }


### PR DESCRIPTION
Closes #722.

I decided to use objects. Some people preferred arrays and some people preferred objects, but it seems like in other problems objects were preferred because they were more explicit (see #721). I don't believe we have a policy yet on whether to use arrays or objects for things like this, but I believe that objects would be a better decision. There are some situations in which it doesn't really matter and some people would prefer arrays, but there are some situations where it really would be better to have objects. Since it sometimes is desirable to have objects and only sometimes slightly preferred to have arrays, I think objects are a better default policy.