### PR TITLE
phone-number: add missing edge cases

### DIFF
--- a/exercises/phone-number/canonical-data.json
+++ b/exercises/phone-number/canonical-data.json
@@ -93,7 +93,7 @@
           "property": "clean",
           "phrase": "(223) 156-7890",
           "expected": null
-        },
+        }
       ]
     }
   ]

--- a/exercises/phone-number/canonical-data.json
+++ b/exercises/phone-number/canonical-data.json
@@ -71,39 +71,29 @@
           "expected": null
         },
         {
-          "description": "invalid if area code does not start with 2-9",
-          "cases": [
-            {
-              "description": "invalid if area code starts with 0",
-              "property": "clean",
-              "phrase": "(023) 456-7890",
-              "expected": null
-            },
-            {
-              "description": "invalid if area code starts with 1",
-              "property": "clean",
-              "phrase": "(123) 456-7890",
-              "expected": null
-            }
-          ]
+          "description": "invalid if area code starts with 0",
+          "property": "clean",
+          "phrase": "(023) 456-7890",
+          "expected": null
         },
         {
-          "description": "invalid if exchange code does not start with 2-9",
-          "cases": [
-            {
-              "description": "invalid if exchange code starts with 0",
-              "property": "clean",
-              "phrase": "(223) 056-7890",
-              "expected": null
-            },
-            {
-              "description": "invalid if exchange code starts with 1",
-              "property": "clean",
-              "phrase": "(223) 156-7890",
-              "expected": null
-            }
-          ]
-        }
+          "description": "invalid if area code starts with 1",
+          "property": "clean",
+          "phrase": "(123) 456-7890",
+          "expected": null
+        },
+        {
+          "description": "invalid if exchange code starts with 0",
+          "property": "clean",
+          "phrase": "(223) 056-7890",
+          "expected": null
+        },
+        {
+          "description": "invalid if exchange code starts with 1",
+          "property": "clean",
+          "phrase": "(223) 156-7890",
+          "expected": null
+        },
       ]
     }
   ]

--- a/exercises/phone-number/canonical-data.json
+++ b/exercises/phone-number/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "phone-number",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "cases": [
     {
       "description": "Cleanup user-entered phone numbers",

--- a/exercises/phone-number/canonical-data.json
+++ b/exercises/phone-number/canonical-data.json
@@ -72,15 +72,37 @@
         },
         {
           "description": "invalid if area code does not start with 2-9",
-          "property": "clean",
-          "phrase": "(123) 456-7890",
-          "expected": null
+          "cases": [
+            {
+              "description": "invalid if area code starts with 0",
+              "property": "clean",
+              "phrase": "(023) 456-7890",
+              "expected": null
+            },
+            {
+              "description": "invalid if area code starts with 1",
+              "property": "clean",
+              "phrase": "(123) 456-7890",
+              "expected": null
+            }
+          ]
         },
         {
           "description": "invalid if exchange code does not start with 2-9",
-          "property": "clean",
-          "phrase": "(223) 056-7890",
-          "expected": null
+          "cases": [
+            {
+              "description": "invalid if exchange code starts with 0",
+              "property": "clean",
+              "phrase": "(223) 056-7890",
+              "expected": null
+            },
+            {
+              "description": "invalid if exchange code starts with 1",
+              "property": "clean",
+              "phrase": "(223) 156-7890",
+              "expected": null
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
The existing descriptions for invalid area codes and exchange codes both cite a range, but only test a single value. This PR tests for all values outside the valid range.