### PR TITLE
isbn-verifier: testdata bump version

### DIFF
--- a/exercises/isbn-verifier/canonical-data.json
+++ b/exercises/isbn-verifier/canonical-data.json
@@ -1,6 +1,6 @@
 {
     "exercise": "isbn-verifier",
-    "version": "2.5.0",
+    "version": "2.6.0",
     "comments": [
         "An expected value of true indicates a valid ISBN-10, ",
         "whereas false means the ISBN-10 is invalid."


### PR DESCRIPTION
I was too hasty when I merged #1251.  I missed that version had not been updated.