### PR TITLE
pov: Remove extraneous heading

### DIFF
--- a/exercises/pov/description.md
+++ b/exercises/pov/description.md
@@ -1,7 +1,5 @@
 Reparent a graph on a selected node.
 
-# Tree Reparenting
-
 This exercise is all about re-orientating a graph to see things from a different
 point of view. For example family trees are usually presented from the
 ancestor's perspective:


### PR DESCRIPTION
I noticed that there is an extra top-level heading in the `description.md` that I don't think should be there, so this PR removes it.