### PR TITLE
markdown: Do not add <p> to list items

### DIFF
--- a/exercises/markdown/canonical-data.json
+++ b/exercises/markdown/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "markdown",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "comments": [
     "Markdown is a shorthand for creating HTML from text strings."
   ],
@@ -51,7 +51,7 @@
       "description": "unordered lists",
       "property": "parse",
       "input": "* Item 1\n* Item 2",
-      "expected": "<ul><li><p>Item 1</p></li><li><p>Item 2</p></li></ul>"
+      "expected": "<ul><li>Item 1</li><li>Item 2</li></ul>"
     },
     {
       "description": "With a little bit of everything",


### PR DESCRIPTION
Compare the case of "unordered lists" vs "With a little bit of
everything":

In the former, each list item is surrounded by `<p>` tags.

In the latter, they are not, instead being surrounded by other tags that
they otherwise had.

This could plausibly be explained by the rule "If there are any tags on
list items, don't add any, otherwise do add `<p>`" but it seems weird
because we don't usually see `<p>` for list items.

On a survey of two arbitrarily chosen Markdown parsers:

* http://parsedown.org/demo
* https://daringfireball.net/projects/markdown/

Neither emits `<p>` for the list items.
It seems they were a mistake and should be removed, unless information
to the contrary is reported at
https://github.com/exercism/problem-specifications/pull/262#discussion_r144485967