### PR TITLE
crypto-square: Clarify rectangular output requirement in description.md

### DIFF
--- a/exercises/crypto-square/description.md
+++ b/exercises/crypto-square/description.md
@@ -43,11 +43,10 @@ The message above is coded as:
 imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau
 ```
 
-Output the encoded text in chunks.  Phrases that fill perfect rectangles
-`(r X c)` should be output `c` chunks of `r` length, separated by spaces.
-Phrases that do not fill perfect rectangles will have `n` empty spaces.
-Those spaces should be distributed evenly, added to the end of the last
-`n` chunks.
+Output the encoded text in chunks that fill perfect rectangles `(r X c)`,
+with `c` chunks of `r` length, separated by spaces. For phrases that are
+`n` characters short of the perfect rectangle, pad each of the last `n`
+chunks with an extra space.
 
 ```text
 imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau 

--- a/exercises/crypto-square/description.md
+++ b/exercises/crypto-square/description.md
@@ -46,7 +46,7 @@ imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau
 Output the encoded text in chunks that fill perfect rectangles `(r X c)`,
 with `c` chunks of `r` length, separated by spaces. For phrases that are
 `n` characters short of the perfect rectangle, pad each of the last `n`
-chunks with an extra space.
+chunks with a single trailing space.
 
 ```text
 imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau 


### PR DESCRIPTION
Ambiguity in the original wording, especially "empty spaces", has led to much confusion, including a Rust implementation that got this requirement wrong.