### PR TITLE
two-bucket: Do not specify any types in description

### DIFF
--- a/exercises/two-bucket/description.md
+++ b/exercises/two-bucket/description.md
@@ -5,15 +5,15 @@ Since this mathematical problem is fairly subject to interpretation / individual
 To help, the tests provide you with which bucket to fill first. That means, when starting with the larger bucket full, you are NOT allowed at any point to have the smaller bucket full and the larger bucket empty (aka, the opposite starting point); that would defeat the purpose of comparing both approaches!
 
 Your program will take as input:
-- the size of bucket one, passed as a numeric value
-- the size of bucket two, passed as a numeric value
-- the desired number of liters to reach, passed as a numeric value
-- which bucket to fill first, passed as a String (either 'one' or 'two')
+- the size of bucket one
+- the size of bucket two
+- the desired number of liters to reach
+- which bucket to fill first, either bucket one or bucket two
 
 Your program should determine:
-- the total number of "moves" it should take to reach the desired number of liters, including the first fill - expects a numeric value
-- which bucket should end up with the desired number of liters (let's say this is bucket A) - expects a String (either 'one' or 'two')
-- how many liters are left in the other bucket (bucket B) - expects a numeric value
+- the total number of "moves" it should take to reach the desired number of liters, including the first fill
+- which bucket should end up with the desired number of liters (let's say this is bucket A) - either bucket one or bucket two
+- how many liters are left in the other bucket (bucket B)
 
 Note: any time a change is made to either or both buckets counts as one (1) move.
 


### PR DESCRIPTION
The description currently specifies that buckets are represented, in
both the input and the output, as strings.

This seems overly constraining. Consider those tracks that wish to
represent these buckets as variants of a tagged union or of an enum for
the purpose of better type safety. These tracks have these options in
order to do so:

* Accept the problem-specifications README as is, but act in
  contravention of it. But it is confusing if the README contradicts the
  tests.
* Create a custom description.md. But this is a little unfortunate
  because only two lines need to change, and it adds extra maintenance
  burden to have to maintain the custom description.md. Consider that if
  this description.md changes, the changes will probably need to be
  copied to each custom description.md
* Add to .meta/hints.md saying something to the effect of "ha ha ignore
  the above text about using Strings, we're using tagged unions / enums"
  so that this will be appended to the description. But it seems too
  strange to have a README contradict itself.
* Other solution I did not think of.

Thus, it seems it is best to remove the specification of the buckets as
a string so as to allow the flexibility.

For the purpose of consistency, all other types have been removed as
well, otherwise it would invite (very reasonable) questions about why
all inputs/outputs except the buckets have types given.

It is surmised that this leads to no real loss, because it should be
obvious that sizes, number of moves, and number of liters are all
numeric values.

Closes #989 by mutual exclusion.