### PR TITLE
isbn-verifier: Rename property

### DIFF
--- a/exercises/isbn-verifier/canonical-data.json
+++ b/exercises/isbn-verifier/canonical-data.json
@@ -1,6 +1,6 @@
 {
     "exercise": "isbn-verifier",
-    "version": "1.1.0",
+    "version": "2.0.0",
     "comments": [
         "An expected value of true indicates a valid ISBN-10, ",
         "whereas false means the ISBN-10 is invalid."
@@ -8,79 +8,79 @@
     "cases": [
         {
             "description": "valid isbn number",
-            "property": "isbn",
+            "property": "isValid",
             "input": "3-598-21508-8",
             "expected": true
         },
         {
             "description": "invalid isbn check digit",
-            "property": "isbn",
+            "property": "isValid",
             "input": "3-598-21508-9",
             "expected": false
         },
         {
             "description": "valid isbn number with a check digit of 10",
-            "property": "isbn",
+            "property": "isValid",
             "input": "3-598-21507-X",
             "expected": true
         },
         {
             "description": "check digit is a character other than X",
-            "property": "isbn",
+            "property": "isValid",
             "input": "3-598-21507-A",
             "expected": false
         },
         {
             "description": "invalid character in isbn",
-            "property": "isbn",
+            "property": "isValid",
             "input": "3-598-2K507-0",
             "expected": false
         },
         {
             "description": "X is only valid as a check digit",
-            "property": "isbn",
+            "property": "isValid",
             "input": "3-598-2X507-9",
             "expected": false
         },
         {
             "description": "valid isbn without separating dashes",
-            "property": "isbn",
+            "property": "isValid",
             "input": "3598215088",
             "expected": true
         },
         {
             "description": "isbn without separating dashes and X as check digit",
-            "property": "isbn",
+            "property": "isValid",
             "input": "359821507X",
             "expected": true
         },
         {
             "description": "isbn without check digit and dashes",
-            "property": "isbn",
+            "property": "isValid",
             "input": "359821507",
             "expected": false
         },
         {
             "description": "too long isbn and no dashes",
-            "property": "isbn",
+            "property": "isValid",
             "input": "3598215078X",
             "expected": false
         },
         {
             "description": "isbn without check digit",
-            "property": "isbn",
+            "property": "isValid",
             "input": "3-598-21507",
             "expected": false
         },
         {
             "description": "too long isbn",
-            "property": "isbn",
+            "property": "isValid",
             "input": "3-598-21507-XX",
             "expected": false
         },
         {
             "description": "check digit of X should not be used for 0",
-            "property": "isbn",
+            "property": "isValid",
             "input": "3-598-21515-X",
             "expected": false
         }


### PR DESCRIPTION
The existing property does not really indicate that any validation occurs. This PR changes the property to better represent validation being done.