### PR TITLE
all-your-base: Be decisive about zeroes

### DIFF
--- a/exercises/all-your-base/canonical-data.json
+++ b/exercises/all-your-base/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "all-your-base",
-  "version": "2.0.0",
+  "version": "1.2.0",
   "comments": [
     "This canonical data makes the following choices:",
     "1. Zero is always represented in outputs as [0] instead of [].",
@@ -9,6 +9,11 @@
     "4. An empty sequence of input digits is considered zero, rather than an error.",
     "",
     "Tracks that wish to make different decisions for these choices may translate appropriately.",
+    "",
+    "It's up to each track do decide:",
+    "How should invalid input be handled?",
+    "",
+    "All the undefined cases are marked as null.",
     "",
     "All your numeric-base are belong to [2..]. :)"
   ],

--- a/exercises/all-your-base/canonical-data.json
+++ b/exercises/all-your-base/canonical-data.json
@@ -1,23 +1,14 @@
 {
   "exercise": "all-your-base",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "comments": [
-    "It's up to each track do decide:",
+    "This canonical data makes the following choices:",
+    "1. Zero is always represented in outputs as [0] instead of [].",
+    "2. In no other instances are leading zeroes present in any outputs.",
+    "3. Leading zeroes are accepted in inputs.",
+    "4. An empty sequence of input digits is considered zero, rather than an error.",
     "",
-    "1. What's the canonical representation of zero?",
-    " - []?",
-    " - [0]?",
-    "",
-    "2. What representations of zero are allowed?",
-    " - []?",
-    " - [0]?",
-    " - [0,0]?",
-    "",
-    "3. Are leading zeroes allowed?",
-    "",
-    "4. How should invalid input be handled?",
-    "",
-    "All the undefined cases are marked as null.",
+    "Tracks that wish to make different decisions for these choices may translate appropriately.",
     "",
     "All your numeric-base are belong to [2..]. :)"
   ],
@@ -92,7 +83,7 @@
       "input_base": 2,
       "input_digits": [],
       "output_base": 10,
-      "expected": null
+      "expected": [0]
     },
     {
       "description": "single zero",
@@ -100,7 +91,7 @@
       "input_base": 10,
       "input_digits": [0],
       "output_base": 2,
-      "expected": null
+      "expected": [0]
     },
     {
       "description": "multiple zeros",
@@ -108,7 +99,7 @@
       "input_base": 10,
       "input_digits": [0, 0, 0],
       "output_base": 2,
-      "expected": null
+      "expected": [0]
     },
     {
       "description": "leading zeros",
@@ -116,7 +107,7 @@
       "input_base": 7,
       "input_digits": [0, 6, 0],
       "output_base": 10,
-      "expected": null
+      "expected": [4, 2]
     },
     {
       "description": "first base is one",


### PR DESCRIPTION
all-your-base 2.0.0

In https://github.com/exercism/problem-specifications/pull/280 we made
the explicit choice to leave various cases `expected: null` where tracks
can make their own decisions (leading zeroes, the representations of
zero, whether empty sequence is acceptable as input).

There are four affected cases.

https://github.com/exercism/problem-specifications/issues/473 results in
a discussion that some post-processing is necessary, based on the
decisions that a given track makes. One might even imagine that each
individual generator may have to reimplement base translation to arrive
at the proper answers for each case.

To ease the process of translation, instead we make some canonical
choices, explicitly show what the choices are, and offer that tracks may
make a different choice if desired.

A previous proposal did not receive support:
https://github.com/exercism/problem-specifications/pull/468

However, this proposal differs because it does change the comments at
the top of the file.

Closes #1002 by mutual exclusion