### PR TITLE
problem-specifications: Replace use of node/npm with yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ cache: yarn
 
 script:
   - bin/check_required_files_present
-  - npm test
+  - yarn test

--- a/README.md
+++ b/README.md
@@ -170,25 +170,25 @@ PATCH changes would never break well-designed test generators, because the test 
 ## Automated Tests
 
 `canonical-data.json` for each exercise is checked for compliance against the [canonical-schema.json](canonical-schema.json).
-In order to run these tests, you will need to have `node` and `npm` installed on your system.
-Install them from [here](https://nodejs.org/en/). (`npm` comes bundled with most installations of `node`).
+In order to run these tests, you will need to have `yarn` installed on your system.
+Install them from [here](https://yarnpkg.com/en/docs/install).
 
 Install the required packages:
 
 ```shell
-npm install
+yarn install
 ```
 
 Run for all exercises:
 
 ```shell
-npm test
+yarn test
 ```
 
 Run for single exercise:
 
 ```shell
-npm run test-one exercises/<exercise>/canonical-data.json
+yarn run test-one exercises/<exercise>/canonical-data.json
 ```
 
 Replace `<exercise>` by the name of exercise which you want to check.


### PR DESCRIPTION
I have noticed that in the README we instruct people to use node/npm. Yet we use Yarn to install our dependencies.

So I figured it would make sense to drop any mention of node/npm and instead use yarn. Yarn provides everything we need and we wouldn't be asking people to install two tools for one job.