### PR TITLE
bracket-push: Add test case "partially paired brackets"

### DIFF
--- a/exercises/bracket-push/canonical-data.json
+++ b/exercises/bracket-push/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "bracket-push",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "cases": [
     {
       "description": "paired square brackets",
@@ -49,6 +49,14 @@
         "value": "{ }"
       },
       "expected": true
+    },
+    {
+      "description": "partially paired brackets",
+      "property": "isPaired",
+      "input": {
+        "value": "{[])"
+      },
+      "expected": false
     },
     {
       "description": "simple nested brackets",


### PR DESCRIPTION
Some incorrect solutions return `true` as soon as brackets are matched. Check out this solution in Python which can pass all current tests:

```python
bracket_dict = {"(": ")", "[": "]", "{": "}"}


def brackets_match(opening_bracket, closing_bracket):
    return bracket_dict[opening_bracket] == closing_bracket


def is_paired(input_string):
    bracket_stack = []
    # Add every "opening" bracket to the stack
    # if we encounter a "closing" bracket, it should match the current
    # bracket on top of the stack
    for char in input_string:
        # If we encounter an opening bracket, we add it on top of the stack
        if char in bracket_dict.keys():
            bracket_stack.append(char)
        elif char in bracket_dict.values():
            # Get the bracket on top of the stack
            try:
                top_of_stack = bracket_stack.pop()
            # If the bracket_stack is empty, then we return false, since
            # the closing bracket has no opening bracket pair
            except IndexError:
                return False

            # Check and return if the opening and closing brackets match
            return brackets_match(top_of_stack, char)

    # Once done processing the string, bracket_stack should be empty
    # If empty, this means that all brackets have been matched
    # If not empty, this means that some brackets remain unmatched
    return bracket_stack == []
```

Clearly `return brackets_match(top_of_stack, char)` within the `for` loop is wrong, so it will fail test cases where brackets are partially paired, like `{[])`.