### PR TITLE
bowling: update test data for recent policy changes

### DIFF
--- a/exercises/bowling/canonical-data.json
+++ b/exercises/bowling/canonical-data.json
@@ -6,7 +6,7 @@
     "Roll should accept a single integer.",
     "Score should return the game's final score, when possible",
     "For brevity the tests display all the previous rolls in an array;",
-    "each element of the previous_rolls array should be passed to the roll method",
+    "each element of the previousRolls array should be passed to the roll method",
     "and each of those previous rolls is expected to succeed.",
     "",
     "Two properties are tested:",
@@ -14,7 +14,7 @@
     "`score`: All rolls succeed, and taking the score gives the expected result.",
     "The expected result may be an integer score or an error.",
     "",
-    "`roll`: All previous_rolls succeed, and rolling the number of pins in `roll` produces the expected result.",
+    "`roll`: All previousRolls succeed, and rolling the number of pins in `roll` produces the expected result.",
     "Currently, all cases of this type result in errors.",
     "",
     "In all error cases you should expect an error as is idiomatic for your language",
@@ -24,105 +24,105 @@
     "description": "should be able to score a game with all zeros",
     "property": "score",
     "input": {
-      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+      "previousRolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     },
     "expected": 0
   }, {
     "description": "should be able to score a game with no strikes or spares",
     "property": "score",
     "input": {
-      "previous_rolls": [3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6]
+      "previousRolls": [3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6]
     },
     "expected": 90
   }, {
     "description": "a spare followed by zeros is worth ten points",
     "property": "score",
     "input": {
-      "previous_rolls": [6, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+      "previousRolls": [6, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     },
     "expected": 10
   }, {
     "description": "points scored in the roll after a spare are counted twice",
     "property": "score",
     "input": {
-      "previous_rolls": [6, 4, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+      "previousRolls": [6, 4, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     },
     "expected": 16
   }, {
     "description": "consecutive spares each get a one roll bonus",
     "property": "score",
     "input": {
-      "previous_rolls": [5, 5, 3, 7, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+      "previousRolls": [5, 5, 3, 7, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     },
     "expected": 31
   }, {
     "description": "a spare in the last frame gets a one roll bonus that is counted once",
     "property": "score",
     "input": {
-      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 7]
+      "previousRolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 7]
     },
     "expected": 17
   }, {
     "description": "a strike earns ten points in a frame with a single roll",
     "property": "score",
     "input": {
-      "previous_rolls": [10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+      "previousRolls": [10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     },
     "expected": 10
   }, {
     "description": "points scored in the two rolls after a strike are counted twice as a bonus",
     "property": "score",
     "input": {
-      "previous_rolls": [10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+      "previousRolls": [10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     },
     "expected": 26
   }, {
     "description": "consecutive strikes each get the two roll bonus",
     "property": "score",
     "input": {
-      "previous_rolls": [10, 10, 10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+      "previousRolls": [10, 10, 10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     },
     "expected": 81
   }, {
     "description": "a strike in the last frame gets a two roll bonus that is counted once",
     "property": "score",
     "input": {
-      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 1]
+      "previousRolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 1]
     },
     "expected": 18
   }, {
     "description": "rolling a spare with the two roll bonus does not get a bonus roll",
     "property": "score",
     "input": {
-      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 3]
+      "previousRolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 3]
     },
     "expected": 20
   }, {
     "description": "strikes with the two roll bonus do not get bonus rolls",
     "property": "score",
     "input": {
-      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 10]
+      "previousRolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 10]
     },
     "expected": 30
   }, {
     "description": "a strike with the one roll bonus after a spare in the last frame does not get a bonus",
     "property": "score",
     "input": {
-      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 10]
+      "previousRolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 10]
     },
     "expected": 20
   }, {
     "description": "all strikes is a perfect game",
     "property": "score",
     "input": {
-      "previous_rolls": [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10]
+      "previousRolls": [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10]
     },
     "expected": 300
   }, {
     "description": "rolls cannot score negative points",
     "property": "roll",
     "input": {
-      "previous_rolls": [],
+      "previousRolls": [],
       "roll": -1
     },
     "expected": {"error": "Negative roll is invalid"}
@@ -130,7 +130,7 @@
     "description": "a roll cannot score more than 10 points",
     "property": "roll",
     "input": {
-      "previous_rolls": [],
+      "previousRolls": [],
       "roll": 11
     },
     "expected": {"error": "Pin count exceeds pins on the lane"}
@@ -138,7 +138,7 @@
     "description": "two rolls in a frame cannot score more than 10 points",
     "property": "roll",
     "input": {
-      "previous_rolls": [5],
+      "previousRolls": [5],
       "roll": 6
     },
     "expected": {"error": "Pin count exceeds pins on the lane"}
@@ -146,7 +146,7 @@
     "description": "bonus roll after a strike in the last frame cannot score more than 10 points",
     "property": "roll",
     "input": {
-      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10],
+      "previousRolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10],
       "roll": 11
     },
     "expected": {"error": "Pin count exceeds pins on the lane"}
@@ -154,7 +154,7 @@
     "description": "two bonus rolls after a strike in the last frame cannot score more than 10 points",
     "property": "roll",
     "input": {
-      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 5],
+      "previousRolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 5],
       "roll": 6
     },
     "expected": {"error": "Pin count exceeds pins on the lane"}
@@ -162,14 +162,14 @@
     "description": "two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike",
     "property": "score",
     "input": {
-      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 6]
+      "previousRolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 6]
     },
     "expected": 26
   }, {
     "description": "the second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike",
     "property": "roll",
     "input": {
-      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 6],
+      "previousRolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 6],
       "roll": 10
     },
     "expected": {"error": "Pin count exceeds pins on the lane"}
@@ -177,7 +177,7 @@
     "description": "second bonus roll after a strike in the last frame cannot score more than 10 points",
     "property": "roll",
     "input": {
-      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10],
+      "previousRolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10],
       "roll": 11
     },
     "expected": {"error": "Pin count exceeds pins on the lane"}
@@ -185,21 +185,21 @@
     "description": "an unstarted game cannot be scored",
     "property": "score",
     "input": {
-      "previous_rolls": []
+      "previousRolls": []
     },
     "expected": {"error": "Score cannot be taken until the end of the game"}
   }, {
     "description": "an incomplete game cannot be scored",
     "property": "score",
     "input": {
-      "previous_rolls": [0, 0]
+      "previousRolls": [0, 0]
     },
     "expected": {"error": "Score cannot be taken until the end of the game"}
   }, {
     "description": "cannot roll if game already has ten frames",
     "property": "roll",
     "input": {
-      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "previousRolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
       "roll": 0
     },
     "expected": {"error": "Cannot roll after game is over"}
@@ -207,21 +207,21 @@
     "description": "bonus rolls for a strike in the last frame must be rolled before score can be calculated",
     "property": "score",
     "input": {
-      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
+      "previousRolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
     },
     "expected": {"error": "Score cannot be taken until the end of the game"}
   }, {
     "description": "both bonus rolls for a strike in the last frame must be rolled before score can be calculated",
     "property": "score",
     "input": {
-      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10]
+      "previousRolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10]
     },
     "expected": {"error": "Score cannot be taken until the end of the game"}
   }, {
     "description": "bonus roll for a spare in the last frame must be rolled before score can be calculated",
     "property": "score",
     "input": {
-      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3]
+      "previousRolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3]
     },
     "expected": {"error": "Score cannot be taken until the end of the game"}
   }]

--- a/exercises/bowling/canonical-data.json
+++ b/exercises/bowling/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "bowling",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "comments": [
     "Students should implement roll and score methods.",
     "Roll should accept a single integer.",

--- a/exercises/bowling/canonical-data.json
+++ b/exercises/bowling/canonical-data.json
@@ -23,150 +23,206 @@
   "cases": [{
     "description": "should be able to score a game with all zeros",
     "property": "score",
-    "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    "input": {
+      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    },
     "expected": 0
   }, {
     "description": "should be able to score a game with no strikes or spares",
     "property": "score",
-    "previous_rolls": [3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6],
+    "input": {
+      "previous_rolls": [3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6]
+    },
     "expected": 90
   }, {
     "description": "a spare followed by zeros is worth ten points",
     "property": "score",
-    "previous_rolls": [6, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    "input": {
+      "previous_rolls": [6, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    },
     "expected": 10
   }, {
     "description": "points scored in the roll after a spare are counted twice",
     "property": "score",
-    "previous_rolls": [6, 4, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    "input": {
+      "previous_rolls": [6, 4, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    },
     "expected": 16
   }, {
     "description": "consecutive spares each get a one roll bonus",
     "property": "score",
-    "previous_rolls": [5, 5, 3, 7, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    "input": {
+      "previous_rolls": [5, 5, 3, 7, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    },
     "expected": 31
   }, {
     "description": "a spare in the last frame gets a one roll bonus that is counted once",
     "property": "score",
-    "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 7],
+    "input": {
+      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 7]
+    },
     "expected": 17
   }, {
     "description": "a strike earns ten points in a frame with a single roll",
     "property": "score",
-    "previous_rolls": [10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    "input": {
+      "previous_rolls": [10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    },
     "expected": 10
   }, {
     "description": "points scored in the two rolls after a strike are counted twice as a bonus",
     "property": "score",
-    "previous_rolls": [10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    "input": {
+      "previous_rolls": [10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    },
     "expected": 26
   }, {
     "description": "consecutive strikes each get the two roll bonus",
     "property": "score",
-    "previous_rolls": [10, 10, 10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    "input": {
+      "previous_rolls": [10, 10, 10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    },
     "expected": 81
   }, {
     "description": "a strike in the last frame gets a two roll bonus that is counted once",
     "property": "score",
-    "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 1],
+    "input": {
+      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 1]
+    },
     "expected": 18
   }, {
     "description": "rolling a spare with the two roll bonus does not get a bonus roll",
     "property": "score",
-    "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 3],
+    "input": {
+      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 3]
+    },
     "expected": 20
   }, {
     "description": "strikes with the two roll bonus do not get bonus rolls",
     "property": "score",
-    "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 10],
+    "input": {
+      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 10]
+    },
     "expected": 30
   }, {
     "description": "a strike with the one roll bonus after a spare in the last frame does not get a bonus",
     "property": "score",
-    "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 10],
+    "input": {
+      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 10]
+    },
     "expected": 20
   }, {
     "description": "all strikes is a perfect game",
     "property": "score",
-    "previous_rolls": [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10],
+    "input": {
+      "previous_rolls": [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10]
+    },
     "expected": 300
   }, {
     "description": "rolls cannot score negative points",
     "property": "roll",
-    "previous_rolls": [],
-    "roll": -1,
+    "input": {
+      "previous_rolls": [],
+      "roll": -1
+    },
     "expected": {"error": "Negative roll is invalid"}
   }, {
     "description": "a roll cannot score more than 10 points",
     "property": "roll",
-    "previous_rolls": [],
-    "roll": 11,
+    "input": {
+      "previous_rolls": [],
+      "roll": 11
+    },
     "expected": {"error": "Pin count exceeds pins on the lane"}
   }, {
     "description": "two rolls in a frame cannot score more than 10 points",
     "property": "roll",
-    "previous_rolls": [5],
-    "roll": 6,
+    "input": {
+      "previous_rolls": [5],
+      "roll": 6
+    },
     "expected": {"error": "Pin count exceeds pins on the lane"}
   }, {
     "description": "bonus roll after a strike in the last frame cannot score more than 10 points",
     "property": "roll",
-    "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10],
-    "roll": 11,
+    "input": {
+      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10],
+      "roll": 11
+    },
     "expected": {"error": "Pin count exceeds pins on the lane"}
   }, {
     "description": "two bonus rolls after a strike in the last frame cannot score more than 10 points",
     "property": "roll",
-    "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 5],
-    "roll": 6,
+    "input": {
+      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 5],
+      "roll": 6
+    },
     "expected": {"error": "Pin count exceeds pins on the lane"}
   }, {
     "description": "two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike",
     "property": "score",
-    "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 6],
+    "input": {
+      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 6]
+    },
     "expected": 26
   }, {
     "description": "the second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike",
     "property": "roll",
-    "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 6],
-    "roll": 10,
+    "input": {
+      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 6],
+      "roll": 10
+    },
     "expected": {"error": "Pin count exceeds pins on the lane"}
   }, {
     "description": "second bonus roll after a strike in the last frame cannot score more than 10 points",
     "property": "roll",
-    "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10],
-    "roll": 11,
+    "input": {
+      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10],
+      "roll": 11
+    },
     "expected": {"error": "Pin count exceeds pins on the lane"}
   }, {
     "description": "an unstarted game cannot be scored",
     "property": "score",
-    "previous_rolls": [],
+    "input": {
+      "previous_rolls": []
+    },
     "expected": {"error": "Score cannot be taken until the end of the game"}
   }, {
     "description": "an incomplete game cannot be scored",
     "property": "score",
-    "previous_rolls": [0, 0],
+    "input": {
+      "previous_rolls": [0, 0]
+    },
     "expected": {"error": "Score cannot be taken until the end of the game"}
   }, {
     "description": "cannot roll if game already has ten frames",
     "property": "roll",
-    "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "roll": 0,
+    "input": {
+      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "roll": 0
+    },
     "expected": {"error": "Cannot roll after game is over"}
   }, {
     "description": "bonus rolls for a strike in the last frame must be rolled before score can be calculated",
     "property": "score",
-    "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10],
+    "input": {
+      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10]
+    },
     "expected": {"error": "Score cannot be taken until the end of the game"}
   }, {
     "description": "both bonus rolls for a strike in the last frame must be rolled before score can be calculated",
     "property": "score",
-    "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10],
+    "input": {
+      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10]
+    },
     "expected": {"error": "Score cannot be taken until the end of the game"}
   }, {
     "description": "bonus roll for a spare in the last frame must be rolled before score can be calculated",
     "property": "score",
-    "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3],
+    "input": {
+      "previous_rolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3]
+    },
     "expected": {"error": "Score cannot be taken until the end of the game"}
   }]
 }


### PR DESCRIPTION
Updates canonical data to be in compliance with #996 and #987.