### PR TITLE
Say: Add 'espeak' reference to README

### DIFF
--- a/exercises/say/description.md
+++ b/exercises/say/description.md
@@ -22,7 +22,7 @@ Some good test cases for this program are:
 ### Extension
 
 If you're on a Mac, shell out to Mac OS X's `say` program to talk out
-loud.
+loud. If you're on Linux or Windows, eSpeakNG may be available with the command `espeak`.
 
 ## Step 2
 


### PR DESCRIPTION
When I first read this README I skimmed past the `extension` section since it said "if you're on a Mac", and I'm using Linux. I'm glad I took the time to find an alternative, it was really fun, and I wanted to make sure others will be made aware of it too.

I'd be happy to receive feedback on the construction of the sentence. I'm sure it can be improved.