### PR TITLE
food-chain: Make properties less ambiguous

### DIFF
--- a/exercises/food-chain/canonical-data.json
+++ b/exercises/food-chain/canonical-data.json
@@ -17,9 +17,9 @@
       "cases": [
         {
           "description": "fly",
-          "property": "verses",
-          "start verse": 1,
-          "end verse": 1,
+          "property": "recite",
+          "startVerse": 1,
+          "endVerse": 1,
           "expected": [
             "I know an old lady who swallowed a fly.",
             "I don't know why she swallowed the fly. Perhaps she'll die."
@@ -27,9 +27,9 @@
         },
         {
           "description": "spider",
-          "property": "verses",
-          "start verse": 2,
-          "end verse": 2,
+          "property": "recite",
+          "startVerse": 2,
+          "endVerse": 2,
           "expected": [
             "I know an old lady who swallowed a spider.",
             "It wriggled and jiggled and tickled inside her.",
@@ -39,9 +39,9 @@
         },
         {
           "description": "bird",
-          "property": "verses",
-          "start verse": 3,
-          "end verse": 3,
+          "property": "recite",
+          "startVerse": 3,
+          "endVerse": 3,
           "expected": [
             "I know an old lady who swallowed a bird.",
             "How absurd to swallow a bird!",
@@ -52,9 +52,9 @@
         },
         {
           "description": "cat",
-          "property": "verses",
-          "start verse": 4,
-          "end verse": 4,
+          "property": "recite",
+          "startVerse": 4,
+          "endVerse": 4,
           "expected": [
             "I know an old lady who swallowed a cat.",
             "Imagine that, to swallow a cat!",
@@ -66,9 +66,9 @@
         },
         {
           "description": "dog",
-          "property": "verses",
-          "start verse": 5,
-          "end verse": 5,
+          "property": "recite",
+          "startVerse": 5,
+          "endVerse": 5,
           "expected": [
             "I know an old lady who swallowed a dog.",
             "What a hog, to swallow a dog!",
@@ -81,9 +81,9 @@
         },
         {
           "description": "goat",
-          "property": "verses",
-          "start verse": 6,
-          "end verse": 6,
+          "property": "recite",
+          "startVerse": 6,
+          "endVerse": 6,
           "expected": [
             "I know an old lady who swallowed a goat.",
             "Just opened her throat and swallowed a goat!",
@@ -97,9 +97,9 @@
         },
         {
           "description": "cow",
-          "property": "verses",
-          "start verse": 7,
-          "end verse": 7,
+          "property": "recite",
+          "startVerse": 7,
+          "endVerse": 7,
           "expected": [
             "I know an old lady who swallowed a cow.",
             "I don't know how she swallowed a cow!",
@@ -114,9 +114,9 @@
         },
         {
           "description": "horse",
-          "property": "verses",
-          "start verse": 8,
-          "end verse": 8,
+          "property": "recite",
+          "startVerse": 8,
+          "endVerse": 8,
           "expected": [
             "I know an old lady who swallowed a horse.",
             "She's dead, of course!"
@@ -124,9 +124,9 @@
         },
         {
           "description": "multiple verses",
-          "property": "verses",
-          "start verse": 1,
-          "end verse": 3,
+          "property": "recite",
+          "startVerse": 1,
+          "endVerse": 3,
           "expected": [
             "I know an old lady who swallowed a fly.",
             "I don't know why she swallowed the fly. Perhaps she'll die.",
@@ -145,9 +145,9 @@
         },
         {
           "description": "full song",
-          "property": "verses",
-          "start verse": 1,
-          "end verse": 8,
+          "property": "recite",
+          "startVerse": 1,
+          "endVerse": 8,
           "expected": [
             "I know an old lady who swallowed a fly.",
             "I don't know why she swallowed the fly. Perhaps she'll die.",

--- a/exercises/food-chain/canonical-data.json
+++ b/exercises/food-chain/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "food-chain",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "comments": [
     "JSON doesn't allow for multi-line strings, so all verses are presented ",
     "here as arrays of strings. It's up to the test generator to join the ",
@@ -18,7 +18,7 @@
         {
           "description": "fly",
           "property": "verse",
-          "start verse": 1,
+          "verse": 1,
           "expected": [
             "I know an old lady who swallowed a fly.",
             "I don't know why she swallowed the fly. Perhaps she'll die."
@@ -27,7 +27,7 @@
         {
           "description": "spider",
           "property": "verse",
-          "start verse": 2,
+          "verse": 2,
           "expected": [
             "I know an old lady who swallowed a spider.",
             "It wriggled and jiggled and tickled inside her.",
@@ -38,7 +38,7 @@
         {
           "description": "bird",
           "property": "verse",
-          "start verse": 3,
+          "verse": 3,
           "expected": [
             "I know an old lady who swallowed a bird.",
             "How absurd to swallow a bird!",
@@ -50,7 +50,7 @@
         {
           "description": "cat",
           "property": "verse",
-          "start verse": 4,
+          "verse": 4,
           "expected": [
             "I know an old lady who swallowed a cat.",
             "Imagine that, to swallow a cat!",
@@ -63,7 +63,7 @@
         {
           "description": "dog",
           "property": "verse",
-          "start verse": 5,
+          "verse": 5,
           "expected": [
             "I know an old lady who swallowed a dog.",
             "What a hog, to swallow a dog!",
@@ -77,7 +77,7 @@
         {
           "description": "goat",
           "property": "verse",
-          "start verse": 6,
+          "verse": 6,
           "expected": [
             "I know an old lady who swallowed a goat.",
             "Just opened her throat and swallowed a goat!",
@@ -92,7 +92,7 @@
         {
           "description": "cow",
           "property": "verse",
-          "start verse": 7,
+          "verse": 7,
           "expected": [
             "I know an old lady who swallowed a cow.",
             "I don't know how she swallowed a cow!",
@@ -108,7 +108,7 @@
         {
           "description": "horse",
           "property": "verse",
-          "start verse": 8,
+          "verse": 8,
           "expected": [
             "I know an old lady who swallowed a horse.",
             "She's dead, of course!"
@@ -116,7 +116,7 @@
         },
         {
           "description": "multiple verses",
-          "property": "verse",
+          "property": "verses",
           "start verse": 1,
           "end verse": 3,
           "expected": [
@@ -137,7 +137,7 @@
         },
         {
           "description": "full song",
-          "property": "verse",
+          "property": "verses",
           "start verse": 1,
           "end verse": 8,
           "expected": [

--- a/exercises/food-chain/canonical-data.json
+++ b/exercises/food-chain/canonical-data.json
@@ -17,8 +17,9 @@
       "cases": [
         {
           "description": "fly",
-          "property": "verse",
-          "verse": 1,
+          "property": "verses",
+          "start verse": 1,
+          "end verse": 1,
           "expected": [
             "I know an old lady who swallowed a fly.",
             "I don't know why she swallowed the fly. Perhaps she'll die."
@@ -26,8 +27,9 @@
         },
         {
           "description": "spider",
-          "property": "verse",
-          "verse": 2,
+          "property": "verses",
+          "start verse": 2,
+          "end verse": 2,
           "expected": [
             "I know an old lady who swallowed a spider.",
             "It wriggled and jiggled and tickled inside her.",
@@ -37,8 +39,9 @@
         },
         {
           "description": "bird",
-          "property": "verse",
-          "verse": 3,
+          "property": "verses",
+          "start verse": 3,
+          "end verse": 3,
           "expected": [
             "I know an old lady who swallowed a bird.",
             "How absurd to swallow a bird!",
@@ -49,8 +52,9 @@
         },
         {
           "description": "cat",
-          "property": "verse",
-          "verse": 4,
+          "property": "verses",
+          "start verse": 4,
+          "end verse": 4,
           "expected": [
             "I know an old lady who swallowed a cat.",
             "Imagine that, to swallow a cat!",
@@ -62,8 +66,9 @@
         },
         {
           "description": "dog",
-          "property": "verse",
-          "verse": 5,
+          "property": "verses",
+          "start verse": 5,
+          "end verse": 5,
           "expected": [
             "I know an old lady who swallowed a dog.",
             "What a hog, to swallow a dog!",
@@ -76,8 +81,9 @@
         },
         {
           "description": "goat",
-          "property": "verse",
-          "verse": 6,
+          "property": "verses",
+          "start verse": 6,
+          "end verse": 6,
           "expected": [
             "I know an old lady who swallowed a goat.",
             "Just opened her throat and swallowed a goat!",
@@ -91,8 +97,9 @@
         },
         {
           "description": "cow",
-          "property": "verse",
-          "verse": 7,
+          "property": "verses",
+          "start verse": 7,
+          "end verse": 7,
           "expected": [
             "I know an old lady who swallowed a cow.",
             "I don't know how she swallowed a cow!",
@@ -107,8 +114,9 @@
         },
         {
           "description": "horse",
-          "property": "verse",
-          "verse": 8,
+          "property": "verses",
+          "start verse": 8,
+          "end verse": 8,
           "expected": [
             "I know an old lady who swallowed a horse.",
             "She's dead, of course!"


### PR DESCRIPTION
Currently, the canonical data uses the same property to get a single verse and to get multiple verses. I think it would make sense to instead use a different property for multiple verses, aptly named `verses` (plural). 

Furthermore, the single verse cases used `"start verse"`  as the input property, but to me that suggests also having an `"end verse"` property, which it doesn't. I've therefore renamed the property for the single verse cases to just `"verse"`.