### PR TITLE
two-bucket: remove broken link

### DIFF
--- a/exercises/two-bucket/description.md
+++ b/exercises/two-bucket/description.md
@@ -25,4 +25,4 @@ To conclude, the only valid moves are:
 - emptying one bucket and doing nothing to the other
 - filling one bucket and doing nothing to the other
 
-Written with <3 at [Fullstack Academy](http://www.fullstackacademy.com/) by [Lindsay](http://lindsaylevine.com).
+Written with <3 at [Fullstack Academy](http://www.fullstackacademy.com/) by Lindsay Levine.


### PR DESCRIPTION
Looks like the link in two-bucket READMEs to http://lindsaylevine.com/ doesn't seem to work anymore.

I've had a quick look and http://lindsay.engineer is a website that does seem to work, though I am not 100% sure if it is the same person or not! I've removed the link for now and replaced with a full name, though if other people know that the other website is actually correct then I'm happy to update it to that too :slightly_smiling_face: 