### PR TITLE
list-ops: clarify purpose of concat function

### DIFF
--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -40,7 +40,7 @@
       ]
     },
     {
-      "description": "given a list of lists, concatenate each list to the previous list",
+      "description": "concatenate a list of lists",
       "cases": [
         {
           "description": "empty list",

--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "list-ops",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "comments": [
     "Though there are no specifications here for dealing with large lists,",
     "implementers may add tests for handling large lists to ensure that the",

--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -57,6 +57,14 @@
             "lists": [[1, 2], [3], [], [4, 5, 6]]
           },
           "expected": [1, 2, 3, 4, 5, 6]
+        },
+        {
+          "description": "list of nested lists",
+          "property": "concat",
+          "input": {
+            "lists": [[[1, 2]], [[3]], [[]], [[4, 5, 6]]]
+          },
+          "expected": [[1, 2], [3], [], [4, 5, 6]]
         }
       ]
     },

--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -40,7 +40,7 @@
       ]
     },
     {
-      "description": "concat lists and lists of list into a new list",
+      "description": "given a list of lists, concatenate each list to the previous list",
       "cases": [
         {
           "description": "empty list",

--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -62,9 +62,9 @@
           "description": "list of nested lists",
           "property": "concat",
           "input": {
-            "lists": [[[1, 2]], [[3]], [[]], [[4, 5, 6]]]
+            "lists": [[[1], [2]], [[3]], [[]], [[4, 5, 6]]]
           },
-          "expected": [[1, 2], [3], [], [4, 5, 6]]
+          "expected": [[1], [2], [3], [], [4, 5, 6]]
         }
       ]
     },


### PR DESCRIPTION
closes #1231 