### PR TITLE
Simplify two tests so the difference is easily spotted.

### DIFF
--- a/exercises/hamming/canonical-data.json
+++ b/exercises/hamming/canonical-data.json
@@ -1,6 +1,6 @@
 {
 "exercise": "hamming",
-"version": "2.0.0",
+"version": "2.0.1",
   "comments": [
     "Language implementations vary on the issue of unequal length strands.",
     "A language may elect to simplify this task by only presenting equal",
@@ -73,15 +73,15 @@
     {
       "description": "non-unique character in first strand",
       "property": "distance",
-      "strand1": "AGA",
-      "strand2": "AGG",
+      "strand1": "AAG",
+      "strand2": "AAA",
       "expected": 1
     },
     {
       "description": "non-unique character in second strand",
       "property": "distance",
-      "strand1": "AGG",
-      "strand2": "AGA",
+      "strand1": "AAA",
+      "strand2": "AAG",
       "expected": 1
     },
     {


### PR DESCRIPTION
I feel like the cases `"non-unique character in first strand"` and `"non-unique character in second strand"` are not clear in how the respective strand has a non-unique character.

So I suggest simplifying it. Otherwise, I would be fine with switching them as seen below. Where it's clear by the pattern of the other strand that the strand with the non-unique character doesn't follow the expected pattern.

```json
{
      "description": "non-unique character in first strand",
      "property": "distance",
      "strand1": "AGG",
      "strand2": "AGA",
      "expected": 1
    },
    {
      "description": "non-unique character in second strand",
      "property": "distance",
      "strand1": "AGA",
      "strand2": "AGG",
      "expected": 1
    },```