### PR TITLE
leap: Improve test suite to cover corner case.

### DIFF
--- a/exercises/leap/canonical-data.json
+++ b/exercises/leap/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "leap",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "cases": [
     {
       "description": "year not divisible by 4: common year",
@@ -11,7 +11,7 @@
     {
       "description": "year divisible by 4, not divisible by 100: leap year",
       "property": "leapYear",
-      "input": 2016,
+      "input": 2020,
       "expected": true
     },
     {


### PR DESCRIPTION
Currently, the test suite has a loophole where it is possible to pass
all the tests with a function that simply checks if the year is evenly
divisble by 16.

This commit changes one of the test cases so that is no longer possible.