### PR TITLE
zipper: fix word order in description

### DIFF
--- a/exercises/zipper/description.md
+++ b/exercises/zipper/description.md
@@ -1,7 +1,7 @@
 Creating a zipper for a binary tree.
 
 [Zippers](https://en.wikipedia.org/wiki/Zipper_%28data_structure%29) are
-a way purely functional of navigating within a data structure and
+a purely functional way of navigating within a data structure and
 manipulating it.  They essentially contain a data structure and a
 pointer into that data structure (called the focus).
 


### PR DESCRIPTION
The adjective phrase "purely functional" should go before the noun "way" in this sentence.