### PR TITLE
two-fer: Apply new "input" policy

### DIFF
--- a/exercises/two-fer/canonical-data.json
+++ b/exercises/two-fer/canonical-data.json
@@ -1,23 +1,29 @@
 {
   "exercise": "two-fer",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "cases": [
     {
       "description": "no name given",
-      "property": "name",
-      "input": null,
+      "property": "twoFer",
+      "input": {
+        "name": null
+      },
       "expected": "One for you, one for me."
     },
     {
       "description": "a name given",
-      "property": "name",
-      "input": "Alice",
+      "property": "twoFer",
+      "input": {
+        "name": "Alice"
+      },
       "expected": "One for Alice, one for me."
     },
     {
       "description": "another name given",
-      "property": "name",
-      "input": "Bob",
+      "property": "twoFer",
+      "input": {
+        "name": "Bob"
+      },
       "expected": "One for Bob, one for me."
     }
   ]


### PR DESCRIPTION
I've renamed the property from `name` to `twoFer`, as `name` is actually the input and what is returned is not a name, but the two-fer.

See #996 