### PR TITLE
simple-cipher: specify substring length for symbolic values

### DIFF
--- a/exercises/simple-cipher/canonical-data.json
+++ b/exercises/simple-cipher/canonical-data.json
@@ -17,13 +17,13 @@
           "input": {
             "plaintext": "aaaaaaaaaa"
           },
-          "expected": "cipher.key.substring(0, 10)"
+          "expected": "cipher.key.substring(0, plaintext.length)"
         },
         {
           "description": "Can decode",
           "property": "decode",
           "input": {
-            "ciphertext": "cipher.key.substring(0, 10)"
+            "ciphertext": "cipher.key.substring(0, expected.length)"
           },
           "expected": "aaaaaaaaaa"
         },

--- a/exercises/simple-cipher/canonical-data.json
+++ b/exercises/simple-cipher/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "simple-cipher",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "comments":
     ["Some of the strings used in this file are symbolic and do not represent their literal value. They are:",
       "cipher.key - Represents the Cipher key",

--- a/exercises/simple-cipher/canonical-data.json
+++ b/exercises/simple-cipher/canonical-data.json
@@ -5,8 +5,8 @@
     ["Some of the strings used in this file are symbolic and do not represent their literal value. They are:",
       "cipher.key - Represents the Cipher key",
       "cipher.encode - Represents the output of the Cipher encode method",
-      "new - Represents the Cipher initialization"
-      "string.substring(start, length) - Represents a substring of 'string' that begins at index 'start' and is 'length' characters long],
+      "new - Represents the Cipher initialization",
+      "string.substring(start, length) - Represents a substring of 'string' that begins at index 'start' and is 'length' characters long"],
   "cases": [
     {
       "description": "Random key cipher",

--- a/exercises/simple-cipher/canonical-data.json
+++ b/exercises/simple-cipher/canonical-data.json
@@ -5,7 +5,8 @@
     ["Some of the strings used in this file are symbolic and do not represent their literal value. They are:",
       "cipher.key - Represents the Cipher key",
       "cipher.encode - Represents the output of the Cipher encode method",
-      "new - Represents the Cipher initialization"],
+      "new - Represents the Cipher initialization"
+      "string.substring(start, length) - Represents a substring of 'string' that begins at index 'start' and is 'length' characters long],
   "cases": [
     {
       "description": "Random key cipher",
@@ -16,13 +17,13 @@
           "input": {
             "plaintext": "aaaaaaaaaa"
           },
-          "expected": "cipher.key"
+          "expected": "cipher.key.substring(0, 10)"
         },
         {
           "description": "Can decode",
           "property": "decode",
           "input": {
-            "ciphertext": "cipher.key"
+            "ciphertext": "cipher.key.substring(0, 10)"
           },
           "expected": "aaaaaaaaaa"
         },


### PR DESCRIPTION
Closes #1250 

To summarize, a face-value translation of the canonical data results in failure, because in the canonical data no substring length is specified for cipher.key. Thus, when then full string is used, the length of the actual value is much greater than the length of the expected value.