### PR TITLE
isbn-verifier: Test only the fact that each case claims to test

### DIFF
--- a/exercises/isbn-verifier/canonical-data.json
+++ b/exercises/isbn-verifier/canonical-data.json
@@ -1,6 +1,6 @@
 {
     "exercise": "isbn-verifier",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "comments": [
         "An expected value of true indicates a valid ISBN-10, ",
         "whereas false means the ISBN-10 is invalid."
@@ -39,7 +39,7 @@
         {
             "description": "X is only valid as a check digit",
             "property": "isbn",
-            "input": "3-598-2X507-0",
+            "input": "3-598-2X507-9",
             "expected": false
         },
         {
@@ -75,7 +75,7 @@
         {
             "description": "too long isbn",
             "property": "isbn",
-            "input": "3-598-21507-XA",
+            "input": "3-598-21507-XX",
             "expected": false
         },
         {


### PR DESCRIPTION
isbn-verifier 1.1.0

"X is only valid as a check-digit"
https://github.com/exercism/problem-specifications/pull/924#discussion_r148174550

An implementation that unconditionally treats X as 10 will still reject
the ISBN 3-598-2X507-0

3 * 10 + 5 * 9 + 9 * 8 + 8 * 7 + 2 * 6 + 10 * 5 + 5 * 4 + 0 * 3 + 7 * 2 + 0 * 1 = 299,
and 299 is not divisible by 11.

If the intention of this test is to ensure that an implementation only
treats X as 10 in the check digit position, then a case such as
3-598-2X507-9 is needed.

The following may be run in a terminal to ensure that this ISBN does sum
to 10 under such a mistaken implementation:

    ruby -e 'p "3-598-2X507-9".delete(?-).chars.reverse.map.with_index { |c, i| (c == ?X ? 10 : Integer(c)) * (i + 1) }.sum % 11'

"too long isbn"
https://github.com/exercism/problem-specifications/pull/924#discussion_r148175037

An implementation that would potentially attempt to checksum ISBNs that
are too long would still reject this input because it would see that the
"A" is invalid.

If the intention of this case is to ensure that an implementation does
in fact reject ISBNs that are too long, at the very least a valid
character should be used instead of A.

If one wanted to be thorough, one might have to include three different
cases here, respectively checking for implementations that try to
checksum:

* all 11 resulting digits (with a coefficient of 11 on the leftmost one, naturally)
* the 10 rightmost digits
* the 10 leftmost digits

by providing a too-long ISBN that has a valid check digit under each respective scheme.

This is not done in this PR because it has not yet become apparent
through submissions that such three cases are necessary (submissions
that unconditionally attempt to checksum using any of the three schemes
listed).