### PR TITLE
crypto-square: Improve test data

### DIFF
--- a/exercises/crypto-square/canonical-data.json
+++ b/exercises/crypto-square/canonical-data.json
@@ -1,52 +1,42 @@
 {
   "exercise": "crypto-square",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "cases": [
     {
-      "description": "the spaces and punctuation are removed from the English text and the message is downcased",
-      "cases": [
-        {
-          "description": "Lowercase",
-          "property": "ciphertext",
-          "plaintext": "A",
-          "expected": "a"
-        },
-        {
-          "description": "Remove spaces",
-          "property": "ciphertext",
-          "plaintext": "  b ",
-          "expected": "b"
-        },
-        {
-          "description": "Remove punctuation",
-          "property": "ciphertext",
-          "plaintext": "@1,%!",
-          "expected": "1"
-        }
-      ]
+      "description": "Lowercase",
+      "property": "ciphertext",
+      "plaintext": "A",
+      "expected": "a"
     },
     {
-      "description": "Output the encoded text in chunks.  Phrases that fill perfect squares `(r X r)` should be output in `r`-length chunks separated by spaces.  Imperfect squares will have `n` empty spaces.  Those spaces should be distributed evenly across the last `n` rows.",
-      "cases": [
-        {
-          "description": "empty plaintext results in an empty ciphertext",
-          "property": "ciphertext",
-          "plaintext": "",
-          "expected": ""
-        },
-        {
-          "description": "9 character plaintext results in 3 chunks of 3 characters",
-          "property": "ciphertext",
-          "plaintext": "This is fun!",
-          "expected": "tsf hiu isn"
-        },
-        {
-          "description": "54 character plaintext results in 7 chunks, the last two padded with spaces",
-          "property": "ciphertext",
-          "plaintext": "If man was meant to stay on the ground, god would have given us roots.",
-          "expected": "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau "
-        }
-      ]
+      "description": "Remove spaces",
+      "property": "ciphertext",
+      "plaintext": "  b ",
+      "expected": "b"
+    },
+    {
+      "description": "Remove punctuation",
+      "property": "ciphertext",
+      "plaintext": "@1,%!",
+      "expected": "1"
+    },
+    {
+      "description": "empty plaintext results in an empty ciphertext",
+      "property": "ciphertext",
+      "plaintext": "",
+      "expected": ""
+    },
+    {
+      "description": "9 character plaintext results in 3 chunks of 3 characters",
+      "property": "ciphertext",
+      "plaintext": "This is fun!",
+      "expected": "tsf hiu isn"
+    },
+    {
+      "description": "54 character plaintext results in 7 chunks, the last two padded with spaces",
+      "property": "ciphertext",
+      "plaintext": "If man was meant to stay on the ground, god would have given us roots.",
+      "expected": "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau "
     }
   ]
 }

--- a/exercises/crypto-square/canonical-data.json
+++ b/exercises/crypto-square/canonical-data.json
@@ -33,6 +33,12 @@
       "expected": "tsf hiu isn"
     },
     {
+      "description": "8 character plaintext results in 3 chunks, the last one with a trailing space",
+      "property": "ciphertext",
+      "plaintext": "Chill out.",
+      "expected": "clu hlt io "
+    },
+    {
       "description": "54 character plaintext results in 7 chunks, the last two padded with spaces",
       "property": "ciphertext",
       "plaintext": "If man was meant to stay on the ground, god would have given us roots.",

--- a/exercises/crypto-square/canonical-data.json
+++ b/exercises/crypto-square/canonical-data.json
@@ -39,7 +39,7 @@
       "expected": "clu hlt io "
     },
     {
-      "description": "54 character plaintext results in 7 chunks, the last two padded with spaces",
+      "description": "54 character plaintext results in 7 chunks, the last two with trailing spaces",
       "property": "ciphertext",
       "plaintext": "If man was meant to stay on the ground, god would have given us roots.",
       "expected": "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau "

--- a/exercises/crypto-square/canonical-data.json
+++ b/exercises/crypto-square/canonical-data.json
@@ -3,6 +3,12 @@
   "version": "3.1.0",
   "cases": [
     {
+      "description": "empty plaintext results in an empty ciphertext",
+      "property": "ciphertext",
+      "plaintext": "",
+      "expected": ""
+    },
+    {
       "description": "Lowercase",
       "property": "ciphertext",
       "plaintext": "A",
@@ -19,12 +25,6 @@
       "property": "ciphertext",
       "plaintext": "@1,%!",
       "expected": "1"
-    },
-    {
-      "description": "empty plaintext results in an empty ciphertext",
-      "property": "ciphertext",
-      "plaintext": "",
-      "expected": ""
     },
     {
       "description": "9 character plaintext results in 3 chunks of 3 characters",


### PR DESCRIPTION
This cleans up a few things about crypto-square's canonical data that I thought were worth addressing before I generated new tests in the Ruby repo to address https://github.com/exercism/ruby/issues/422.

- Removes unnecessary sub-groupings of test cases ([related discussion](https://github.com/exercism/problem-specifications/pull/922#discussion_r142604966))
- Moves the blank string test case to the top since it feels like the simplest one to get passing using TDD
- Adds a new test case