### PR TITLE
Protein-translation: Fix codon spelling in description

### DIFF
--- a/exercises/protein-translation/description.md
+++ b/exercises/protein-translation/description.md
@@ -18,11 +18,11 @@ All subsequent codons after are ignored, like this:
 
 RNA: `"AUGUUUUCUUAAAUG"` =>
 
-Codons: `"AUG", "UUU", "UCU", "UAG", "AUG"` =>
+Codons: `"AUG", "UUU", "UCU", "UAA", "AUG"` =>
 
 Protein: `"Methionine", "Phenylalanine", "Serine"`
 
-Note the stop codon terminates the translation and the final methionine is not translated into the protein sequence.
+Note the stop codon `"UAA"` terminates the translation and the final methionine is not translated into the protein sequence.
 
 Below are the codons and resulting Amino Acids needed for the exercise.
 


### PR DESCRIPTION
There was a misspelled STOP codon in the readme of the Protein
Translation exercise.

The spelling has been corrected and the codon has also been
added to the following paragraph to clarify the meaning.