### PR TITLE
all-your-base: Be explicit about error cases

### DIFF
--- a/exercises/all-your-base/canonical-data.json
+++ b/exercises/all-your-base/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "all-your-base",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "comments": [
     "This canonical data makes the following choices:",
     "1. Zero is always represented in outputs as [0] instead of [].",
@@ -9,11 +9,6 @@
     "4. An empty sequence of input digits is considered zero, rather than an error.",
     "",
     "Tracks that wish to make different decisions for these choices may translate appropriately.",
-    "",
-    "It's up to each track do decide:",
-    "How should invalid input be handled?",
-    "",
-    "All the undefined cases are marked as null.",
     "",
     "All your numeric-base are belong to [2..]. :)"
   ],
@@ -120,7 +115,7 @@
       "input_base": 1,
       "input_digits": [],
       "output_base": 10,
-      "expected": null
+      "expected": {"error": "input base must be >= 2"}
     },
     {
       "description": "first base is zero",
@@ -128,7 +123,7 @@
       "input_base": 0,
       "input_digits": [],
       "output_base": 10,
-      "expected": null
+      "expected": {"error": "input base must be >= 2"}
     },
     {
       "description": "first base is negative",
@@ -136,7 +131,7 @@
       "input_base": -2,
       "input_digits": [1],
       "output_base": 10,
-      "expected": null
+      "expected": {"error": "input base must be >= 2"}
     },
     {
       "description": "negative digit",
@@ -144,7 +139,7 @@
       "input_base": 2,
       "input_digits": [1, -1, 1, 0, 1, 0],
       "output_base": 10,
-      "expected": null
+      "expected": {"error": "all digits must satisfy 0 <= d < input base"}
     },
     {
       "description": "invalid positive digit",
@@ -152,7 +147,7 @@
       "input_base": 2,
       "input_digits": [1, 2, 1, 0, 1, 0],
       "output_base": 10,
-      "expected": null
+      "expected": {"error": "all digits must satisfy 0 <= d < input base"}
     },
     {
       "description": "second base is one",
@@ -160,7 +155,7 @@
       "input_base": 2,
       "input_digits": [1, 0, 1, 0, 1, 0],
       "output_base": 1,
-      "expected": null
+      "expected": {"error": "output base must be >= 2"}
     },
     {
       "description": "second base is zero",
@@ -168,7 +163,7 @@
       "input_base": 10,
       "input_digits": [7],
       "output_base": 0,
-      "expected": null
+      "expected": {"error": "output base must be >= 2"}
     },
     {
       "description": "second base is negative",
@@ -176,7 +171,7 @@
       "input_base": 2,
       "input_digits": [1],
       "output_base": -7,
-      "expected": null
+      "expected": {"error": "output base must be >= 2"}
     },
     {
       "description": "both bases are negative",
@@ -184,7 +179,7 @@
       "input_base": -2,
       "input_digits": [1],
       "output_base": -7,
-      "expected": null
+      "expected": {"error": "input base must be >= 2"}
     }
   ]
 }


### PR DESCRIPTION
all-your-base 2.0.0

This uses the error object defined in
https://github.com/exercism/problem-specifications/issues/401#issuecomment-274395645
and thenceforth added to the README's **Test Data Format**.

In https://github.com/exercism/problem-specifications/pull/280 we made
the explicit choice to leave various cases `expected: null` where tracks
can make their own decisions (leading zeroes, the representations of
zero, whether empty sequence is acceptable as input).

However, since `expected: null` is also used for cases where there is
always an error (and there is no decision being left to the tracks),
it becomes unreasonably hard to tell cases in these two categories
apart.

To make this easier, all cases in the latter category (always are
errors) can canonically be marked as such.