### PR TITLE
rna-transcription: remove bad input tests

### DIFF
--- a/exercises/rna-transcription/canonical-data.json
+++ b/exercises/rna-transcription/canonical-data.json
@@ -48,19 +48,19 @@
       "description": "correctly handles invalid input (RNA instead of DNA)",
       "property": "toRna",
       "dna": "U",
-      "expected": null
+      "expected": {"error": "invalid input"}
     },
     {
       "description": "correctly handles completely invalid DNA input",
       "property": "toRna",
       "dna": "XXX",
-      "expected": null
+      "expected": {"error": "invalid input"}
     },
     {
       "description": "correctly handles partially invalid DNA input",
       "property": "toRna",
       "dna": "ACGTXXXCTTAA",
-      "expected": null
+      "expected": {"error": "invalid input"}
     }
   ]
 }

--- a/exercises/rna-transcription/canonical-data.json
+++ b/exercises/rna-transcription/canonical-data.json
@@ -43,24 +43,6 @@
       "property": "toRna",
       "dna": "ACGTGGTCTTAA",
       "expected": "UGCACCAGAAUU"
-    },
-    {
-      "description": "correctly handles invalid input (RNA instead of DNA)",
-      "property": "toRna",
-      "dna": "U",
-      "expected": {"error": "invalid input"}
-    },
-    {
-      "description": "correctly handles completely invalid DNA input",
-      "property": "toRna",
-      "dna": "XXX",
-      "expected": {"error": "invalid input"}
-    },
-    {
-      "description": "correctly handles partially invalid DNA input",
-      "property": "toRna",
-      "dna": "ACGTXXXCTTAA",
-      "expected": {"error": "invalid input"}
     }
   ]
 }


### PR DESCRIPTION
closes #977 

Replacing expected value of `null` with an error object.

propose error object:
```text
{"error": "invalid input"}
```
Let me know if the message should be re-worded.
