### PR TITLE
meetup: correct example in description.md

### DIFF
--- a/exercises/meetup/description.md
+++ b/exercises/meetup/description.md
@@ -6,7 +6,7 @@ will take a description of a meetup date, and return the actual meetup date.
 Examples of general descriptions are:
 
 - The first Monday of January 2017
-- The third Tuesday of January 2017
+- The second Tuesday of January 2017
 - The wednesteenth of January 2017
 - The last Thursday of January 2017
 


### PR DESCRIPTION
The *third* Tuesday of January 2017 was the 17th and thus should either be specified as a "-teenth" or be a different Tuesday. I went with the latter.

This confused me no end when trying to grok what qualified a day to be "teenth" or not >.<