### PR TITLE
description.md: rm trailing spaces

### DIFF
--- a/exercises/kindergarten-garden/description.md
+++ b/exercises/kindergarten-garden/description.md
@@ -7,8 +7,8 @@ actual dirt, and grow actual plants.
 
 They've chosen to grow grass, clover, radishes, and violets.
 
-To this end, the children have put little cups along the window sills, and 
-planted one type of plant in each cup, choosing randomly from the available 
+To this end, the children have put little cups along the window sills, and
+planted one type of plant in each cup, choosing randomly from the available
 types of seeds.
 
 ```text
@@ -23,7 +23,7 @@ There are 12 children in the class:
 - Eve, Fred, Ginny, Harriet,
 - Ileana, Joseph, Kincaid, and Larry.
 
-Each child gets 4 cups, two on each row. Their teacher assigns cups to 
+Each child gets 4 cups, two on each row. Their teacher assigns cups to
 the children alphabetically by their names.
 
 The following diagram represents Alice's plants:

--- a/exercises/nucleotide-count/description.md
+++ b/exercises/nucleotide-count/description.md
@@ -1,7 +1,7 @@
 Given a single stranded DNA string, compute how many times each nucleotide occurs in the string.
 
-The genetic language of every living thing on the planet is DNA. 
-DNA is a large molecule that is built from an extremely long sequence of individual elements called nucleotides. 
+The genetic language of every living thing on the planet is DNA.
+DNA is a large molecule that is built from an extremely long sequence of individual elements called nucleotides.
 4 types exist in DNA and these differ only slightly and can be represented as the following symbols: 'A' for adenine, 'C' for cytosine, 'G' for guanine, and 'T' thymine.
 
 Here is an analogy:

--- a/exercises/palindrome-products/description.md
+++ b/exercises/palindrome-products/description.md
@@ -7,7 +7,7 @@ Given a range of numbers, find the largest and smallest palindromes which
 are products of numbers within that range.
 
 Your solution should return the largest and smallest palindromes, along with the
-factors of each within the range. If the largest or smallest palindrome has more 
+factors of each within the range. If the largest or smallest palindrome has more
 than one pair of factors within the range, then return all the pairs.
 
 ## Example 1

--- a/exercises/rectangles/description.md
+++ b/exercises/rectangles/description.md
@@ -35,27 +35,27 @@ The above diagram contains 6 rectangles:
 ```
 
 ```text
-       
-       
+
+
    +--+
    |  |
    +--+
 ```
 
 ```text
-       
-       
+
+
 +--+
 |  |
 +--+
 ```
 
 ```text
-       
-  ++   
-  ++   
-       
-       
+
+  ++
+  ++
+
+
 ```
 
 You may assume that the input is always a proper rectangle (i.e. the length of


### PR DESCRIPTION
One might assume that we can consider a CI check that there are no
trailing spaces, but we have to be careful because some embedded strings
that serve as example outputs are expected to have trailing spaces. The
currently only example is ocr-numbers. One might consider a CI check,
but simply exclude that file.