### PR TITLE
series: Improve documentation

### DIFF
--- a/exercises/series/canonical-data.json
+++ b/exercises/series/canonical-data.json
@@ -1,0 +1,105 @@
+{
+  "exercise": "series",
+  "version": "1.0.0",
+  "cases": [
+    {
+      "description": "slices of one from one",
+      "property": "slices",
+      "input": {
+        "series": "1",
+        "sliceLength": 1
+      },
+      "expected": ["1"]
+    },
+    {
+      "description": "slices of one from two",
+      "property": "slices",
+      "input": {
+        "series": "12",
+        "sliceLength": 1
+      },
+      "expected": ["1", "2"]
+    },
+    {
+      "description": "slices of two",
+      "property": "slices",
+      "input": {
+        "series": "35",
+        "sliceLength": 2
+      },
+      "expected": ["35"]
+    },
+    {
+      "description": "slices of two overlap",
+      "property": "slices",
+      "input": {
+        "series": "9142",
+        "sliceLength": 2
+      },
+      "expected": ["91", "14", "42"]
+    },
+    {
+      "description": "slices can include duplicates",
+      "property": "slices",
+      "input": {
+        "series": "777777",
+        "sliceLength": 3
+      },
+      "expected": ["777", "777", "777", "777"]
+    },
+    {
+      "description": "slices of a long series",
+      "property": "slices",
+      "input": {
+        "series": "918493904243",
+        "sliceLength": 5
+      },
+      "expected": ["91849", "18493", "84939", "49390",
+                   "93904", "39042", "90424", "04243"]
+    },
+    {
+      "description": "slice length is too large",
+      "property": "slices",
+      "input": {
+        "series": "12345",
+        "sliceLength": 6
+      },
+      "expected": {
+        "error": "slice length cannot be greater than series length"
+      }
+    },
+    {
+      "description": "slice length cannot be zero",
+      "property": "slices",
+      "input": {
+        "series": "12345",
+        "sliceLength": 0
+      },
+      "expected": {
+        "error": "slice length cannot be zero"
+      }
+    },
+    {
+      "description": "slice length cannot be negative",
+      "property": "slices",
+      "input": {
+        "series": "123",
+        "sliceLength": -1
+      },
+      "expected": {
+        "error": "slice length cannot be negative"
+      }
+    },
+    {
+      "description": "empty series is invalid",
+      "property": "slices",
+      "input": {
+        "series": "",
+        "sliceLength": 1
+      },
+      "expected": {
+        "error": "series cannot be empty"
+      }
+    }
+  ]
+}

--- a/exercises/series/description.md
+++ b/exercises/series/description.md
@@ -1,16 +1,16 @@
 Given a string of digits, output all the contiguous substrings of length `n` in
-that string.
+that string in the order that they appear.
 
 For example, the string "49142" has the following 3-digit series:
 
-- 491
-- 914
-- 142
+- "491"
+- "914"
+- "142"
 
 And the following 4-digit series:
 
-- 4914
-- 9142
+- "4914"
+- "9142"
 
 And if you ask for a 6-digit series from a 5-digit string, you deserve
 whatever you get.


### PR DESCRIPTION
Resolves #584 by implementing canonical data for `series`.

I've noticed that lots of implementations expect the output to be a list of lists of integers rather than a list of strings:
- [F#](https://github.com/exercism/fsharp/blob/master/exercises/series/SeriesTest.fs)
- [Java](https://github.com/exercism/java/blob/master/exercises/series/src/test/java/SeriesTest.java)
- [Haskell](https://github.com/exercism/haskell/blob/master/exercises/series/test/Tests.hs)

However, I would argue that a list of strings is more reasonable, particularly given the current description, which mentions substrings. Some tracks have implemented it this way:
- [Go](https://github.com/exercism/go/blob/master/exercises/series/series_test.go)
- [Ruby](https://github.com/exercism/ruby/blob/master/exercises/series/series_test.rb)
- Python, subject to exercism/python#1117 (as a result of exercism/python#1109)

As a result, this implementation of the canonical data expects the output to be a list of strings.