### PR TITLE
nucleotide-count: add case-agnostic test

### DIFF
--- a/exercises/nucleotide-count/canonical-data.json
+++ b/exercises/nucleotide-count/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "nucleotide-count",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "cases": [
     {
       "description": "count all nucleotides in a strand",
@@ -42,6 +42,17 @@
           "description": "strand with multiple nucleotides",
           "property": "nucleotideCounts",
           "strand": "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC",
+          "expected": {
+            "A": 20,
+            "C": 12,
+            "G": 17,
+            "T": 21
+          }
+        },
+        {
+          "description": "is case-agnostic against a strand of mixed-case nucleotides",
+          "property": "nucleotideCounts",
+          "strand": "aGcTtTtCaTtCtGaCtGcAaCgGgCaAtAtGtCtCtGtGtGgAtTaAaAaAaGaGtGtCtGaTaGcAgC",
           "expected": {
             "A": 20,
             "C": 12,


### PR DESCRIPTION
Splitting #895 into multiple PRs.

This adds a test case that ensures that lower- and uppercase inputs do not matter and don't interfere with each other. You can use both interchangeably.

Reasoning:
1. "Postel's law" (a.k.a. "robustness principle")
https://en.wikipedia.org/wiki/Robustness_principle
1. Also, in everyday life, we got used to ignore cases. I see no reasoning why lower-case inputs should be in any way incorrect for this exercise.
1. The test is located near the end of the spec to cover some generic special cases as part of the finishing touches of the exercise.