### PR TITLE
bowling: add tests for rolling after bonus rolls

### DIFF
--- a/exercises/bowling/canonical-data.json
+++ b/exercises/bowling/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "bowling",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "comments": [
     "Students should implement roll and score methods.",
     "Roll should accept a single integer.",
@@ -224,5 +224,21 @@
       "previousRolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3]
     },
     "expected": {"error": "Score cannot be taken until the end of the game"}
+  }, {
+    "description": "cannot roll after bonus roll for spare",
+    "property": "roll",
+    "input": {
+      "previousRolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 2],
+      "roll": 2
+    },
+    "expected": {"error": "Cannot roll after game is over"}
+  }, {
+    "description": "cannot roll after bonus rolls for strike",
+    "property": "roll",
+    "input": {
+      "previousRolls": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 3, 2],
+      "roll": 2
+    },
+    "expected": {"error": "Cannot roll after game is over"}
   }]
 }


### PR DESCRIPTION
Currently, there are no tests confirming that a game with bonus rolls for a spare or strike in the 10th frame is complete. This PR adds a case for both spare and strike, attempting to roll an additional ball after the bonus rolls have been completed, expecting an error to be raised upon the roll attempt.

For confirmation that these are not currently tested for, the [current example solution in the Python track](https://github.com/exercism/python/blob/f6f9279e7725e8bb891a34d439cf9075c69760d5/exercises/bowling/example.py) passes all existing tests, but fails these new tests.