### PR TITLE
pangram: fix duplicative case for a missing 'x'

### DIFF
--- a/exercises/pangram/canonical-data.json
+++ b/exercises/pangram/canonical-data.json
@@ -3,7 +3,7 @@
   "comments": [
     "A pangram is a sentence using every letter of the alphabet at least once."
   ],
-  "version": "1.2.0",
+  "version": "1.3.0",
   "cases": [
     {
       "description": "Check if the given string is an pangram",
@@ -36,9 +36,9 @@
           "expected": false
         },
         {
-          "description": "another missing character 'x'",
+          "description": "another missing character, e.g. 'h'",
           "property": "isPangram",
-          "input": "the quick brown fish jumps over the lazy dog",
+          "input": "five boxing wizards jump quickly at it",
           "expected": false
         },
         {


### PR DESCRIPTION
Splitting #893 into multiple PRs.

Currently two cases check for a missing 'x'. This does not make much sense and the second case was changed to test for a missing 'h' instead, while 'h' was chosen randomly.

This improves the TDD progression and forces the user to check for more than just 'x'.