### PR TITLE
leap: Fix loophole in unit tests

### DIFF
--- a/exercises/leap/canonical-data.json
+++ b/exercises/leap/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "leap",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "cases": [
     {
       "description": "year not divisible by 4: common year",
@@ -11,7 +11,7 @@
     {
       "description": "year divisible by 4, not divisible by 100: leap year",
       "property": "leapYear",
-      "input": 2020,
+      "input": 1996,
       "expected": true
     },
     {


### PR DESCRIPTION
Currently, it's possible to pass all the unit tests by checking if `(year % 100) == (year % 400)`.

This commit changes one of the test cases so that this is no longer possible. Note that this is a separate issue to #955 -- however, 1996, like 2020, is not divisible by 16, so that loophole will remain closed.