### PR TITLE
forth: Remove test for empty input

### DIFF
--- a/exercises/forth/canonical-data.json
+++ b/exercises/forth/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "forth",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "comments": [
     "The cases are split into multiple sections, all with the same structure.",
     "In all cases, the `expected` key is the resulting stack",
@@ -14,6 +14,12 @@
           "description": "empty input results in empty stack",
           "property": "evaluate",
           "input": [],
+          "expected": []
+        },
+        {
+          "description": "empty line results in empty stack",
+          "property": "evaluate",
+          "input": [""],
           "expected": []
         },
         {

--- a/exercises/forth/canonical-data.json
+++ b/exercises/forth/canonical-data.json
@@ -11,18 +11,6 @@
       "description": "parsing and numbers",
       "cases": [
         {
-          "description": "empty input results in empty stack",
-          "property": "evaluate",
-          "input": [],
-          "expected": []
-        },
-        {
-          "description": "empty line results in empty stack",
-          "property": "evaluate",
-          "input": [""],
-          "expected": []
-        },
-        {
           "description": "numbers just get pushed onto the stack",
           "property": "evaluate",
           "input": ["1 2 3 4 5"],


### PR DESCRIPTION
~~This PR adds a new test designed to check that an empty line (represented by an empty string) is handled/ignored and leaves the stack empty without failing.~~

This PR removed the test for empty input `[]` in line with the discussion below. This test was considered to be unexpected for the current problem description.