### PR TITLE
custom-set: add test for inequality of subset

### DIFF
--- a/exercises/custom-set/canonical-data.json
+++ b/exercises/custom-set/canonical-data.json
@@ -179,6 +179,13 @@
           "set1": [1, 2, 3],
           "set2": [1, 2, 4],
           "expected": false
+        },
+        {
+          "description": "set is not equal to larger set with same elements",
+          "property": "equal",
+          "set1": [1, 2, 3],
+          "set2": [1, 2, 3, 4],
+          "expected": false
         }
       ]
     },

--- a/exercises/custom-set/canonical-data.json
+++ b/exercises/custom-set/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "custom-set",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "comments": [
     "These tests cover the core components of a set data structure: checking",
     "presence, adding, comparing and basic set operations. Other features",


### PR DESCRIPTION
Consider the following pseudocode
```
equals(self, other)
    if self.empty
        return other.empty
    else
        for x in self
            if !other.contains(x)
                return false
        return true
```

This solution would return a false positive for [1, 2, 3] == [1, 2, 3, 4], but would pass all other tests for `equals`.