### PR TITLE
simple-cipher: Add canonical-data.json

### DIFF
--- a/exercises/simple-cipher/canonical-data.json
+++ b/exercises/simple-cipher/canonical-data.json
@@ -1,6 +1,11 @@
 {
   "exercise": "simple-cipher",
   "version": "1.0.0",
+  "comments":
+    ["Some of the strings used in this file are symbolic and doesn't represent their literal value. They are:",
+      "cipher.key - Represents the Cipher key",
+      "cipher.encode - Represents the output of the Cipher encode method",
+      "new - Represents the Cipher initialization"],
   "cases": [
     {
       "description": "Random key cipher",

--- a/exercises/simple-cipher/canonical-data.json
+++ b/exercises/simple-cipher/canonical-data.json
@@ -1,0 +1,141 @@
+{
+  "exercise": "simple-cipher",
+  "version": "1.0.0",
+  "cases": [
+    {
+      "description": "Random key cipher",
+      "cases": [
+        {
+          "description": "Key is made only of lowercase letters",
+          "property": "key",
+          "matches": "^[a-z]+$"
+        },
+        {
+          "description": "It can encode",
+          "property": "encode",
+          "input": {
+            "plaintext": "aaaaaaaaaa"
+          },
+          "expected": "cipher.key"
+        },
+        {
+          "description": "It can decode",
+          "property": "decode",
+          "input": {
+            "ciphertext": "cipher.key"
+          },
+          "expected": "aaaaaaaaaa"
+        },
+        {
+          "description": "It is reversible. I.e., if you apply decode in a encoded result, you must see the same plaintext encode parameter as a result of the decode method",
+          "property": "decode",
+          "input": {
+            "plaintext": "abcdefghij",
+            "ciphertext": "cipher.encode"
+          },
+          "expected": "abcdefghij"
+        }
+      ]
+    },
+    {
+      "description": "Incorrect key cipher",
+      "cases": [
+        {
+          "description": "It throws an error with an all uppercase key",
+          "property": "new",
+          "input": {
+            "key": "ABCDEF"
+          },
+          "expected": { "error": "Bad key" }
+        },
+        {
+          "description": "It throws an error with a numeric key",
+          "property": "new",
+          "input": {
+            "key": "12345"
+          },
+          "expected": { "error": "Bad key" }
+        },
+        {
+          "description": "It throws an error with empty key",
+          "property": "new",
+          "input": {
+            "key": ""
+          },
+          "expected": { "error": "Bad key" }
+        }
+      ]
+    },
+    {
+      "description": "Substitution cipher",
+      "cases": [
+        {
+          "description": "It keeps submitted key",
+          "property": "key",
+          "input": {
+            "key": "abcdefghij"
+          },
+          "expected": "abcdefghij"
+        },
+        {
+          "description": "It can encode",
+          "property": "encode",
+          "input": { 
+            "plaintext": "aaaaaaaaaa"
+          },
+          "expected": "abcdefghij"
+        },
+        {
+          "description": "It can decode",
+          "property": "decode",
+          "input": { 
+            "ciphertext": "abcdefghij"
+          },
+          "expected": "aaaaaaaaaa"
+        },
+        {
+          "description": "It is reversible. I.e., if you apply decode in a encoded result, you must see the same plaintext encode parameter as a result of the decode method",
+          "property": "decode",
+          "input": {
+            "plaintext": "abcdefghij",
+            "ciphertext": "cipher.encode"
+          },
+          "expected": "abcdefghij"
+        },
+        {
+          "description": "It can double shift encode",
+          "input": {
+            "key": "iamapandabear",
+            "plaintext": "iamapandabear"
+          },
+          "expected": "qayaeaagaciai"
+        },
+        {
+          "description": "It can wrap on encode", 
+          "property": "encode",
+          "input": {
+            "plaintext": "zzzzzzzzzz"
+          },
+          "expected": "zabcdefghi"
+        },
+        {
+          "description": "It can wrap on decode",
+          "property": "decode",
+          "input": {
+            "ciphertext": "zabcdefghi"
+          },
+          "expected": "zzzzzzzzzz"
+        },
+        {
+          "description": "It can handle messages longer than the key",
+          "property": "encode",
+          "input": {
+            "key": "abc",
+            "plaintext": "iamapandabear"
+          },
+          "expected": "iboaqcnecbfcr"
+        }
+      ]
+    }
+  ]
+}

--- a/exercises/simple-cipher/canonical-data.json
+++ b/exercises/simple-cipher/canonical-data.json
@@ -2,7 +2,7 @@
   "exercise": "simple-cipher",
   "version": "1.0.0",
   "comments":
-    ["Some of the strings used in this file are symbolic and doesn't represent their literal value. They are:",
+    ["Some of the strings used in this file are symbolic and do not represent their literal value. They are:",
       "cipher.key - Represents the Cipher key",
       "cipher.encode - Represents the output of the Cipher encode method",
       "new - Represents the Cipher initialization"],

--- a/exercises/simple-cipher/canonical-data.json
+++ b/exercises/simple-cipher/canonical-data.json
@@ -6,15 +6,7 @@
       "description": "Random key cipher",
       "cases": [
         {
-          "description": "Key is made only of lowercase letters",
-          "property": "key",
-          "input": {},
-          "expected": {
-            "match": "^[a-z]+$"
-          }
-        },
-        {
-          "description": "It can encode",
+          "description": "Can encode",
           "property": "encode",
           "input": {
             "plaintext": "aaaaaaaaaa"
@@ -22,7 +14,7 @@
           "expected": "cipher.key"
         },
         {
-          "description": "It can decode",
+          "description": "Can decode",
           "property": "decode",
           "input": {
             "ciphertext": "cipher.key"
@@ -30,42 +22,21 @@
           "expected": "aaaaaaaaaa"
         },
         {
-          "description": "It is reversible. I.e., if you apply decode in a encoded result, you must see the same plaintext encode parameter as a result of the decode method",
+          "description": "Is reversible. I.e., if you apply decode in a encoded result, you must see the same plaintext encode parameter as a result of the decode method",
           "property": "decode",
           "input": {
             "plaintext": "abcdefghij",
             "ciphertext": "cipher.encode"
           },
           "expected": "abcdefghij"
-        }
-      ]
-    },
-    {
-      "description": "Incorrect key cipher",
-      "cases": [
-        {
-          "description": "It throws an error with an all uppercase key",
-          "property": "new",
-          "input": {
-            "key": "ABCDEF"
-          },
-          "expected": { "error": "Bad key" }
         },
         {
-          "description": "It throws an error with a numeric key",
-          "property": "new",
-          "input": {
-            "key": "12345"
-          },
-          "expected": { "error": "Bad key" }
-        },
-        {
-          "description": "It throws an error with empty key",
-          "property": "new",
-          "input": {
-            "key": ""
-          },
-          "expected": { "error": "Bad key" }
+          "description": "Key is made only of lowercase letters",
+          "property": "key",
+          "input": {},
+          "expected": {
+            "match": "^[a-z]+$"
+          }
         }
       ]
     },
@@ -73,40 +44,35 @@
       "description": "Substitution cipher",
       "cases": [
         {
-          "description": "It keeps submitted key",
-          "property": "key",
-          "input": {
-            "key": "abcdefghij"
-          },
-          "expected": "abcdefghij"
-        },
-        {
-          "description": "It can encode",
+          "description": "Can encode",
           "property": "encode",
-          "input": { 
+          "input": {
+            "key": "abcdefghij",
             "plaintext": "aaaaaaaaaa"
           },
           "expected": "abcdefghij"
         },
         {
-          "description": "It can decode",
+          "description": "Can decode",
           "property": "decode",
-          "input": { 
+          "input": {
+            "key": "abcdefghij",
             "ciphertext": "abcdefghij"
           },
           "expected": "aaaaaaaaaa"
         },
         {
-          "description": "It is reversible. I.e., if you apply decode in a encoded result, you must see the same plaintext encode parameter as a result of the decode method",
+          "description": "Is reversible. I.e., if you apply decode in a encoded result, you must see the same plaintext encode parameter as a result of the decode method",
           "property": "decode",
           "input": {
+            "key": "abcdefghij",
             "plaintext": "abcdefghij",
             "ciphertext": "cipher.encode"
           },
           "expected": "abcdefghij"
         },
         {
-          "description": "It can double shift encode",
+          "description": "Can double shift encode",
           "property": "encode",
           "input": {
             "key": "iamapandabear",
@@ -115,29 +81,60 @@
           "expected": "qayaeaagaciai"
         },
         {
-          "description": "It can wrap on encode", 
+          "description": "Can wrap on encode", 
           "property": "encode",
           "input": {
+            "key": "abcdefghij",
             "plaintext": "zzzzzzzzzz"
           },
           "expected": "zabcdefghi"
         },
         {
-          "description": "It can wrap on decode",
+          "description": "Can wrap on decode",
           "property": "decode",
           "input": {
+            "key": "abcdefghij",
             "ciphertext": "zabcdefghi"
           },
           "expected": "zzzzzzzzzz"
         },
         {
-          "description": "It can handle messages longer than the key",
+          "description": "Can handle messages longer than the key",
           "property": "encode",
           "input": {
             "key": "abc",
             "plaintext": "iamapandabear"
           },
           "expected": "iboaqcnecbfcr"
+        }
+      ]
+    },
+    {
+      "description": "Incorrect key cipher",
+      "cases": [
+        {
+          "description": "Throws an error with an all uppercase key",
+          "property": "new",
+          "input": {
+            "key": "ABCDEF"
+          },
+          "expected": { "error": "Bad key" }
+        },
+        {
+          "description": "Throws an error with a numeric key",
+          "property": "new",
+          "input": {
+            "key": "12345"
+          },
+          "expected": { "error": "Bad key" }
+        },
+        {
+          "description": "Throws an error with empty key",
+          "property": "new",
+          "input": {
+            "key": ""
+          },
+          "expected": { "error": "Bad key" }
         }
       ]
     }

--- a/exercises/simple-cipher/canonical-data.json
+++ b/exercises/simple-cipher/canonical-data.json
@@ -8,7 +8,10 @@
         {
           "description": "Key is made only of lowercase letters",
           "property": "key",
-          "matches": "^[a-z]+$"
+          "input": {},
+          "expected": {
+            "match": "^[a-z]+$"
+          }
         },
         {
           "description": "It can encode",
@@ -104,6 +107,7 @@
         },
         {
           "description": "It can double shift encode",
+          "property": "encode",
           "input": {
             "key": "iamapandabear",
             "plaintext": "iamapandabear"


### PR DESCRIPTION
Can anyone clarify the CI building output for me? I see that is failing but I didn't understand why. 

As I understood from the [canonical-data.json specification](https://github.com/exercism/problem-specifications#test-data-format-canonical-datajson), I should be able to nest `cases ` keywords.

For this problem in specific, there is a test case where we don't assert, but we use a match test to check a property against a regex, so I used a `match` key for it.

Closes #586 