### PR TITLE
isbn-verifier: add empty isbn case

### DIFF
--- a/exercises/isbn-verifier/canonical-data.json
+++ b/exercises/isbn-verifier/canonical-data.json
@@ -1,6 +1,6 @@
 {
     "exercise": "isbn-verifier",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "comments": [
         "An expected value of true indicates a valid ISBN-10, ",
         "whereas false means the ISBN-10 is invalid."
@@ -107,6 +107,14 @@
             "property": "isValid",
             "input": {
               "isbn": "3-598-21515-X"
+            },
+            "expected": false
+        },
+        {
+            "description": "empty isbn",
+            "property": "isValid",
+            "input": {
+              "isbn": ""
             },
             "expected": false
         }


### PR DESCRIPTION
I have inserted the new test case at the end of  the test data.  I am not sure where it might fit better.
[description](https://github.com/exercism/problem-specifications/blob/master/exercises/isbn-verifier/description.md)
closes #1052