### PR TITLE
Add an ISBN Verifier test case for short ISBN

### DIFF
--- a/exercises/isbn-verifier/canonical-data.json
+++ b/exercises/isbn-verifier/canonical-data.json
@@ -87,6 +87,14 @@
             "expected": false
         },
         {
+            "description": "too short isbn",
+            "property": "isValid",
+            "input": {
+              "isbn": "00"
+            },
+            "expected": false
+        },
+        {
             "description": "isbn without check digit",
             "property": "isValid",
             "input": {


### PR DESCRIPTION
If your code verify the isbn length to be only less than or equal to 10, it will accept some ISBN with less than 10 digits which still satisfy other rules, being "00" a case which could be considered ISBN by some "almost correct" solutions missing this consideration.

I.e: http://exercism.io/submissions/f2fac1e79bf441e08afecd196ec0a442