### PR TITLE
crypto-square: add quotes to indicate relevant whitespace

### DIFF
--- a/exercises/crypto-square/description.md
+++ b/exercises/crypto-square/description.md
@@ -10,11 +10,15 @@ regarded as forming a rectangle when printed with intervening newlines.
 
 For example, the sentence
 
-> If man was meant to stay on the ground, god would have given us roots.
+```text
+"If man was meant to stay on the ground, god would have given us roots."
+```
 
 is normalized to:
 
-> ifmanwasmeanttostayonthegroundgodwouldhavegivenusroots
+```text
+"ifmanwasmeanttostayonthegroundgodwouldhavegivenusroots"
+```
 
 The plaintext should be organized in to a rectangle.  The size of the
 rectangle (`r x c`) should be decided by the length of the message,
@@ -25,13 +29,13 @@ Our normalized text is 54 characters long, dictating a rectangle with
 `c = 8` and `r = 7`:
 
 ```text
-ifmanwas
-meanttos
-tayonthe
-groundgo
-dwouldha
-vegivenu
-sroots
+"ifmanwas"
+"meanttos"
+"tayonthe"
+"groundgo"
+"dwouldha"
+"vegivenu"
+"sroots"
 ```
 
 The coded message is obtained by reading down the columns going left to
@@ -40,7 +44,7 @@ right.
 The message above is coded as:
 
 ```text
-imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau
+"imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau"
 ```
 
 Output the encoded text in chunks that fill perfect rectangles `(r X c)`,
@@ -49,19 +53,19 @@ with `c` chunks of `r` length, separated by spaces. For phrases that are
 chunks with a single trailing space.
 
 ```text
-imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau 
+"imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau "
 ```
 
 Notice that were we to stack these, we could visually decode the
 cyphertext back in to the original message:
 
 ```text
-imtgdvs
-fearwer
-mayoogo
-anouuio
-ntnnlvt
-wttddes
-aohghn
-sseoau
+"imtgdvs"
+"fearwer"
+"mayoogo"
+"anouuio"
+"ntnnlvt"
+"wttddes"
+"aohghn"
+"sseoau"
 ```

--- a/exercises/crypto-square/description.md
+++ b/exercises/crypto-square/description.md
@@ -35,7 +35,7 @@ Our normalized text is 54 characters long, dictating a rectangle with
 "groundgo"
 "dwouldha"
 "vegivenu"
-"sroots"
+"sroots  "
 ```
 
 The coded message is obtained by reading down the columns going left to
@@ -66,6 +66,6 @@ cyphertext back in to the original message:
 "anouuio"
 "ntnnlvt"
 "wttddes"
-"aohghn"
-"sseoau"
+"aohghn "
+"sseoau "
 ```


### PR DESCRIPTION
per #1208.  Quotes (`"`) added to indicate relevant white space in description.