### PR TITLE
forth: add test for multiple word redefinition

### DIFF
--- a/exercises/forth/canonical-data.json
+++ b/exercises/forth/canonical-data.json
@@ -378,7 +378,7 @@
           "expected": [5, 6]
         },
         {
-          "description": "can define word that use word with the same name",
+          "description": "can define word that uses word with the same name",
           "property": "evaluate",
           "input": {
             "instructions": [

--- a/exercises/forth/canonical-data.json
+++ b/exercises/forth/canonical-data.json
@@ -365,16 +365,29 @@
           "expected": [12]
         },
         {
-          "description": "can override words multiple times",
+          "description": "can use different words with the same name",
           "property": "evaluate",
           "input": {
             "instructions": [
-              ": add_x 1 + ; 5 add_x",
-              ": add_x add_x 1 + ; 5 add_x",
-              ": add_x add_x 1 + ; 5 add_x"
+              ": foo 5 ;",
+              ": bar foo ;",
+              ": foo 6 ;",
+              "bar foo"
             ]
           },
-          "expected": [6, 7, 8]
+          "expected": [5, 6]
+        },
+        {
+          "description": "can define word that use word with the same name",
+          "property": "evaluate",
+          "input": {
+            "instructions": [
+              ": foo 10 ;",
+              ": foo foo 1 + ;",
+              "foo"
+            ]
+          },
+          "expected": [11]
         },
         {
           "description": "cannot redefine numbers",

--- a/exercises/forth/canonical-data.json
+++ b/exercises/forth/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "forth",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "comments": [
     "The cases are split into multiple sections, all with the same structure.",
     "In all cases, the `expected` key is the resulting stack",
@@ -363,6 +363,18 @@
             ]
           },
           "expected": [12]
+        },
+        {
+          "description": "can override words multiple times",
+          "property": "evaluate",
+          "input": {
+            "instructions": [
+              ": add_x 1 + ; 5 add_x",
+              ": add_x add_x 1 + ; 5 add_x",
+              ": add_x add_x 1 + ; 5 add_x"
+            ]
+          },
+          "expected": [6, 7, 8]
         },
         {
           "description": "cannot redefine numbers",


### PR DESCRIPTION
All solutions I have seen don't support "recursive" word definitions and/or word "versioning". New test case will check both situations.