### PR TITLE
react: Fold expect_callback_values into set_value

### DIFF
--- a/exercises/react/canonical-data.json
+++ b/exercises/react/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "react",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "comments": [
     "Note that, due to the nature of this exercise,",
     "the tests are specified using their cells and a series of operations to perform on the cells.",
@@ -13,11 +13,12 @@
     "The possible types and semantics of their fields are as follows:",
     "",
     "* expect_cell_value (`cell`, `value`): Expect that cell `cell` has value `value`.",
-    "* set_value (`cell`, `value`): Sets input cell `cell` to value `value`.",
+    "* set_value (`cell`, `value`, optionally `expect_callbacks`, `expect_callbacks_not_to_be_called`): Sets input cell `cell` to value `value`.",
+    "  Expect that, as a result, all callbacks in `expect_callbacks` (if present) were called exactly once with the designated value",
+    "  Expect that no callbacks in `expect_callbacks_not_to_be_called` (if present) were called as a result.",
     "* add_callback (`cell`, `name`): Adds a callback to cell `cell`. Store the callback ID in a variable named `name`.",
     "  all callbacks are assumed to simply store the values they're called with in some array.",
     "* remove_callback (`cell`, `name`): Removes the callback `name` from cell `cell`.",
-    "* expect_callback_values (`callback`, `values`): Expects callback `callback` to have been called with values `values` since the last `expect_callback_values` operation.",
     "",
     "Additional notes:",
     "",
@@ -256,12 +257,10 @@
           {
             "type": "set_value",
             "cell": "input",
-            "value": 3
-          },
-          {
-            "type": "expect_callback_values",
-            "callback": "callback1",
-            "values": [4]
+            "value": 3,
+            "expect_callbacks": {
+              "callback1": 4
+            }
           }
         ]
       },
@@ -293,22 +292,16 @@
           {
             "type": "set_value",
             "cell": "input",
-            "value": 2
-          },
-          {
-            "type": "expect_callback_values",
-            "callback": "callback1",
-            "values": []
+            "value": 2,
+            "expect_callbacks_not_to_be_called": ["callback1"]
           },
           {
             "type": "set_value",
             "cell": "input",
-            "value": 4
-          },
-          {
-            "type": "expect_callback_values",
-            "callback": "callback1",
-            "values": [222]
+            "value": 4,
+            "expect_callbacks": {
+              "callback1": 222
+            }
           }
         ]
       },
@@ -340,22 +333,18 @@
           {
             "type": "set_value",
             "cell": "input",
-            "value": 2
-          },
-          {
-            "type": "expect_callback_values",
-            "callback": "callback1",
-            "values": [3]
+            "value": 2,
+            "expect_callbacks": {
+              "callback1": 3
+            }
           },
           {
             "type": "set_value",
             "cell": "input",
-            "value": 3
-          },
-          {
-            "type": "expect_callback_values",
-            "callback": "callback1",
-            "values": [4]
+            "value": 3,
+            "expect_callbacks": {
+              "callback1": 4
+            }
           }
         ]
       },
@@ -398,17 +387,11 @@
           {
             "type": "set_value",
             "cell": "input",
-            "value": 10
-          },
-          {
-            "type": "expect_callback_values",
-            "callback": "callback1",
-            "values": [11]
-          },
-          {
-            "type": "expect_callback_values",
-            "callback": "callback2",
-            "values": [9]
+            "value": 10,
+            "expect_callbacks": {
+              "callback1": 11,
+              "callback2": 9
+            }
           }
         ]
       },
@@ -445,7 +428,11 @@
           {
             "type": "set_value",
             "cell": "input",
-            "value": 31
+            "value": 31,
+            "expect_callbacks": {
+              "callback1": 32,
+              "callback2": 32
+            }
           },
           {
             "type": "remove_callback",
@@ -460,22 +447,12 @@
           {
             "type": "set_value",
             "cell": "input",
-            "value": 41
-          },
-          {
-            "type": "expect_callback_values",
-            "callback": "callback1",
-            "values": [32]
-          },
-          {
-            "type": "expect_callback_values",
-            "callback": "callback2",
-            "values": [32, 42]
-          },
-          {
-            "type": "expect_callback_values",
-            "callback": "callback3",
-            "values": [42]
+            "value": 41,
+            "expect_callbacks": {
+              "callback2": 42,
+              "callback3": 42
+            },
+            "expect_callbacks_not_to_be_called": ["callback1"]
           }
         ]
       },
@@ -532,17 +509,11 @@
           {
             "type": "set_value",
             "cell": "input",
-            "value": 2
-          },
-          {
-            "type": "expect_callback_values",
-            "callback": "callback1",
-            "values": []
-          },
-          {
-            "type": "expect_callback_values",
-            "callback": "callback2",
-            "values": [3]
+            "value": 2,
+            "expect_callbacks": {
+              "callback2": 3
+            },
+            "expect_callbacks_not_to_be_called": ["callback1"]
           }
         ]
       },
@@ -596,12 +567,10 @@
           {
             "type": "set_value",
             "cell": "input",
-            "value": 4
-          },
-          {
-            "type": "expect_callback_values",
-            "callback": "callback1",
-            "values": [10]
+            "value": 4,
+            "expect_callbacks": {
+              "callback1": 10
+            }
           }
         ]
       },
@@ -650,27 +619,26 @@
           {
             "type": "set_value",
             "cell": "input",
-            "value": 2
+            "value": 2,
+            "expect_callbacks_not_to_be_called": ["callback1"]
           },
           {
             "type": "set_value",
             "cell": "input",
-            "value": 3
+            "value": 3,
+            "expect_callbacks_not_to_be_called": ["callback1"]
           },
           {
             "type": "set_value",
             "cell": "input",
-            "value": 4
+            "value": 4,
+            "expect_callbacks_not_to_be_called": ["callback1"]
           },
           {
             "type": "set_value",
             "cell": "input",
-            "value": 5
-          },
-          {
-            "type": "expect_callback_values",
-            "callback": "callback1",
-            "values": []
+            "value": 5,
+            "expect_callbacks_not_to_be_called": ["callback1"]
           }
         ]
       },


### PR DESCRIPTION
react 2.0.0

expect_callback_values is often not precise enough about which
`set_value` calls should result in which callbacks being called or not
called. "callbacks can be added and removed" is the worst offender,
expecting a `[32, 42]` from callback2 only after both `set_value` have
fired.

That means for all we know, maybe an implementation:

* magically manages to predict the future and calls the callback twice
  on the first `set_value`, with the correct value, and then zero times
  on the second `set_value`.
* calls the callback zero times on the first `set_value`, but twice
  on the second `set_value`.

To remedy this, we observe that the only time callbacks might be called
is if there was a `set_value`. So, let's explicitly associate our
callback expectations along with each `set_value`.