### PR TITLE
pov: add test for paths not involving root

### DIFF
--- a/exercises/pov/canonical-data.json
+++ b/exercises/pov/canonical-data.json
@@ -435,7 +435,7 @@
           ]
         },
         {
-          "description": "Can find path below root",
+          "description": "Can find path not involving root",
           "property": "pathTo",
           "input": {
             "from": "x",

--- a/exercises/pov/canonical-data.json
+++ b/exercises/pov/canonical-data.json
@@ -439,7 +439,7 @@
           "property": "pathTo",
           "input": {
             "from": "x",
-            "to": "cousin-1",
+            "to": "sibling-1",
             "tree": {
               "label": "grandparent",
               "children": [
@@ -447,24 +447,13 @@
                   "label": "parent",
                   "children": [
                     {
+                      "label": "x"
+                    },
+                    {
                       "label": "sibling-0"
                     },
                     {
                       "label": "sibling-1"
-                    }
-                  ]
-                },
-                {
-                  "label": "uncle",
-                  "children": [
-                    {
-                      "label": "x"
-                    },
-                    {
-                      "label": "cousin-0"
-                    },
-                    {
-                      "label": "cousin-1"
                     }
                   ]
                 }
@@ -473,8 +462,8 @@
           },
           "expected": [
             "x",
-            "uncle",
-            "cousin-1"
+            "parent",
+            "sibling-1"
           ]
         },
         {

--- a/exercises/pov/canonical-data.json
+++ b/exercises/pov/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "pov",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "cases": [
     {
       "description": "Reroot a tree so that its root is the specified node.",
@@ -430,6 +430,49 @@
             "x",
             "parent",
             "grandparent",
+            "uncle",
+            "cousin-1"
+          ]
+        },
+        {
+          "description": "Can find path below root",
+          "property": "pathTo",
+          "input": {
+            "from": "x",
+            "to": "cousin-1",
+            "tree": {
+              "label": "grandparent",
+              "children": [
+                {
+                  "label": "parent",
+                  "children": [
+                    {
+                      "label": "sibling-0"
+                    },
+                    {
+                      "label": "sibling-1"
+                    }
+                  ]
+                },
+                {
+                  "label": "uncle",
+                  "children": [
+                    {
+                      "label": "x"
+                    },
+                    {
+                      "label": "cousin-0"
+                    },
+                    {
+                      "label": "cousin-1"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "expected": [
+            "x",
             "uncle",
             "cousin-1"
           ]


### PR DESCRIPTION
I've seen solutions that always hit root node, even when the shortest path should not. So here is a test for that.