### PR TITLE
bracket-push: remove ambiguity in description

### DIFF
--- a/exercises/bracket-push/description.md
+++ b/exercises/bracket-push/description.md
@@ -1,2 +1,3 @@
-Given a string containing brackets `[]`, braces `{}` and parentheses `()`,
-verify that all the pairs are matched and nested correctly.
+Given a string containing brackets `[]`, braces `{}`, parentheses `()`,
+or any combination thereof, verify that any and all pairs are matched
+and nested correctly.


### PR DESCRIPTION
fixes #1178
Rewording now indicates that the input string `may` have instead of `will` have.