### PR TITLE
proverb: Add canonical data.

### DIFF
--- a/exercises/proverb/canonical-data.json
+++ b/exercises/proverb/canonical-data.json
@@ -1,0 +1,69 @@
+{
+    "cases": [
+        {
+            "cases": [
+                {
+                    "description": "zero pieces",
+                    "expected": "",
+                    "input": [],
+                    "property": "construct"
+                },
+                {
+                    "description": "one piece",
+                    "expected": "And all for the want of a nail.",
+                    "input": [
+                        "nail"
+                    ],
+                    "property": "construct"
+                },
+                {
+                    "description": "two pieces",
+                    "expected": "For want of a nail the shoe was lost.\nAnd all for the want of a nail.",
+                    "input": [
+                        "nail",
+                        "shoe"
+                    ],
+                    "property": "construct"
+                },
+                {
+                    "description": "three pieces",
+                    "expected": "For want of a nail the shoe was lost.\nFor want of a shoe the horse was lost.\nAnd all for the want of a nail.",
+                    "input": [
+                        "nail",
+                        "shoe",
+                        "horse"
+                    ],
+                    "property": "construct"
+                },
+                {
+                    "description": "full proverb",
+                    "expected": "For want of a nail the shoe was lost.\nFor want of a shoe the horse was lost.\nFor want of a horse the rider was lost.\nFor want of a rider the message was lost.\nFor want of a message the battle was lost.\nFor want of a battle the kingdom was lost.\nAnd all for the want of a nail.",
+                    "input": [
+                        "nail",
+                        "shoe",
+                        "horse",
+                        "rider",
+                        "message",
+                        "battle",
+                        "kingdom"
+                    ],
+                    "property": "construct"
+                },
+                {
+                    "description": "three pieces modernized",
+                    "expected": "For want of a pin the gun was lost.\nFor want of a gun the soldier was lost.\nFor want of a soldier the battle was lost.\nAnd all for the want of a pin.",
+                    "input": [
+                        "pin",
+                        "gun",
+                        "soldier",
+                        "battle"
+                    ],
+                    "property": "construct"
+                }
+            ],
+            "description": "Construct a proverb of the form 'for want of an X, the Y was lost'"
+        }
+    ],
+    "exercise": "proverb",
+    "version": "1.0.0"
+}

--- a/exercises/proverb/canonical-data.json
+++ b/exercises/proverb/canonical-data.json
@@ -2,97 +2,93 @@
     "exercise": "proverb",
     "version": "1.0.0",
     "comments": [
-       "JSON doesn't allow for multi-line strings, so all expected outputs are presented ",
-       "here as arrays of strings. It's up to the test generator to join the ",
-       "lines together with line breaks."
+        "JSON doesn't allow for multi-line strings, so all expected outputs are presented ",
+        "here as arrays of strings. It's up to the test generator to join the ",
+        "lines together with line breaks. ",
+        "All cases expect the student to construct a proverb of the form ",
+        "'For want of an X, the Y was lost.', terminating with the stock phrase ",
+        "'And all for the want of a Z.'"
     ],
     "cases": [
         {
-            "cases": [
-                {
-                    "description": "zero pieces",
-                    "expected": [
-                        ""
-                    ],
-                    "input": [],
-                    "property": "recite"
-                },
-                {
-                    "description": "one piece",
-                    "expected": [
-                        "And all for the want of a nail."
-                    ],
-                    "input": [
-                        "nail"
-                    ],
-                    "property": "recite"
-                },
-                {
-                    "description": "two pieces",
-                    "expected": [
-                        "For want of a nail the shoe was lost.",
-                        "And all for the want of a nail."
-                    ],
-                    "input": [
-                        "nail",
-                        "shoe"
-                    ],
-                    "property": "recite"
-                },
-                {
-                    "description": "three pieces",
-                    "expected": [
-                        "For want of a nail the shoe was lost.",
-                        "For want of a shoe the horse was lost.",
-                        "And all for the want of a nail."
-                    ],
-                    "input": [
-                        "nail",
-                        "shoe",
-                        "horse"
-                    ],
-                    "property": "recite"
-                },
-                {
-                    "description": "full proverb",
-                    "expected": [
-                        "For want of a nail the shoe was lost.",
-                        "For want of a shoe the horse was lost.",
-                        "For want of a horse the rider was lost.",
-                        "For want of a rider the message was lost.",
-                        "For want of a message the battle was lost.",
-                        "For want of a battle the kingdom was lost.",
-                        "And all for the want of a nail."
-                    ],
-                    "input": [
-                        "nail",
-                        "shoe",
-                        "horse",
-                        "rider",
-                        "message",
-                        "battle",
-                        "kingdom"
-                    ],
-                    "property": "recite"
-                },
-                {
-                    "description": "four pieces modernized",
-                    "expected": [
-                        "For want of a pin the gun was lost.",
-                        "For want of a gun the soldier was lost.",
-                        "For want of a soldier the battle was lost.",
-                        "And all for the want of a pin."
-                    ],
-                    "input": [
-                        "pin",
-                        "gun",
-                        "soldier",
-                        "battle"
-                    ],
-                    "property": "recite"
-                }
+            "description": "zero pieces",
+            "property": "recite",
+            "input": [],
+            "expected": []
+        },
+        {
+            "description": "one piece",
+            "property": "recite",
+            "input": [
+                "nail"
             ],
-            "description": "Construct a proverb of the form 'for want of an X, the Y was lost'"
+            "expected": [
+                "And all for the want of a nail."
+            ]
+        },
+        {
+            "description": "two pieces",
+            "property": "recite",
+            "input": [
+                "nail",
+                "shoe"
+            ],
+            "expected": [
+                "For want of a nail the shoe was lost.",
+                "And all for the want of a nail."
+            ]
+        },
+        {
+            "description": "three pieces",
+            "property": "recite",
+            "input": [
+                "nail",
+                "shoe",
+                "horse"
+            ],
+            "expected": [
+                "For want of a nail the shoe was lost.",
+                "For want of a shoe the horse was lost.",
+                "And all for the want of a nail."
+            ]
+        },
+        {
+            "description": "full proverb",
+            "property": "recite",
+            "input": [
+                "nail",
+                "shoe",
+                "horse",
+                "rider",
+                "message",
+                "battle",
+                "kingdom"
+            ],
+            "expected": [
+                "For want of a nail the shoe was lost.",
+                "For want of a shoe the horse was lost.",
+                "For want of a horse the rider was lost.",
+                "For want of a rider the message was lost.",
+                "For want of a message the battle was lost.",
+                "For want of a battle the kingdom was lost.",
+                "And all for the want of a nail."
+            ]
+        },
+        {
+            "description": "four pieces modernized",
+            "property": "recite",
+            "input": [
+                "pin",
+                "gun",
+                "soldier",
+                "battle"
+            ],
+            "expected": [
+                "For want of a pin the gun was lost.",
+                "For want of a gun the soldier was lost.",
+                "For want of a soldier the battle was lost.",
+                "And all for the want of a pin."
+            ]
         }
     ]
 }

--- a/exercises/proverb/canonical-data.json
+++ b/exercises/proverb/canonical-data.json
@@ -1,43 +1,70 @@
 {
+    "exercise": "proverb",
+    "version": "1.0.0",
+    "comments": [
+       "JSON doesn't allow for multi-line strings, so all expected outputs are presented ",
+       "here as arrays of strings. It's up to the test generator to join the ",
+       "lines together with line breaks."
+    ],
+    "description": "https://github.com/exercism/problem-specifications/blob/master/exercises/proverb/description.md",
     "cases": [
         {
             "cases": [
                 {
                     "description": "zero pieces",
-                    "expected": "",
+                    "expected": [
+                        ""
+                    ],
                     "input": [],
-                    "property": "construct"
+                    "property": "recite"
                 },
                 {
                     "description": "one piece",
-                    "expected": "And all for the want of a nail.",
+                    "expected": [
+                        "And all for the want of a nail."
+                    ],
                     "input": [
                         "nail"
                     ],
-                    "property": "construct"
+                    "property": "recite"
                 },
                 {
                     "description": "two pieces",
-                    "expected": "For want of a nail the shoe was lost.\nAnd all for the want of a nail.",
+                    "expected": [
+                        "For want of a nail the shoe was lost.",
+                        "And all for the want of a nail."
+                    ],
                     "input": [
                         "nail",
                         "shoe"
                     ],
-                    "property": "construct"
+                    "property": "recite"
                 },
                 {
                     "description": "three pieces",
-                    "expected": "For want of a nail the shoe was lost.\nFor want of a shoe the horse was lost.\nAnd all for the want of a nail.",
+                    "expected": [
+                        "For want of a nail the shoe was lost.",
+                        "For want of a shoe the horse was lost.",
+                        "And all for the want of a nail."
+                    ],
                     "input": [
                         "nail",
                         "shoe",
                         "horse"
                     ],
-                    "property": "construct"
+                    "property": "recite"
                 },
                 {
                     "description": "full proverb",
-                    "expected": "For want of a nail the shoe was lost.\nFor want of a shoe the horse was lost.\nFor want of a horse the rider was lost.\nFor want of a rider the message was lost.\nFor want of a message the battle was lost.\nFor want of a battle the kingdom was lost.\nAnd all for the want of a nail.",
+                    "expected": [
+                        "For want of a nail the shoe was lost.",
+                        "For want of a shoe the horse was lost.",
+                        "For want of a horse the rider was lost.",
+                        "For want of a rider the message was lost.",
+                        "For want of a message the battle was lost.",
+                        "For want of a battle the kingdom was lost.",
+                        "And all for the want of a nail."
+                    ],
                     "input": [
                         "nail",
                         "shoe",
@@ -47,23 +74,26 @@
                         "battle",
                         "kingdom"
                     ],
-                    "property": "construct"
+                    "property": "recite"
                 },
                 {
-                    "description": "three pieces modernized",
-                    "expected": "For want of a pin the gun was lost.\nFor want of a gun the soldier was lost.\nFor want of a soldier the battle was lost.\nAnd all for the want of a pin.",
+                    "description": "four pieces modernized",
+                    "expected": [
+                        "For want of a pin the gun was lost.",
+                        "For want of a gun the soldier was lost.",
+                        "For want of a soldier the battle was lost.",
+                        "And all for the want of a pin."
+                    ],
                     "input": [
                         "pin",
                         "gun",
                         "soldier",
                         "battle"
                     ],
-                    "property": "construct"
+                    "property": "recite"
                 }
             ],
             "description": "Construct a proverb of the form 'for want of an X, the Y was lost'"
         }
-    ],
-    "exercise": "proverb",
-    "version": "1.0.0"
+    ]
 }

--- a/exercises/proverb/canonical-data.json
+++ b/exercises/proverb/canonical-data.json
@@ -4,10 +4,7 @@
     "comments": [
         "JSON doesn't allow for multi-line strings, so all expected outputs are presented ",
         "here as arrays of strings. It's up to the test generator to join the ",
-        "lines together with line breaks. ",
-        "All cases expect the student to construct a proverb of the form ",
-        "'For want of an X, the Y was lost.', terminating with the stock phrase ",
-        "'And all for the want of a Z.'"
+        "lines together with line breaks. "
     ],
     "cases": [
         {

--- a/exercises/proverb/canonical-data.json
+++ b/exercises/proverb/canonical-data.json
@@ -6,7 +6,6 @@
        "here as arrays of strings. It's up to the test generator to join the ",
        "lines together with line breaks."
     ],
-    "description": "https://github.com/exercism/problem-specifications/blob/master/exercises/proverb/description.md",
     "cases": [
         {
             "cases": [

--- a/exercises/proverb/description.md
+++ b/exercises/proverb/description.md
@@ -12,4 +12,4 @@ For want of a battle the kingdom was lost.
 And all for the want of a nail.
 ```
 
-Note that the list of inputs may vary; your solution should be able to handle lists of arbitrary length and content.
+Note that the list of inputs may vary; your solution should be able to handle lists of arbitrary length and content. No line of the output text should be a static, unchanging string; all should vary according to the input given.

--- a/exercises/proverb/description.md
+++ b/exercises/proverb/description.md
@@ -1,6 +1,6 @@
 For want of a horseshoe nail, a kingdom was lost, or so the saying goes.
 
-Output the full text of this proverbial rhyme:
+Given a list of inputs, generate the relevant proverb. For example, given the list `["nail", "shoe", "horse", "rider", "message", "battle", "kingdom"]`, you will output the full text of this proverbial rhyme:
 
 ```text
 For want of a nail the shoe was lost.
@@ -9,5 +9,7 @@ For want of a horse the rider was lost.
 For want of a rider the message was lost.
 For want of a message the battle was lost.
 For want of a battle the kingdom was lost.
-And all for the want of a horseshoe nail.
+And all for the want of a nail.
 ```
+
+Note that the list of inputs may vary; your solution should be able to handle lists of arbitrary length and content.


### PR DESCRIPTION
This is based on the Rust tests as implemented in exercism/rust#380.
The lack of canonical data had resulted in odd custom tests being
designed, which was reported in exercism/rust#379.

Closes #578.