### PR TITLE
two-fer: fix case inconsistency

### DIFF
--- a/exercises/two-fer/metadata.yml
+++ b/exercises/two-fer/metadata.yml
@@ -1,4 +1,4 @@
 ---
 blurb: 'Create a sentence of the form "One for X, one for me."'
-source: "This is an exercise to introduce users to basic programming constructs, just after hello World."
+source: "This is an exercise to introduce users to basic programming constructs, just after Hello World."
 source_url: "https://en.wikipedia.org/wiki/Two-fer"


### PR DESCRIPTION
I implemented this exercise for Clojure and noticed the case was inconsistent. I hope this fix is ok, and the odd case was not intentional - let me know :slightly_smiling_face: 