### PR TITLE
list-ops: Normalize format of functions

### DIFF
--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "list-ops",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "comments": [
     "Though there are no specifications here for dealing with large lists,",
     "implementers may add tests for handling large lists to ensure that the",
@@ -57,14 +57,14 @@
           "description": "empty list",
           "property": "filter",
           "list": [],
-          "function": "value modulo 2 == 1",
+          "function": "(x) -> x modulo 2 == 1",
           "expected": []
         },
         {
           "description": "non-empty list",
           "property": "filter",
           "list": [1, 2, 3, 5],
-          "function": "value modulo 2 == 1",
+          "function": "(x) -> x modulo 2 == 1",
           "expected": [1, 3, 5]
         }
       ]
@@ -87,20 +87,20 @@
       ]
     },
     {
-      "description": "return a list of elements whos values equal the list value transformed by the mapping function",
+      "description": "return a list of elements whose values equal the list value transformed by the mapping function",
       "cases": [
         {
           "description": "empty list",
           "property": "map",
           "list": [],
-          "function": "value + 1",
+          "function": "(x) -> x + 1",
           "expected": []
         },
         {
           "description": "non-empty list",
           "property": "map",
           "list": [1, 3, 5, 7],
-          "function": "value + 1",
+          "function": "(x) -> x + 1",
           "expected": [2, 4, 6, 8]
         }
       ]


### PR DESCRIPTION
There were two formats being used to define a function:

1. A unary function where the parameter is not defined by assumed to be named `value`. Example: `value + 1`
2. A binary function where the parameters are defined by `(x, y)`. Example: `(x, y) -> x + y`