### PR TITLE
word-search: Remove unneeded exception case comment

### DIFF
--- a/exercises/word-search/canonical-data.json
+++ b/exercises/word-search/canonical-data.json
@@ -1,9 +1,8 @@
 {
   "exercise": "word-search",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "comments": [
-    "Grid rows and columns are 1-indexed.",
-    "An expected value of -1 indicates that some sort of failure should occur."
+    "Grid rows and columns are 1-indexed."
   ],
   "cases": [
     {


### PR DESCRIPTION
There is no mention of the value `-1` anywhere in the canonical data, so this comment line can be removed.