### PR TITLE
book-store: convert to fixed point output

### DIFF
--- a/exercises/book-store/canonical-data.json
+++ b/exercises/book-store/canonical-data.json
@@ -9,7 +9,8 @@
         "a single series.  There is no discount advantage for having more than ",
         "one copy of any single book in a grouping.",
         "implementors should use proper fixed-point or currency data types of the ",
-        "corresponding language and not float."
+        "corresponding language and not float.",
+        "All 'expected' amounts are in cents."
       ],
       "cases": [
         {

--- a/exercises/book-store/canonical-data.json
+++ b/exercises/book-store/canonical-data.json
@@ -1,13 +1,15 @@
 {
   "exercise": "book-store",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "cases": [
     {
       "description": "Return the total basket price after applying the best discount.",
       "comments": [
         "Calculate lowest price for a shopping basket containing books only from ",
         "a single series.  There is no discount advantage for having more than ",
-        "one copy of any single book in a grouping."
+        "one copy of any single book in a grouping.",
+        "implementors should use proper fixed-point or currency data types of the ",
+        "corresponding language and not float."
       ],
       "cases": [
         {
@@ -17,7 +19,7 @@
          "input": {
            "basket": [1]
          },
-         "expected": 8.00
+         "expected": 800
         },
         {
          "property": "total",
@@ -26,7 +28,7 @@
          "input": {
            "basket": [2,2]
          },
-         "expected": 16.00
+         "expected": 1600
         },
         {
          "property": "total",
@@ -35,7 +37,7 @@
          "input": {
            "basket": []
          },
-         "expected": 0.00
+         "expected": 0
         },
         {
          "property": "total",
@@ -44,7 +46,7 @@
          "input": {
            "basket": [1,2]
          },
-         "expected": 15.20
+         "expected": 1520
         },
         {
          "property": "total",
@@ -53,7 +55,7 @@
          "input": {
            "basket": [1,2,3]
          },
-         "expected": 21.60
+         "expected": 2160
         },
         {
          "property": "total",
@@ -62,7 +64,7 @@
          "input": {
            "basket": [1,2,3,4]
          },
-         "expected": 25.60
+         "expected": 2560
         },
         {
          "property": "total",
@@ -71,7 +73,7 @@
          "input": {
            "basket": [1,2,3,4,5]
          },
-         "expected": 30.00
+         "expected": 3000
         },
         {
          "property": "total",
@@ -80,7 +82,7 @@
          "input": {
            "basket": [1,1,2,2,3,3,4,5]
          },
-         "expected": 51.20
+         "expected": 5120
         },
         {
          "property": "total",
@@ -89,7 +91,7 @@
          "input": {
            "basket": [1,1,2,2,3,4]
          },
-         "expected": 40.80
+         "expected": 4080
         },
         {
          "property": "total",
@@ -98,7 +100,7 @@
          "input": {
            "basket": [1,1,2,2,3,3,4,4,5]
          },
-         "expected": 55.60
+         "expected": 5560
         },
         {
          "property": "total",
@@ -107,7 +109,7 @@
          "input": {
            "basket": [1,1,2,2,3,3,4,4,5,5]
          },
-         "expected": 60.00
+         "expected": 6000
         },
         {
          "property": "total",
@@ -116,7 +118,7 @@
          "input": {
            "basket": [1,1,2,2,3,3,4,4,5,5,1]
          },
-         "expected": 68.00
+         "expected": 6800
         },
         {
          "property": "total",
@@ -125,7 +127,7 @@
          "input": {
            "basket": [1,1,2,2,3,3,4,4,5,5,1,2]
          },
-         "expected": 75.20
+         "expected": 7520
         },
         {
          "property": "total",
@@ -134,7 +136,7 @@
          "input": {
            "basket": [1,1,2,2,3,3,4,5,1,1,2,2,3,3,4,5]
          },
-         "expected": 102.4
+         "expected": 10240
         }
      ]
     }


### PR DESCRIPTION
Convert "expected" output to fixed point (cents) to remove floating point values.
closes #964