### PR TITLE
simple-cipher: Replace language-specific wording

### DIFF
--- a/exercises/simple-cipher/description.md
+++ b/exercises/simple-cipher/description.md
@@ -56,15 +56,13 @@ would get the same thing as the Caesar Cipher.
 
 The weakest link in any cipher is the human being. Let's make your
 substitution cipher a little more fault tolerant by providing a source
-of randomness and ensuring that the key is not composed of numbers or
-capital letters.
+of randomness and ensuring that the key contains only lowercase letters.
 
 If someone doesn't submit a key at all, generate a truly random key of
-at least 100 characters in length, accessible via Cipher#key (the #
-syntax means instance variable)
+at least 100 characters in length.
 
-If the key submitted has capital letters or numbers, throw an
-ArgumentError with a message to that effect.
+If the key submitted is not composed only of lowercase letters, your
+solution should handle the error in a language-appropriate way.
 
 ## Extensions
 


### PR DESCRIPTION
I noticed a few language-specific phrases in the `simple-cipher` description, so this PR removes them.

I'm more than happy to take suggestions on the replacement wording.