### PR TITLE
all-your-base: improve "input base is one" test

### DIFF
--- a/exercises/all-your-base/canonical-data.json
+++ b/exercises/all-your-base/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "all-your-base",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "comments": [
     "This canonical data makes the following choices:",
     "1. Zero is always represented in outputs as [0] instead of [].",
@@ -138,7 +138,7 @@
       "property": "rebase",
       "input": {
         "inputBase": 1,
-        "digits": [],
+        "digits": [0],
         "outputBase": 10
       },
       "expected": {"error": "input base must be >= 2"}


### PR DESCRIPTION
the previous version was not properly testing that input base was validated
passing the "empty list" test would also pass this test

fixed in elixir here: exercism/elixir#389