### PR TITLE
readme.md: Update example to reflect "input key as an object" policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,10 @@ is easier to understand with an example:
       }
     , { "description": "Bar'ing a name returns its parts combined"
       , "property"   : "bar"
-      , "firstName"  : "Alan"
-      , "lastName"   : "Smithee"
+      , "input"      : {
+          "firstName"  : "Alan",
+          "lastName"   : "Smithee"
+        }  
       , "expected"   : "ASlmainthee"
       }
     , { "comments":
@@ -88,8 +90,10 @@ is easier to understand with an example:
             }
           , { "description": "Bar'ing a name with numbers gives an error"
             , "property"   : "bar"
-            , "firstName"  : "HAL"
-            , "lastName"   : "9000"
+            , "input"      : {
+                "firstName"  : "HAL",
+                "lastName"   : "9000"
+              }  
             , "expected"   : { "error": "You should never bar a number" }
             }
           ]


### PR DESCRIPTION
In #996 it was decided that the canonical data should have an explicit input key whose value is an object containing the input(s) to the code under test.

closes #1007 