### PR TITLE
reverse-string: More consistent canonical data descriptions

### DIFF
--- a/exercises/reverse-string/canonical-data.json
+++ b/exercises/reverse-string/canonical-data.json
@@ -1,12 +1,12 @@
 {
   "exercise": "reverse-string",
-  "version": "1.0.0",      
+  "version": "1.0.1",      
   "comments": [
         "If property based testing tools are available, a good property to test is reversing a string twice: reverse(reverse(string)) == string"
       ],
   "cases": [
     {
-      "description": "empty string",
+      "description": "an empty string",
       "property": "reverse",
       "input": "",
       "expected": ""


### PR DESCRIPTION
All the case in the reverse-string canonical data start with "a ...", expect for the first case. To make this more consistent, I propose to change "empty string" to "an empty string".