### PR TITLE
complex-numbers: exponential of complex number

### DIFF
--- a/exercises/complex-numbers/canonical-data.json
+++ b/exercises/complex-numbers/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "complex-numbers",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "comments": [
     " The canonical data assumes mathematically correct real   ",
     " numbers. The testsuites should consider rounding errors  ",

--- a/exercises/complex-numbers/canonical-data.json
+++ b/exercises/complex-numbers/canonical-data.json
@@ -327,7 +327,9 @@
         {
           "description": "Exponential of a number with real and imaginary part",
           "property": "exp",
-          "input": ["ln(2)", "pi"],
+          "input": {
+            "z": ["ln(2)", "pi"]
+          },
           "expected": [2, 0]
         }
       ]

--- a/exercises/complex-numbers/canonical-data.json
+++ b/exercises/complex-numbers/canonical-data.json
@@ -323,6 +323,12 @@
             "z": [1, 0]
           },
           "expected": ["e", 0]
+        },
+        {
+          "description": "Exponential of a number with real and imaginary part",
+          "property": "exp",
+          "input": ["ln(2)", "pi"],
+          "expected": [2, 0]
         }
       ]
     }

--- a/exercises/complex-numbers/canonical-data.json
+++ b/exercises/complex-numbers/canonical-data.json
@@ -330,7 +330,7 @@
           "input": {
             "z": ["ln(2)", "pi"]
           },
-          "expected": [2, 0]
+          "expected": [-2, 0]
         }
       ]
     }


### PR DESCRIPTION
For some reason, there was no test for exp(a + bi) where a + bi has both a real part and an imaginary part. This PR adds such a test with exact values that are simple to define (requiring no rounded values).

Proof:
```
e^(ln(2) + PI * i) = e^ln(2) * e^(PI * i)
e^ln(2) = 2
e^(PI * i) = cos(PI) + isin(PI) = -1 + 0i = -1
e^(ln(2) + PI * i) = 2 * -1 = -2
```