### PR TITLE
forth: Add tests for case-insensitivity

### DIFF
--- a/exercises/forth/canonical-data.json
+++ b/exercises/forth/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "forth",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "comments": [
     "The cases are split into multiple sections, all with the same structure.",
     "In all cases, the `expected` key is the resulting stack",
@@ -143,15 +143,15 @@
       "description": "dup",
       "cases": [
         {
-          "description": "copies the top value on the stack",
+          "description": "copies a value on the stack",
           "property": "evaluate",
-          "input": ["1 DUP"],
+          "input": ["1 dup"],
           "expected": [1, 1]
         },
         {
-          "description": "is case-insensitive",
+          "description": "copies the top value on the stack",
           "property": "evaluate",
-          "input": ["1 2 Dup"],
+          "input": ["1 2 dup"],
           "expected": [1, 2, 2]
         },
         {
@@ -303,6 +303,53 @@
           "property": "evaluate",
           "input": ["foo"],
           "expected": null
+        }
+      ]
+    },
+    {
+      "description": "case-insensitivity",
+      "cases": [
+        {
+          "description": "DUP is case-insensitive",
+          "property": "evaluate",
+          "input": ["1 DUP Dup dup"],
+          "expected": [1, 1, 1, 1]
+        },
+        {
+          "description": "DROP is case-insensitive",
+          "property": "evaluate",
+          "input": ["1 2 3 4 DROP Drop drop"],
+          "expected": [1]
+        },
+        {
+          "description": "SWAP is case-insensitive",
+          "property": "evaluate",
+          "input": ["1 2 SWAP 3 Swap 4 swap"],
+          "expected": [2, 3, 4, 1]
+        },
+        {
+          "description": "OVER is case-insensitive",
+          "property": "evaluate",
+          "input": ["1 2 OVER Over over"],
+          "expected": [1, 2, 1, 2, 1]
+        },
+        {
+          "description": "user-defined words are case-insensitive",
+          "property": "evaluate",
+          "input": [
+            ": foo dup ;",
+            "1 FOO Foo foo"
+          ],
+          "expected": [1, 1, 1, 1]
+        },
+        {
+          "description": "definitions are case-insensitive",
+          "property": "evaluate",
+          "input": [
+            ": SWAP DUP Dup dup ;",
+            "1 swap"
+          ],
+          "expected": [1, 1, 1, 1]
         }
       ]
     }


### PR DESCRIPTION
This PR add tests for case insensitivity to `forth` to better match the problem description. Previously there was some testing for case-insensitivity, but it was limited to `dup` - I have removed this in favour of a block of tests for each word and type of word at the end of the canonical data.

I'm not sure whether "copies a value on the stack" on line 152 is really necessary - I'm happy to remove it if so desired.

The updated version number assumes the merge of #976 (removal of the empty test case `[]`) before this one.