### PR TITLE
space-age: describe tolerance of two decimal places

### DIFF
--- a/exercises/space-age/description.md
+++ b/exercises/space-age/description.md
@@ -10,7 +10,9 @@ Given an age in seconds, calculate how old someone would be on:
    - Neptune: orbital period 164.79132 Earth years
 
 So if you were told someone were 1,000,000,000 seconds old, you should
-be able to say that they're 31.69 Earth-years old.
+be able to say that they're 31.69 Earth-years old. Because floating-point
+math is not exact, your answer only needs to be correct to two decimal places.
+This means you are free to leave your answer unrounded.
 
 If you're wondering why Pluto didn't make the cut, go watch [this
 youtube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).


### PR DESCRIPTION
In https://github.com/exercism/problem-specifications/pull/880 we
discussed that tracks may need to use a tolerance in their floating
point comparisons.

Since this is a good idea for all tracks, this means that this is
suitable to put it in the description.

Thus, explain that the answer only needs to be correct to two decimal
places (the precision used in canonical-data). This gives the freedom to
students to round to two places or leave the answer unrounded.

It might be the case that some tracks are asking for rounded values, but
such tracks can update their READMEs and tests at their own pace.

The tracks that currently implement the exercise, and whether their
equality tests have tolerances:

Please excuse me if I miscategorised your track because of my
unfamiliarity with your language (and then correct me).

Exactly equal:

* https://github.com/exercism/csharp/blob/master/exercises/space-age/SpaceAgeTest.cs
* https://github.com/exercism/cfml/blob/master/exercises/space-age/SpaceAgeTest.cfc
* https://github.com/exercism/ecmascript/blob/master/exercises/space-age/space-age.spec.js
* https://github.com/exercism/fsharp/blob/master/exercises/space-age/SpaceAgeTest.fs
* https://github.com/exercism/javascript/blob/master/exercises/space-age/space-age.spec.js
* https://github.com/exercism/kotlin/blob/master/exercises/space-age/src/test/kotlin/SpaceAgeTest.kt
* https://github.com/exercism/lua/blob/master/exercises/space-age/space-age_spec.lua
* https://github.com/exercism/perl5/blob/master/exercises/space-age/space.t
* https://github.com/exercism/perl6/blob/master/exercises/space-age/space-age.t
* https://github.com/exercism/python/blob/master/exercises/space-age/space_age_test.py
* https://github.com/exercism/r/blob/master/exercises/space-age/test_space-age.R
* https://github.com/exercism/scala/blob/master/exercises/space-age/src/test/scala/SpaceAgeTest.scala
* https://github.com/exercism/swift/blob/master/exercises/space-age/Tests/SpaceAgeTests/SpaceAgeTests.swift
* https://github.com/exercism/typescript/blob/master/exercises/space-age/space-age.test.ts

Fixed tolerance 0.5 in either direction (so that the answer rounds to the desired value if rounding to closest integer)

* https://github.com/exercism/elm/blob/master/exercises/space-age/tests/Tests.elm

Fixed tolerance 0.01 in either direction

* https://github.com/exercism/java/blob/master/exercises/space-age/src/test/java/SpaceAgeTest.java
* https://github.com/exercism/objective-c/blob/master/exercises/space-age/SpaceAgeTest.m
* https://github.com/exercism/php/blob/master/exercises/space-age/space-age_test.php
* https://github.com/exercism/ruby/blob/master/exercises/space-age/space_age_test.rb
* https://github.com/exercism/rust/blob/master/exercises/space-age/tests/space-age.rs

Fixed tolerance 0.005 in either direction (so that the answer rounds to the desired value if rounding to two decimal places)

* https://github.com/exercism/cpp/blob/master/exercises/space-age/space_age_test.cpp
* https://github.com/exercism/clojure/blob/master/exercises/space-age/test/space_age_test.clj
* https://github.com/exercism/common-lisp/blob/master/exercises/space-age/space-age-test.lisp
* https://github.com/exercism/elixir/blob/master/exercises/space-age/space_age_test.exs
* https://github.com/exercism/erlang/blob/master/exercises/space-age/test/space_age_tests.erl
* https://github.com/exercism/haskell/blob/master/exercises/space-age/test/Tests.hs
* https://github.com/exercism/lfe/blob/master/exercises/space-age/test/space-age-tests.lfe
* https://github.com/exercism/ocaml/blob/master/exercises/space-age/test.ml
* https://github.com/exercism/prolog/blob/master/exercises/space-age/space_age_tests.plt

Variable tolerances (decided ahead-of-time):

* https://github.com/exercism/c/blob/master/exercises/space-age/test/test_space_age.c