### PR TITLE
 hamming: move inputs (strand1, strand2) to input object

### DIFF
--- a/exercises/hamming/canonical-data.json
+++ b/exercises/hamming/canonical-data.json
@@ -101,7 +101,7 @@
     {
       "description": "large distance in off-by-one strand",
       "property": "distance",
-      "strand1":  "GGACGGATTCTG",
+      "strand1": "GGACGGATTCTG",
       "strand2": "AGGACGGATTCT",
       "expected": 9
     },

--- a/exercises/hamming/canonical-data.json
+++ b/exercises/hamming/canonical-data.json
@@ -1,6 +1,6 @@
 {
 "exercise": "hamming",
-"version": "2.0.1",
+"version": "2.1.0",
   "comments": [
     "Language implementations vary on the issue of unequal length strands.",
     "A language may elect to simplify this task by only presenting equal",
@@ -17,106 +17,136 @@
     {
       "description": "empty strands",
       "property": "distance",
-      "strand1": "",
-      "strand2": "",
+      "input": {
+        "strand1": "",
+        "strand2": ""
+      },
       "expected": 0
     },
     {
       "description": "identical strands",
       "property": "distance",
-      "strand1": "A",
-      "strand2": "A",
+      "input": {
+        "strand1": "A",
+        "strand2": "A"
+      },
       "expected": 0
     },
     {
       "description": "long identical strands",
       "property": "distance",
-      "strand1": "GGACTGA",
-      "strand2": "GGACTGA",
+      "input": {
+        "strand1": "GGACTGA",
+        "strand2": "GGACTGA"
+      },
       "expected": 0
     },
     {
       "description": "complete distance in single nucleotide strands",
       "property": "distance",
-      "strand1": "A",
-      "strand2": "G",
+      "input": {
+        "strand1": "A",
+        "strand2": "G"
+      },
       "expected": 1
     },
     {
       "description": "complete distance in small strands",
       "property": "distance",
-      "strand1": "AG",
-      "strand2": "CT",
+      "input": {
+        "strand1": "AG",
+        "strand2": "CT"
+      },
       "expected": 2
     },
     {
       "description": "small distance in small strands",
       "property": "distance",
-      "strand1": "AT",
-      "strand2": "CT",
+      "input": {
+        "strand1": "AT",
+        "strand2": "CT"
+      },
       "expected": 1
     },
     {
       "description": "small distance",
       "property": "distance",
-      "strand1": "GGACG",
-      "strand2": "GGTCG",
+      "input": {
+        "strand1": "GGACG",
+        "strand2": "GGTCG"
+      },
       "expected": 1
     },
     {
       "description": "small distance in long strands",
       "property": "distance",
-      "strand1": "ACCAGGG",
-      "strand2": "ACTATGG",
+      "input": {
+        "strand1": "ACCAGGG",
+        "strand2": "ACTATGG"
+      },
       "expected": 2
     },
     {
       "description": "non-unique character in first strand",
       "property": "distance",
-      "strand1": "AAG",
-      "strand2": "AAA",
+      "input": {
+        "strand1": "AAG",
+        "strand2": "AAA"
+      },
       "expected": 1
     },
     {
       "description": "non-unique character in second strand",
       "property": "distance",
-      "strand1": "AAA",
-      "strand2": "AAG",
+      "input": {
+        "strand1": "AAA",
+        "strand2": "AAG"
+      },
       "expected": 1
     },
     {
       "description": "same nucleotides in different positions",
       "property": "distance",
-      "strand1": "TAG",
-      "strand2": "GAT",
+      "input": {
+        "strand1": "TAG",
+        "strand2": "GAT"
+      },
       "expected": 2
     },
     {
       "description": "large distance",
       "property": "distance",
-      "strand1": "GATACA",
-      "strand2": "GCATAA",
+      "input": {
+        "strand1": "GATACA",
+        "strand2": "GCATAA"
+      },
       "expected": 4
     },
     {
       "description": "large distance in off-by-one strand",
       "property": "distance",
-      "strand1": "GGACGGATTCTG",
-      "strand2": "AGGACGGATTCT",
+      "input": {
+        "strand1": "GGACGGATTCTG",
+        "strand2": "AGGACGGATTCT"
+      },
       "expected": 9
     },
     {
       "description": "disallow first strand longer",
       "property": "distance",
-      "strand1": "AATG",
-      "strand2": "AAA",
+      "input": {
+        "strand1": "AATG",
+        "strand2": "AAA"
+      },
       "expected": {"error": "left and right strands must be of equal length"}
     },
     {
       "description": "disallow second strand longer",
       "property": "distance",
-      "strand1": "ATA",
-      "strand2": "AGTG",
+      "input": {
+        "strand1": "ATA",
+        "strand2": "AGTG"
+      },
       "expected": {"error": "left and right strands must be of equal length"}
     }
   ]


### PR DESCRIPTION
hamming 2.1.0

As proposed and accepted in #996

```ruby
indent = false

ARGF.each_line { |l|
  if l.include?('version')
    ver = l.split(?")[3]
    ver_components = ver.split(?.).map(&:to_i)
    ver_components[1] += 1
    ver_components[2] = 0
    l[ver] = ver_components.join(?.)
  end

  first_non_space = l.index(?")
  if l.include?('strand1')
    puts ' ' * first_non_space + '"input": {'
    indent = true
  end
  l.delete!(?,) if l.include?('strand2')
  puts "#{'  ' if indent}#{l}"
  if l.include?('strand2')
    puts ' ' * first_non_space + '},'
    indent = false
  end
}
```