### PR TITLE
protein-translation: Add canonical data.

### DIFF
--- a/exercises/protein-translation/canonical-data.json
+++ b/exercises/protein-translation/canonical-data.json
@@ -11,127 +11,127 @@
       "cases": [
         {
           "description": "Methionine RNA sequence is identified",
-          "property": "translate",
+          "property": "translate_codon",
           "strand": "AUG",
           "expected": "Methionine"
         },
         {
           "description": "Phenylalanine RNA sequence 1 is identified",
-          "property": "translate",
+          "property": "translate_codon",
           "strand": "UUU",
           "expected": "Phenylalanine"
         },
         {
           "description": "Phenylalanine RNA sequence 2 is identified",
-          "property": "translate",
+          "property": "translate_codon",
           "strand": "UUC",
           "expected": "Phenylalanine"
         },
         {
           "description": "Leucine RNA sequence 1 is identified",
-          "property": "translate",
+          "property": "translate_codon",
           "strand": "UUA",
           "expected": "Leucine"
         },
         {
           "description": "Leucine RNA sequence 2 is identified",
-          "property": "translate",
+          "property": "translate_codon",
           "strand": "UUG",
           "expected": "Leucine"
         },
         {
           "description": "Serine RNA sequence 1 is identified",
-          "property": "translate",
+          "property": "translate_codon",
           "strand": "UCU",
           "expected": "Serine"
         },
         {
           "description": "Serine RNA sequence 2 is identified",
-          "property": "translate",
+          "property": "translate_codon",
           "strand": "UCC",
           "expected": "Serine"
         },
         {
           "description": "Serine RNA sequence 3 is identified",
-          "property": "translate",
+          "property": "translate_codon",
           "strand": "UCA",
           "expected": "Serine"
         },
         {
           "description": "Serine RNA sequence 4 is identified",
-          "property": "translate",
+          "property": "translate_codon",
           "strand": "UCG",
           "expected": "Serine"
         },
         {
           "description": "Tyrosine RNA sequence 1 is identified",
-          "property": "translate",
+          "property": "translate_codon",
           "strand": "UAU",
           "expected": "Tyrosine"
         },
         {
           "description": "Tyrosine RNA sequence 2 is identified",
-          "property": "translate",
+          "property": "translate_codon",
           "strand": "UAC",
           "expected": "Tyrosine"
         },
         {
           "description": "Cysteine RNA sequence 1 is identified",
-          "property": "translate",
+          "property": "translate_codon",
           "strand": "UGU",
           "expected": "Cysteine"
         },
         {
           "description": "Cysteine RNA sequence 2 is identified",
-          "property": "translate",
+          "property": "translate_codon",
           "strand": "UGC",
           "expected": "Cysteine"
         },
         {
           "description": "Tryptophan RNA sequence is identified",
-          "property": "translate",
+          "property": "translate_codon",
           "strand": "UGG",
           "expected": "Tryptophan"
         },
         {
           "description": "STOP codon RNA sequence is identified",
-          "property": "translate",
+          "property": "translate_codon",
           "strand": "UAA",
           "expected": "STOP"
         },
         {
           "description": "STOP codon RNA sequence is identified",
-          "property": "translate",
+          "property": "translate_codon",
           "strand": "UAG",
           "expected": "STOP"
         },
         {
           "description": "STOP codon RNA sequence is identified",
-          "property": "translate",
+          "property": "translate_codon",
           "strand": "UGA",
           "expected": "STOP"
         },
         {
           "description": "Translate RNA strand into correct protein list",
-          "property": "translate",
+          "property": "translate_rna",
           "strand": "AUGUUUUGG",
           "expected": ["Methionine","Phenylalanine","Tryptophan"]
         },
         {
           "description": "Translation stops if STOP codon present 1",
-          "property": "translate",
+          "property": "translate_rna",
           "strand": "AUGUUUUAA",
           "expected": ["Methionine","Phenylalanine"]
         },
         {
           "description": "Translation stops if codon present 2",
-          "property": "translate",
+          "property": "translate_rna",
           "strand": "UGGUGUUAUUAAUGGUUU",
           "expected": ["Tryptophan","Cysteine","Tyrosine"]
         },
         {
           "description": "Test invalid codons",
-          "property": "translate",
+          "property": "translate_codon",
           "strand": "CARROT",
           "expected": {
             "error": "Invalid nucleotide in strand"

--- a/exercises/protein-translation/canonical-data.json
+++ b/exercises/protein-translation/canonical-data.json
@@ -94,22 +94,22 @@
           "expected": ["Tryptophan"]
         },
         {
-          "description": "STOP codon RNA sequence",
+          "description": "STOP codon RNA sequence 1",
           "property": "translate",
           "strand": "UAA",
-          "expected": ["STOP"]
+          "expected": []
         },
         {
-          "description": "STOP codon RNA sequence",
+          "description": "STOP codon RNA sequence 2",
           "property": "translate",
           "strand": "UAG",
-          "expected": ["STOP"]
+          "expected": []
         },
         {
-          "description": "STOP codon RNA sequence",
+          "description": "STOP codon RNA sequence 3",
           "property": "translate",
           "strand": "UGA",
-          "expected": ["STOP"]
+          "expected": []
         },
         {
           "description": "Translate RNA strand into correct protein list",
@@ -121,13 +121,13 @@
           "description": "Translation stops if STOP codon at end of sequence",
           "property": "translate",
           "strand": "AUGUUUUAA",
-          "expected": ["Methionine","Phenylalanine", "STOP"]
+          "expected": ["Methionine","Phenylalanine"]
         },
         {
           "description": "Translation stops if codon in middle of sequence",
           "property": "translate",
           "strand": "UGGUGUUAUUAAUGGUUU",
-          "expected": ["Tryptophan","Cysteine","Tyrosine", "STOP"]
+          "expected": ["Tryptophan","Cysteine","Tyrosine"]
         },
         {
           "description": "Test invalid codons",

--- a/exercises/protein-translation/canonical-data.json
+++ b/exercises/protein-translation/canonical-data.json
@@ -121,13 +121,13 @@
           "description": "Translation stops if STOP codon present in short string",
           "property": "translate",
           "strand": "AUGUUUUAA",
-          "expected": ["Methionine","Phenylalanine"]
+          "expected": ["Methionine","Phenylalanine", "STOP"]
         },
         {
-          "description": "Translation stops if codon present in longer string",
+          "description": "Translation stops if codon in middle of sequence",
           "property": "translate",
           "strand": "UGGUGUUAUUAAUGGUUU",
-          "expected": ["Tryptophan","Cysteine","Tyrosine"]
+          "expected": ["Tryptophan","Cysteine","Tyrosine", "STOP"]
         },
         {
           "description": "Test invalid codons",

--- a/exercises/protein-translation/canonical-data.json
+++ b/exercises/protein-translation/canonical-data.json
@@ -5,133 +5,133 @@
     {
       "description": "Translate input RNA sequences into proteins",
       "comments": [
-        " Returns the name of the protein if given RNA is valid, "
-      , " else throws an error. "
+        "Returns the name of the protein if given RNA is valid, "
+      , "else throws an error. "
       ],
       "cases": [
         {
           "description": "Methionine RNA sequence is identified",
-          "property": "translate_codon",
+          "property": "translate",
           "strand": "AUG",
-          "expected": "Methionine"
+          "expected": ["Methionine"]
         },
         {
           "description": "Phenylalanine RNA sequence 1 is identified",
-          "property": "translate_codon",
+          "property": "translate",
           "strand": "UUU",
-          "expected": "Phenylalanine"
+          "expected": ["Phenylalanine"]
         },
         {
           "description": "Phenylalanine RNA sequence 2 is identified",
-          "property": "translate_codon",
+          "property": "translate",
           "strand": "UUC",
-          "expected": "Phenylalanine"
+          "expected": ["Phenylalanine"]
         },
         {
           "description": "Leucine RNA sequence 1 is identified",
-          "property": "translate_codon",
+          "property": "translate",
           "strand": "UUA",
-          "expected": "Leucine"
+          "expected": ["Leucine"]
         },
         {
           "description": "Leucine RNA sequence 2 is identified",
-          "property": "translate_codon",
+          "property": "translate",
           "strand": "UUG",
-          "expected": "Leucine"
+          "expected": ["Leucine"]
         },
         {
           "description": "Serine RNA sequence 1 is identified",
-          "property": "translate_codon",
+          "property": "translate",
           "strand": "UCU",
-          "expected": "Serine"
+          "expected": ["Serine"]
         },
         {
           "description": "Serine RNA sequence 2 is identified",
-          "property": "translate_codon",
+          "property": "translate",
           "strand": "UCC",
-          "expected": "Serine"
+          "expected": ["Serine"]
         },
         {
           "description": "Serine RNA sequence 3 is identified",
-          "property": "translate_codon",
+          "property": "translate",
           "strand": "UCA",
-          "expected": "Serine"
+          "expected": ["Serine"]
         },
         {
           "description": "Serine RNA sequence 4 is identified",
-          "property": "translate_codon",
+          "property": "translate",
           "strand": "UCG",
-          "expected": "Serine"
+          "expected": ["Serine"]
         },
         {
           "description": "Tyrosine RNA sequence 1 is identified",
-          "property": "translate_codon",
+          "property": "translate",
           "strand": "UAU",
-          "expected": "Tyrosine"
+          "expected": ["Tyrosine"]
         },
         {
           "description": "Tyrosine RNA sequence 2 is identified",
-          "property": "translate_codon",
+          "property": "translate",
           "strand": "UAC",
-          "expected": "Tyrosine"
+          "expected": ["Tyrosine"]
         },
         {
           "description": "Cysteine RNA sequence 1 is identified",
-          "property": "translate_codon",
+          "property": "translate",
           "strand": "UGU",
-          "expected": "Cysteine"
+          "expected": ["Cysteine"]
         },
         {
           "description": "Cysteine RNA sequence 2 is identified",
-          "property": "translate_codon",
+          "property": "translate",
           "strand": "UGC",
-          "expected": "Cysteine"
+          "expected": ["Cysteine"]
         },
         {
           "description": "Tryptophan RNA sequence is identified",
-          "property": "translate_codon",
+          "property": "translate",
           "strand": "UGG",
-          "expected": "Tryptophan"
+          "expected": ["Tryptophan"]
         },
         {
           "description": "STOP codon RNA sequence is identified",
-          "property": "translate_codon",
+          "property": "translate",
           "strand": "UAA",
-          "expected": "STOP"
+          "expected": ["STOP"]
         },
         {
           "description": "STOP codon RNA sequence is identified",
-          "property": "translate_codon",
+          "property": "translate",
           "strand": "UAG",
-          "expected": "STOP"
+          "expected": ["STOP"]
         },
         {
           "description": "STOP codon RNA sequence is identified",
-          "property": "translate_codon",
+          "property": "translate",
           "strand": "UGA",
-          "expected": "STOP"
+          "expected": ["STOP"]
         },
         {
           "description": "Translate RNA strand into correct protein list",
-          "property": "translate_rna",
+          "property": "translate",
           "strand": "AUGUUUUGG",
           "expected": ["Methionine","Phenylalanine","Tryptophan"]
         },
         {
           "description": "Translation stops if STOP codon present 1",
-          "property": "translate_rna",
+          "property": "translate",
           "strand": "AUGUUUUAA",
           "expected": ["Methionine","Phenylalanine"]
         },
         {
           "description": "Translation stops if codon present 2",
-          "property": "translate_rna",
+          "property": "translate",
           "strand": "UGGUGUUAUUAAUGGUUU",
           "expected": ["Tryptophan","Cysteine","Tyrosine"]
         },
         {
           "description": "Test invalid codons",
-          "property": "translate_codon",
+          "property": "translate",
           "strand": "CARROT",
           "expected": {
             "error": "Invalid nucleotide in strand"

--- a/exercises/protein-translation/canonical-data.json
+++ b/exercises/protein-translation/canonical-data.json
@@ -1,0 +1,143 @@
+{
+  "exercise": "protein-translation",
+  "version": "1.0.0",
+  "cases": [
+    {
+      "description": "Translate input RNA sequences into proteins",
+      "comments": [
+        " Returns the name of the protein if given RNA is valid, "
+      , " else throws an error. "
+      ],
+      "cases": [
+        {
+          "description": "Methionine RNA sequence is identified",
+          "property": "translate",
+          "strand": "AUG",
+          "expected": "Methionine"
+        },
+        {
+          "description": "Phenylalanine RNA sequence 1 is identified",
+          "property": "translate",
+          "strand": "UUU",
+          "expected": "Phenylalanine"
+        },
+        {
+          "description": "Phenylalanine RNA sequence 2 is identified",
+          "property": "translate",
+          "strand": "UUC",
+          "expected": "Phenylalanine"
+        },
+        {
+          "description": "Leucine RNA sequence 1 is identified",
+          "property": "translate",
+          "strand": "UUA",
+          "expected": "Leucine"
+        },
+        {
+          "description": "Leucine RNA sequence 2 is identified",
+          "property": "translate",
+          "strand": "UUG",
+          "expected": "Leucine"
+        },
+        {
+          "description": "Serine RNA sequence 1 is identified",
+          "property": "translate",
+          "strand": "UCU",
+          "expected": "Serine"
+        },
+        {
+          "description": "Serine RNA sequence 2 is identified",
+          "property": "translate",
+          "strand": "UCC",
+          "expected": "Serine"
+        },
+        {
+          "description": "Serine RNA sequence 3 is identified",
+          "property": "translate",
+          "strand": "UCA",
+          "expected": "Serine"
+        },
+        {
+          "description": "Serine RNA sequence 4 is identified",
+          "property": "translate",
+          "strand": "UCG",
+          "expected": "Serine"
+        },
+        {
+          "description": "Tyrosine RNA sequence 1 is identified",
+          "property": "translate",
+          "strand": "UAU",
+          "expected": "Tyrosine"
+        },
+        {
+          "description": "Tyrosine RNA sequence 2 is identified",
+          "property": "translate",
+          "strand": "UAC",
+          "expected": "Tyrosine"
+        },
+        {
+          "description": "Cysteine RNA sequence 1 is identified",
+          "property": "translate",
+          "strand": "UGU",
+          "expected": "Cysteine"
+        },
+        {
+          "description": "Cysteine RNA sequence 2 is identified",
+          "property": "translate",
+          "strand": "UGC",
+          "expected": "Cysteine"
+        },
+        {
+          "description": "Tryptophan RNA sequence is identified",
+          "property": "translate",
+          "strand": "UGG",
+          "expected": "Tryptophan"
+        },
+        {
+          "description": "STOP codon RNA sequence is identified",
+          "property": "translate",
+          "strand": "UAA",
+          "expected": "STOP"
+        },
+        {
+          "description": "STOP codon RNA sequence is identified",
+          "property": "translate",
+          "strand": "UAG",
+          "expected": "STOP"
+        },
+        {
+          "description": "STOP codon RNA sequence is identified",
+          "property": "translate",
+          "strand": "UGA",
+          "expected": "STOP"
+        },
+        {
+          "description": "Translate RNA strand into correct protein list",
+          "property": "translate",
+          "strand": "AUGUUUUGG",
+          "expected": ["Methionine","Phenylalanine","Tryptophan"]
+        },
+        {
+          "description": "Translation stops if STOP codon present 1",
+          "property": "translate",
+          "strand": "AUGUUUUAA",
+          "expected": ["Methionine","Phenylalanine"]
+        },
+        {
+          "description": "Translation stops if codon present 2",
+          "property": "translate",
+          "strand": "UGGUGUUAUUAAUGGUUU",
+          "expected": ["Tryptophan","Cysteine","Tyrosine"]
+        },
+        {
+          "description": "Test invalid codons",
+          "property": "translate",
+          "strand": "CARROT",
+          "expected": {
+            "error": "Invalid nucleotide in strand"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/exercises/protein-translation/canonical-data.json
+++ b/exercises/protein-translation/canonical-data.json
@@ -10,103 +10,103 @@
       ],
       "cases": [
         {
-          "description": "Methionine RNA sequence is identified",
+          "description": "Methionine RNA sequence",
           "property": "translate",
           "strand": "AUG",
           "expected": ["Methionine"]
         },
         {
-          "description": "Phenylalanine RNA sequence 1 is identified",
+          "description": "Phenylalanine RNA sequence 1",
           "property": "translate",
           "strand": "UUU",
           "expected": ["Phenylalanine"]
         },
         {
-          "description": "Phenylalanine RNA sequence 2 is identified",
+          "description": "Phenylalanine RNA sequence 2",
           "property": "translate",
           "strand": "UUC",
           "expected": ["Phenylalanine"]
         },
         {
-          "description": "Leucine RNA sequence 1 is identified",
+          "description": "Leucine RNA sequence 1",
           "property": "translate",
           "strand": "UUA",
           "expected": ["Leucine"]
         },
         {
-          "description": "Leucine RNA sequence 2 is identified",
+          "description": "Leucine RNA sequence 2",
           "property": "translate",
           "strand": "UUG",
           "expected": ["Leucine"]
         },
         {
-          "description": "Serine RNA sequence 1 is identified",
+          "description": "Serine RNA sequence 1",
           "property": "translate",
           "strand": "UCU",
           "expected": ["Serine"]
         },
         {
-          "description": "Serine RNA sequence 2 is identified",
+          "description": "Serine RNA sequence 2",
           "property": "translate",
           "strand": "UCC",
           "expected": ["Serine"]
         },
         {
-          "description": "Serine RNA sequence 3 is identified",
+          "description": "Serine RNA sequence 3",
           "property": "translate",
           "strand": "UCA",
           "expected": ["Serine"]
         },
         {
-          "description": "Serine RNA sequence 4 is identified",
+          "description": "Serine RNA sequence 4",
           "property": "translate",
           "strand": "UCG",
           "expected": ["Serine"]
         },
         {
-          "description": "Tyrosine RNA sequence 1 is identified",
+          "description": "Tyrosine RNA sequence 1",
           "property": "translate",
           "strand": "UAU",
           "expected": ["Tyrosine"]
         },
         {
-          "description": "Tyrosine RNA sequence 2 is identified",
+          "description": "Tyrosine RNA sequence 2",
           "property": "translate",
           "strand": "UAC",
           "expected": ["Tyrosine"]
         },
         {
-          "description": "Cysteine RNA sequence 1 is identified",
+          "description": "Cysteine RNA sequence 1",
           "property": "translate",
           "strand": "UGU",
           "expected": ["Cysteine"]
         },
         {
-          "description": "Cysteine RNA sequence 2 is identified",
+          "description": "Cysteine RNA sequence 2",
           "property": "translate",
           "strand": "UGC",
           "expected": ["Cysteine"]
         },
         {
-          "description": "Tryptophan RNA sequence is identified",
+          "description": "Tryptophan RNA sequence",
           "property": "translate",
           "strand": "UGG",
           "expected": ["Tryptophan"]
         },
         {
-          "description": "STOP codon RNA sequence is identified",
+          "description": "STOP codon RNA sequence",
           "property": "translate",
           "strand": "UAA",
           "expected": ["STOP"]
         },
         {
-          "description": "STOP codon RNA sequence is identified",
+          "description": "STOP codon RNA sequence",
           "property": "translate",
           "strand": "UAG",
           "expected": ["STOP"]
         },
         {
-          "description": "STOP codon RNA sequence is identified",
+          "description": "STOP codon RNA sequence",
           "property": "translate",
           "strand": "UGA",
           "expected": ["STOP"]

--- a/exercises/protein-translation/canonical-data.json
+++ b/exercises/protein-translation/canonical-data.json
@@ -118,13 +118,13 @@
           "expected": ["Methionine","Phenylalanine","Tryptophan"]
         },
         {
-          "description": "Translation stops if STOP codon present 1",
+          "description": "Translation stops if STOP codon present in short string",
           "property": "translate",
           "strand": "AUGUUUUAA",
           "expected": ["Methionine","Phenylalanine"]
         },
         {
-          "description": "Translation stops if codon present 2",
+          "description": "Translation stops if codon present in longer string",
           "property": "translate",
           "strand": "UGGUGUUAUUAAUGGUUU",
           "expected": ["Tryptophan","Cysteine","Tyrosine"]

--- a/exercises/protein-translation/canonical-data.json
+++ b/exercises/protein-translation/canonical-data.json
@@ -118,7 +118,7 @@
           "expected": ["Methionine","Phenylalanine","Tryptophan"]
         },
         {
-          "description": "Translation stops if STOP codon present in short string",
+          "description": "Translation stops if STOP codon at end of sequence",
           "property": "translate",
           "strand": "AUGUUUUAA",
           "expected": ["Methionine","Phenylalanine", "STOP"]

--- a/exercises/protein-translation/canonical-data.json
+++ b/exercises/protein-translation/canonical-data.json
@@ -11,131 +11,141 @@
       "cases": [
         {
           "description": "Methionine RNA sequence",
-          "property": "translate",
+          "property": "proteins",
           "strand": "AUG",
           "expected": ["Methionine"]
         },
         {
           "description": "Phenylalanine RNA sequence 1",
-          "property": "translate",
+          "property": "proteins",
           "strand": "UUU",
           "expected": ["Phenylalanine"]
         },
         {
           "description": "Phenylalanine RNA sequence 2",
-          "property": "translate",
+          "property": "proteins",
           "strand": "UUC",
           "expected": ["Phenylalanine"]
         },
         {
           "description": "Leucine RNA sequence 1",
-          "property": "translate",
+          "property": "proteins",
           "strand": "UUA",
           "expected": ["Leucine"]
         },
         {
           "description": "Leucine RNA sequence 2",
-          "property": "translate",
+          "property": "proteins",
           "strand": "UUG",
           "expected": ["Leucine"]
         },
         {
           "description": "Serine RNA sequence 1",
-          "property": "translate",
+          "property": "proteins",
           "strand": "UCU",
           "expected": ["Serine"]
         },
         {
           "description": "Serine RNA sequence 2",
-          "property": "translate",
+          "property": "proteins",
           "strand": "UCC",
           "expected": ["Serine"]
         },
         {
           "description": "Serine RNA sequence 3",
-          "property": "translate",
+          "property": "proteins",
           "strand": "UCA",
           "expected": ["Serine"]
         },
         {
           "description": "Serine RNA sequence 4",
-          "property": "translate",
+          "property": "proteins",
           "strand": "UCG",
           "expected": ["Serine"]
         },
         {
           "description": "Tyrosine RNA sequence 1",
-          "property": "translate",
+          "property": "proteins",
           "strand": "UAU",
           "expected": ["Tyrosine"]
         },
         {
           "description": "Tyrosine RNA sequence 2",
-          "property": "translate",
+          "property": "proteins",
           "strand": "UAC",
           "expected": ["Tyrosine"]
         },
         {
           "description": "Cysteine RNA sequence 1",
-          "property": "translate",
+          "property": "proteins",
           "strand": "UGU",
           "expected": ["Cysteine"]
         },
         {
           "description": "Cysteine RNA sequence 2",
-          "property": "translate",
+          "property": "proteins",
           "strand": "UGC",
           "expected": ["Cysteine"]
         },
         {
           "description": "Tryptophan RNA sequence",
-          "property": "translate",
+          "property": "proteins",
           "strand": "UGG",
           "expected": ["Tryptophan"]
         },
         {
           "description": "STOP codon RNA sequence 1",
-          "property": "translate",
+          "property": "proteins",
           "strand": "UAA",
           "expected": []
         },
         {
           "description": "STOP codon RNA sequence 2",
-          "property": "translate",
+          "property": "proteins",
           "strand": "UAG",
           "expected": []
         },
         {
           "description": "STOP codon RNA sequence 3",
-          "property": "translate",
+          "property": "proteins",
           "strand": "UGA",
           "expected": []
         },
         {
           "description": "Translate RNA strand into correct protein list",
-          "property": "translate",
+          "property": "proteins",
           "strand": "AUGUUUUGG",
           "expected": ["Methionine","Phenylalanine","Tryptophan"]
         },
         {
-          "description": "Translation stops if STOP codon at end of sequence",
-          "property": "translate",
+          "description": "Translation stops if STOP codon at beginning of sequence",
+          "property": "proteins",
+          "strand": "UAGUGG",
+          "expected": []
+        },
+        {
+          "description": "Translation stops if STOP codon at end of two-codon sequence",
+          "property": "proteins",
+          "strand": "UGGUAG",
+          "expected": ["Tryptophan"]
+        },
+        {
+          "description": "Translation stops if STOP codon at end of three-codon sequence",
+          "property": "proteins",
           "strand": "AUGUUUUAA",
           "expected": ["Methionine","Phenylalanine"]
         },
         {
-          "description": "Translation stops if codon in middle of sequence",
-          "property": "translate",
-          "strand": "UGGUGUUAUUAAUGGUUU",
-          "expected": ["Tryptophan","Cysteine","Tyrosine"]
+          "description": "Translation stops if STOP codon in middle of sequence of three-codon sequence",
+          "property": "proteins",
+          "strand": "UGGUAGUGG",
+          "expected": ["Tryptophan"]
         },
         {
-          "description": "Test invalid codons",
-          "property": "translate",
-          "strand": "CARROT",
-          "expected": {
-            "error": "Invalid nucleotide in strand"
-          }
+          "description": "Translation stops if codon in middle of sequence of six-codon sequence",
+          "property": "proteins",
+          "strand": "UGGUGUUAUUAAUGGUUU",
+          "expected": ["Tryptophan","Cysteine","Tyrosine"]
         }
       ]
     }


### PR DESCRIPTION
Add protein translation canonical data as per #577.

After going to implement this exercise in Java, and realising that there is not a `canonical-data.json` for the problem, I decided to do this. I have helped a friend complete this exercise on the Python track, and believe the Python tests to be very comprehensive, so I have used them as my main source of data.

Please let me know if this is too long for a `canonical-data.json`, as there are about 20 tests...