### PR TITLE
clock: remove mention of negative minutes in comment

### DIFF
--- a/exercises/clock/canonical-data.json
+++ b/exercises/clock/canonical-data.json
@@ -1,9 +1,9 @@
 {
   "exercise": "clock",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "comments": [
     "Most languages require constructing a clock with initial values,",
-    "adding a positive or negative number of minutes, and testing equality",
+    "adding or subtracting some number of minutes, and testing equality",
     "in some language-native way.  Some languages require separate add and",
     "subtract functions.  Negative and out of range values are generally",
     "expected to wrap around rather than represent errors."

--- a/exercises/clock/canonical-data.json
+++ b/exercises/clock/canonical-data.json
@@ -4,9 +4,8 @@
   "comments": [
     "Most languages require constructing a clock with initial values,",
     "adding or subtracting some number of minutes, and testing equality",
-    "in some language-native way.  Some languages require separate add and",
-    "subtract functions.  Negative and out of range values are generally",
-    "expected to wrap around rather than represent errors."
+    "in some language-native way.  Negative and out of range values are",
+    "generally expected to wrap around rather than represent errors."
   ],
   "cases": [
     {


### PR DESCRIPTION
This exercise does not directly test adding or subtracting negative minutes.  I thought it prudent to revise the comment at the top of the testdata to reflect this recent change to the exercise.