### PR TITLE
protein-translation: Remove repetition from canonical data

### DIFF
--- a/exercises/protein-translation/canonical-data.json
+++ b/exercises/protein-translation/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "protein-translation",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "cases": [
     {
       "description": "Translate input RNA sequences into proteins",

--- a/exercises/protein-translation/canonical-data.json
+++ b/exercises/protein-translation/canonical-data.json
@@ -142,7 +142,7 @@
           "expected": ["Tryptophan"]
         },
         {
-          "description": "Translation stops if codon in middle of six-codon sequence",
+          "description": "Translation stops if STOP codon in middle of six-codon sequence",
           "property": "proteins",
           "strand": "UGGUGUUAUUAAUGGUUU",
           "expected": ["Tryptophan","Cysteine","Tyrosine"]

--- a/exercises/protein-translation/canonical-data.json
+++ b/exercises/protein-translation/canonical-data.json
@@ -136,13 +136,13 @@
           "expected": ["Methionine","Phenylalanine"]
         },
         {
-          "description": "Translation stops if STOP codon in middle of sequence of three-codon sequence",
+          "description": "Translation stops if STOP codon in middle of three-codon sequence",
           "property": "proteins",
           "strand": "UGGUAGUGG",
           "expected": ["Tryptophan"]
         },
         {
-          "description": "Translation stops if codon in middle of sequence of six-codon sequence",
+          "description": "Translation stops if codon in middle of six-codon sequence",
           "property": "proteins",
           "strand": "UGGUGUUAUUAAUGGUUU",
           "expected": ["Tryptophan","Cysteine","Tyrosine"]


### PR DESCRIPTION
I noticed there was some redundancy in the test names - removed it :slightly_smiling_face: 