### PR TITLE
 react: Move inputs (cells, operations) to input object

### DIFF
--- a/exercises/react/canonical-data.json
+++ b/exercises/react/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "react",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "comments": [
     "Note that, due to the nature of this exercise,",
     "the tests are specified using their cells and a series of operations to perform on the cells.",
@@ -46,321 +46,339 @@
     {
       "description": "input cells have a value",
       "property": "react",
-      "cells": [
-        {
-          "name": "input",
-          "type": "input",
-          "initial_value": 10
-        }
-      ],
-      "operations": [
-        {
-          "type": "expect_cell_value",
-          "cell": "input",
-          "value": 10
-        }
-      ],
+      "input": {
+        "cells": [
+          {
+            "name": "input",
+            "type": "input",
+            "initial_value": 10
+          }
+        ],
+        "operations": [
+          {
+            "type": "expect_cell_value",
+            "cell": "input",
+            "value": 10
+          }
+        ]
+      },
       "expected": {}
     },
     {
       "description": "an input cell's value can be set",
       "property": "react",
-      "cells": [
-        {
-          "name": "input",
-          "type": "input",
-          "initial_value": 4
-        }
-      ],
-      "operations": [
-        {
-          "type": "set_value",
-          "cell": "input",
-          "value": 20
-        },
-        {
-          "type": "expect_cell_value",
-          "cell": "input",
-          "value": 20
-        }
-      ],
+      "input": {
+        "cells": [
+          {
+            "name": "input",
+            "type": "input",
+            "initial_value": 4
+          }
+        ],
+        "operations": [
+          {
+            "type": "set_value",
+            "cell": "input",
+            "value": 20
+          },
+          {
+            "type": "expect_cell_value",
+            "cell": "input",
+            "value": 20
+          }
+        ]
+      },
       "expected": {}
     },
     {
       "description": "compute cells calculate initial value",
       "property": "react",
-      "cells": [
-        {
-          "name": "input",
-          "type": "input",
-          "initial_value": 1
-        },
-        {
-          "name": "output",
-          "type": "compute",
-          "inputs": ["input"],
-          "compute_function": "inputs[0] + 1"
-        }
-      ],
-      "operations": [
-        {
-          "type": "expect_cell_value",
-          "cell": "output",
-          "value": 2
-        }
-      ],
+      "input": {
+        "cells": [
+          {
+            "name": "input",
+            "type": "input",
+            "initial_value": 1
+          },
+          {
+            "name": "output",
+            "type": "compute",
+            "inputs": ["input"],
+            "compute_function": "inputs[0] + 1"
+          }
+        ],
+        "operations": [
+          {
+            "type": "expect_cell_value",
+            "cell": "output",
+            "value": 2
+          }
+        ]
+      },
       "expected": {}
     },
     {
       "description": "compute cells take inputs in the right order",
       "property": "react",
-      "cells": [
-        {
-          "name": "one",
-          "type": "input",
-          "initial_value": 1
-        },
-        {
-          "name": "two",
-          "type": "input",
-          "initial_value": 2
-        },
-        {
-          "name": "output",
-          "type": "compute",
-          "inputs": ["one", "two"],
-          "compute_function": "inputs[0] + inputs[1] * 10"
-        }
-      ],
-      "operations": [
-        {
-          "type": "expect_cell_value",
-          "cell": "output",
-          "value": 21
-        }
-      ],
+      "input": {
+        "cells": [
+          {
+            "name": "one",
+            "type": "input",
+            "initial_value": 1
+          },
+          {
+            "name": "two",
+            "type": "input",
+            "initial_value": 2
+          },
+          {
+            "name": "output",
+            "type": "compute",
+            "inputs": ["one", "two"],
+            "compute_function": "inputs[0] + inputs[1] * 10"
+          }
+        ],
+        "operations": [
+          {
+            "type": "expect_cell_value",
+            "cell": "output",
+            "value": 21
+          }
+        ]
+      },
       "expected": {}
     },
     {
       "description": "compute cells update value when dependencies are changed",
       "property": "react",
-      "cells": [
-        {
-          "name": "input",
-          "type": "input",
-          "initial_value": 1
-        },
-        {
-          "name": "output",
-          "type": "compute",
-          "inputs": ["input"],
-          "compute_function": "inputs[0] + 1"
-        }
-      ],
-      "operations": [
-        {
-          "type": "set_value",
-          "cell": "input",
-          "value": 3
-        },
-        {
-          "type": "expect_cell_value",
-          "cell": "output",
-          "value": 4
-        }
-      ],
+      "input": {
+        "cells": [
+          {
+            "name": "input",
+            "type": "input",
+            "initial_value": 1
+          },
+          {
+            "name": "output",
+            "type": "compute",
+            "inputs": ["input"],
+            "compute_function": "inputs[0] + 1"
+          }
+        ],
+        "operations": [
+          {
+            "type": "set_value",
+            "cell": "input",
+            "value": 3
+          },
+          {
+            "type": "expect_cell_value",
+            "cell": "output",
+            "value": 4
+          }
+        ]
+      },
       "expected": {}
     },
     {
       "description": "compute cells can depend on other compute cells",
       "property": "react",
-      "cells": [
-        {
-          "name": "input",
-          "type": "input",
-          "initial_value": 1
-        },
-        {
-          "name": "times_two",
-          "type": "compute",
-          "inputs": ["input"],
-          "compute_function": "inputs[0] * 2"
-        },
-        {
-          "name": "times_thirty",
-          "type": "compute",
-          "inputs": ["input"],
-          "compute_function": "inputs[0] * 30"
-        },
-        {
-          "name": "output",
-          "type": "compute",
-          "inputs": ["times_two", "times_thirty"],
-          "compute_function": "inputs[0] + inputs[1]"
-        }
-      ],
-      "operations": [
-        {
-          "type": "expect_cell_value",
-          "cell": "output",
-          "value": 32
-        },
-        {
-          "type": "set_value",
-          "cell": "input",
-          "value": 3
-        },
-        {
-          "type": "expect_cell_value",
-          "cell": "output",
-          "value": 96
-        }
-      ],
+      "input": {
+        "cells": [
+          {
+            "name": "input",
+            "type": "input",
+            "initial_value": 1
+          },
+          {
+            "name": "times_two",
+            "type": "compute",
+            "inputs": ["input"],
+            "compute_function": "inputs[0] * 2"
+          },
+          {
+            "name": "times_thirty",
+            "type": "compute",
+            "inputs": ["input"],
+            "compute_function": "inputs[0] * 30"
+          },
+          {
+            "name": "output",
+            "type": "compute",
+            "inputs": ["times_two", "times_thirty"],
+            "compute_function": "inputs[0] + inputs[1]"
+          }
+        ],
+        "operations": [
+          {
+            "type": "expect_cell_value",
+            "cell": "output",
+            "value": 32
+          },
+          {
+            "type": "set_value",
+            "cell": "input",
+            "value": 3
+          },
+          {
+            "type": "expect_cell_value",
+            "cell": "output",
+            "value": 96
+          }
+        ]
+      },
       "expected": {}
     },
     {
       "description": "compute cells fire callbacks",
       "property": "react",
-      "cells": [
-        {
-          "name": "input",
-          "type": "input",
-          "initial_value": 1
-        },
-        {
-          "name": "output",
-          "type": "compute",
-          "inputs": ["input"],
-          "compute_function": "inputs[0] + 1"
-        }
-      ],
-      "operations": [
-        {
-          "type": "add_callback",
-          "cell": "output",
-          "name": "callback1"
-        },
-        {
-          "type": "set_value",
-          "cell": "input",
-          "value": 3
-        },
-        {
-          "type": "expect_callback_values",
-          "callback": "callback1",
-          "values": [4]
-        }
-      ],
+      "input": {
+        "cells": [
+          {
+            "name": "input",
+            "type": "input",
+            "initial_value": 1
+          },
+          {
+            "name": "output",
+            "type": "compute",
+            "inputs": ["input"],
+            "compute_function": "inputs[0] + 1"
+          }
+        ],
+        "operations": [
+          {
+            "type": "add_callback",
+            "cell": "output",
+            "name": "callback1"
+          },
+          {
+            "type": "set_value",
+            "cell": "input",
+            "value": 3
+          },
+          {
+            "type": "expect_callback_values",
+            "callback": "callback1",
+            "values": [4]
+          }
+        ]
+      },
       "expected": {}
     },
     {
       "description": "callback cells only fire on change",
       "property": "react",
-      "cells": [
-        {
-          "name": "input",
-          "type": "input",
-          "initial_value": 1
-        },
-        {
-          "name": "output",
-          "type": "compute",
-          "inputs": ["input"],
-          "compute_function": "if inputs[0] < 3 then 111 else 222"
-        }
-      ],
-      "operations": [
-        {
-          "type": "add_callback",
-          "cell": "output",
-          "name": "callback1"
-        },
-        {
-          "type": "set_value",
-          "cell": "input",
-          "value": 2
-        },
-        {
-          "type": "expect_callback_values",
-          "callback": "callback1",
-          "values": []
-        },
-        {
-          "type": "set_value",
-          "cell": "input",
-          "value": 4
-        },
-        {
-          "type": "expect_callback_values",
-          "callback": "callback1",
-          "values": [222]
-        }
-      ],
+      "input": {
+        "cells": [
+          {
+            "name": "input",
+            "type": "input",
+            "initial_value": 1
+          },
+          {
+            "name": "output",
+            "type": "compute",
+            "inputs": ["input"],
+            "compute_function": "if inputs[0] < 3 then 111 else 222"
+          }
+        ],
+        "operations": [
+          {
+            "type": "add_callback",
+            "cell": "output",
+            "name": "callback1"
+          },
+          {
+            "type": "set_value",
+            "cell": "input",
+            "value": 2
+          },
+          {
+            "type": "expect_callback_values",
+            "callback": "callback1",
+            "values": []
+          },
+          {
+            "type": "set_value",
+            "cell": "input",
+            "value": 4
+          },
+          {
+            "type": "expect_callback_values",
+            "callback": "callback1",
+            "values": [222]
+          }
+        ]
+      },
       "expected": {}
     },
     {
       "description": "callbacks can be added and removed",
       "property": "react",
-      "cells": [
-        {
-          "name": "input",
-          "type": "input",
-          "initial_value": 11
-        },
-        {
-          "name": "output",
-          "type": "compute",
-          "inputs": ["input"],
-          "compute_function": "inputs[0] + 1"
-        }
-      ],
-      "operations": [
-        {
-          "type": "add_callback",
-          "cell": "output",
-          "name": "callback1"
-        },
-        {
-          "type": "add_callback",
-          "cell": "output",
-          "name": "callback2"
-        },
-        {
-          "type": "set_value",
-          "cell": "input",
-          "value": 31
-        },
-        {
-          "type": "remove_callback",
-          "cell": "output",
-          "name": "callback1"
-        },
-        {
-          "type": "add_callback",
-          "cell": "output",
-          "name": "callback3"
-        },
-        {
-          "type": "set_value",
-          "cell": "input",
-          "value": 41
-        },
-        {
-          "type": "expect_callback_values",
-          "callback": "callback1",
-          "values": [32]
-        },
-        {
-          "type": "expect_callback_values",
-          "callback": "callback2",
-          "values": [32, 42]
-        },
-        {
-          "type": "expect_callback_values",
-          "callback": "callback3",
-          "values": [42]
-        }
-      ],
+      "input": {
+        "cells": [
+          {
+            "name": "input",
+            "type": "input",
+            "initial_value": 11
+          },
+          {
+            "name": "output",
+            "type": "compute",
+            "inputs": ["input"],
+            "compute_function": "inputs[0] + 1"
+          }
+        ],
+        "operations": [
+          {
+            "type": "add_callback",
+            "cell": "output",
+            "name": "callback1"
+          },
+          {
+            "type": "add_callback",
+            "cell": "output",
+            "name": "callback2"
+          },
+          {
+            "type": "set_value",
+            "cell": "input",
+            "value": 31
+          },
+          {
+            "type": "remove_callback",
+            "cell": "output",
+            "name": "callback1"
+          },
+          {
+            "type": "add_callback",
+            "cell": "output",
+            "name": "callback3"
+          },
+          {
+            "type": "set_value",
+            "cell": "input",
+            "value": 41
+          },
+          {
+            "type": "expect_callback_values",
+            "callback": "callback1",
+            "values": [32]
+          },
+          {
+            "type": "expect_callback_values",
+            "callback": "callback2",
+            "values": [32, 42]
+          },
+          {
+            "type": "expect_callback_values",
+            "callback": "callback3",
+            "values": [42]
+          }
+        ]
+      },
       "expected": {}
     },
     {
@@ -371,61 +389,63 @@
         "or causes an out of bounds access."
       ],
       "property": "react",
-      "cells": [
-        {
-          "name": "input",
-          "type": "input",
-          "initial_value": 1
-        },
-        {
-          "name": "output",
-          "type": "compute",
-          "inputs": ["input"],
-          "compute_function": "inputs[0] + 1"
-        }
-      ],
-      "operations": [
-        {
-          "type": "add_callback",
-          "cell": "output",
-          "name": "callback1"
-        },
-        {
-          "type": "add_callback",
-          "cell": "output",
-          "name": "callback2"
-        },
-        {
-          "type": "remove_callback",
-          "cell": "output",
-          "name": "callback1"
-        },
-        {
-          "type": "remove_callback",
-          "cell": "output",
-          "name": "callback1"
-        },
-        {
-          "type": "remove_callback",
-          "cell": "output",
-          "name": "callback1"
-        },
-        {
-          "type": "set_value",
-          "cell": "input",
-          "value": 2
-        },
-        {
-          "type": "expect_callback_values",
-          "callback": "callback1",
-          "values": []
-        },
-        {
-          "type": "expect_callback_values",
-          "callback": "callback2",
-          "values": [3]
-        }
-      ],
+      "input": {
+        "cells": [
+          {
+            "name": "input",
+            "type": "input",
+            "initial_value": 1
+          },
+          {
+            "name": "output",
+            "type": "compute",
+            "inputs": ["input"],
+            "compute_function": "inputs[0] + 1"
+          }
+        ],
+        "operations": [
+          {
+            "type": "add_callback",
+            "cell": "output",
+            "name": "callback1"
+          },
+          {
+            "type": "add_callback",
+            "cell": "output",
+            "name": "callback2"
+          },
+          {
+            "type": "remove_callback",
+            "cell": "output",
+            "name": "callback1"
+          },
+          {
+            "type": "remove_callback",
+            "cell": "output",
+            "name": "callback1"
+          },
+          {
+            "type": "remove_callback",
+            "cell": "output",
+            "name": "callback1"
+          },
+          {
+            "type": "set_value",
+            "cell": "input",
+            "value": 2
+          },
+          {
+            "type": "expect_callback_values",
+            "callback": "callback1",
+            "values": []
+          },
+          {
+            "type": "expect_callback_values",
+            "callback": "callback2",
+            "values": [3]
+          }
+        ]
+      },
       "expected": {}
     },
     {
@@ -435,54 +455,56 @@
         "when not all of the inputs of a compute cell have propagated new values."
       ],
       "property": "react",
-      "cells": [
-        {
-          "name": "input",
-          "type": "input",
-          "initial_value": 1
-        },
-        {
-          "name": "plus_one",
-          "type": "compute",
-          "inputs": ["input"],
-          "compute_function": "inputs[0] + 1"
-        },
-        {
-          "name": "minus_one1",
-          "type": "compute",
-          "inputs": ["input"],
-          "compute_function": "inputs[0] - 1"
-        },
-        {
-          "name": "minus_one2",
-          "type": "compute",
-          "inputs": ["minus_one1"],
-          "compute_function": "inputs[0] - 1"
-        },
-        {
-          "name": "output",
-          "type": "compute",
-          "inputs": ["plus_one", "minus_one2"],
-          "compute_function": "inputs[0] * inputs[1]"
-        }
-      ],
-      "operations": [
-        {
-          "type": "add_callback",
-          "cell": "output",
-          "name": "callback1"
-        },
-        {
-          "type": "set_value",
-          "cell": "input",
-          "value": 4
-        },
-        {
-          "type": "expect_callback_values",
-          "callback": "callback1",
-          "values": [10]
-        }
-      ],
+      "input": {
+        "cells": [
+          {
+            "name": "input",
+            "type": "input",
+            "initial_value": 1
+          },
+          {
+            "name": "plus_one",
+            "type": "compute",
+            "inputs": ["input"],
+            "compute_function": "inputs[0] + 1"
+          },
+          {
+            "name": "minus_one1",
+            "type": "compute",
+            "inputs": ["input"],
+            "compute_function": "inputs[0] - 1"
+          },
+          {
+            "name": "minus_one2",
+            "type": "compute",
+            "inputs": ["minus_one1"],
+            "compute_function": "inputs[0] - 1"
+          },
+          {
+            "name": "output",
+            "type": "compute",
+            "inputs": ["plus_one", "minus_one2"],
+            "compute_function": "inputs[0] * inputs[1]"
+          }
+        ],
+        "operations": [
+          {
+            "type": "add_callback",
+            "cell": "output",
+            "name": "callback1"
+          },
+          {
+            "type": "set_value",
+            "cell": "input",
+            "value": 4
+          },
+          {
+            "type": "expect_callback_values",
+            "callback": "callback1",
+            "values": [10]
+          }
+        ]
+      },
       "expected": {}
     },
     {
@@ -493,63 +515,65 @@
         "This is incorrect since the specification indicates only to call callbacks on change."
       ],
       "property": "react",
-      "cells": [
-        {
-          "name": "input",
-          "type": "input",
-          "initial_value": 1
-        },
-        {
-          "name": "plus_one",
-          "type": "compute",
-          "inputs": ["input"],
-          "compute_function": "inputs[0] + 1"
-        },
-        {
-          "name": "minus_one",
-          "type": "compute",
-          "inputs": ["input"],
-          "compute_function": "inputs[0] - 1"
-        },
-        {
-          "name": "always_two",
-          "type": "compute",
-          "inputs": ["plus_one", "minus_one"],
-          "compute_function": "inputs[0] - inputs[1]"
-        }
-      ],
-      "operations": [
-        {
-          "type": "add_callback",
-          "cell": "always_two",
-          "name": "callback1"
-        },
-        {
-          "type": "set_value",
-          "cell": "input",
-          "value": 2
-        },
-        {
-          "type": "set_value",
-          "cell": "input",
-          "value": 3
-        },
-        {
-          "type": "set_value",
-          "cell": "input",
-          "value": 4
-        },
-        {
-          "type": "set_value",
-          "cell": "input",
-          "value": 5
-        },
-        {
-          "type": "expect_callback_values",
-          "callback": "callback1",
-          "values": []
-        }
-      ],
+      "input": {
+        "cells": [
+          {
+            "name": "input",
+            "type": "input",
+            "initial_value": 1
+          },
+          {
+            "name": "plus_one",
+            "type": "compute",
+            "inputs": ["input"],
+            "compute_function": "inputs[0] + 1"
+          },
+          {
+            "name": "minus_one",
+            "type": "compute",
+            "inputs": ["input"],
+            "compute_function": "inputs[0] - 1"
+          },
+          {
+            "name": "always_two",
+            "type": "compute",
+            "inputs": ["plus_one", "minus_one"],
+            "compute_function": "inputs[0] - inputs[1]"
+          }
+        ],
+        "operations": [
+          {
+            "type": "add_callback",
+            "cell": "always_two",
+            "name": "callback1"
+          },
+          {
+            "type": "set_value",
+            "cell": "input",
+            "value": 2
+          },
+          {
+            "type": "set_value",
+            "cell": "input",
+            "value": 3
+          },
+          {
+            "type": "set_value",
+            "cell": "input",
+            "value": 4
+          },
+          {
+            "type": "set_value",
+            "cell": "input",
+            "value": 5
+          },
+          {
+            "type": "expect_callback_values",
+            "callback": "callback1",
+            "values": []
+          }
+        ]
+      },
       "expected": {}
     }
   ]

--- a/exercises/react/canonical-data.json
+++ b/exercises/react/canonical-data.json
@@ -59,7 +59,8 @@
           "cell": "input",
           "value": 10
         }
-      ]
+      ],
+      "expected": {}
     },
     {
       "description": "an input cell's value can be set",
@@ -82,7 +83,8 @@
           "cell": "input",
           "value": 20
         }
-      ]
+      ],
+      "expected": {}
     },
     {
       "description": "compute cells calculate initial value",
@@ -106,7 +108,8 @@
           "cell": "output",
           "value": 2
         }
-      ]
+      ],
+      "expected": {}
     },
     {
       "description": "compute cells take inputs in the right order",
@@ -135,7 +138,8 @@
           "cell": "output",
           "value": 21
         }
-      ]
+      ],
+      "expected": {}
     },
     {
       "description": "compute cells update value when dependencies are changed",
@@ -164,7 +168,8 @@
           "cell": "output",
           "value": 4
         }
-      ]
+      ],
+      "expected": {}
     },
     {
       "description": "compute cells can depend on other compute cells",
@@ -210,7 +215,8 @@
           "cell": "output",
           "value": 96
         }
-      ]
+      ],
+      "expected": {}
     },
     {
       "description": "compute cells fire callbacks",
@@ -244,7 +250,8 @@
           "callback": "callback1",
           "values": [4]
         }
-      ]
+      ],
+      "expected": {}
     },
     {
       "description": "callback cells only fire on change",
@@ -288,7 +295,8 @@
           "callback": "callback1",
           "values": [222]
         }
-      ]
+      ],
+      "expected": {}
     },
     {
       "description": "callbacks can be added and removed",
@@ -352,7 +360,8 @@
           "callback": "callback3",
           "values": [42]
         }
-      ]
+      ],
+      "expected": {}
     },
     {
       "description": "removing a callback multiple times doesn't interfere with other callbacks",
@@ -416,7 +425,8 @@
           "callback": "callback2",
           "values": [3]
         }
-      ]
+      ],
+      "expected": {}
     },
     {
       "description": "callbacks should only be called once even if multiple dependencies change",
@@ -472,7 +482,8 @@
           "callback": "callback1",
           "values": [10]
         }
-      ]
+      ],
+      "expected": {}
     },
     {
       "description": "callbacks should not be called if dependencies change but output value doesn't change",
@@ -538,7 +549,8 @@
           "callback": "callback1",
           "values": []
         }
-      ]
+      ],
+      "expected": {}
     }
   ]
 }


### PR DESCRIPTION
react 1.1.0

As proposed and accepted in #996

```ruby
indent = false
operations = false

ARGF.each_line { |l|
  if l.include?('version')
    ver = l.split(?")[3]
    ver_components = ver.split(?.).map(&:to_i)
    ver_components[1] += 1
    ver_components[2] = 0
    l[ver] = ver_components.join(?.)
  end

  first_non_space = l.index(/\S/)
  if l.include?('"cells"')
    puts ' ' * first_non_space + '"input": {'
    indent = true
  end
  operations ||= l.include?('"operations"')
  l.delete!(?,) if operations && l.strip == '],'
  puts "#{'  ' if indent}#{l}"
  if operations && l.strip == ?]
    puts ' ' * first_non_space + '},'
    operations = false
    indent = false
  end
}
```

---

also note the additional commit that adds `"expected": {}`, since it's required but we expect nothing other than what was already expected in `operations`.