### PR TITLE
isbn-verifier: Crafted input to catch more incorrect algorithms

### DIFF
--- a/exercises/isbn-verifier/canonical-data.json
+++ b/exercises/isbn-verifier/canonical-data.json
@@ -103,14 +103,6 @@
             "expected": false
         },
         {
-            "description": "too long isbn",
-            "property": "isValid",
-            "input": {
-              "isbn": "3-598-21507-XX"
-            },
-            "expected": false
-        },
-        {
             "description": "check digit of X should not be used for 0",
             "property": "isValid",
             "input": {

--- a/exercises/isbn-verifier/canonical-data.json
+++ b/exercises/isbn-verifier/canonical-data.json
@@ -1,6 +1,6 @@
 {
     "exercise": "isbn-verifier",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "comments": [
         "An expected value of true indicates a valid ISBN-10, ",
         "whereas false means the ISBN-10 is invalid."
@@ -139,6 +139,14 @@
             "property": "isValid",
             "input": {
                 "isbn": "3132P34035"
+            },
+            "expected": false
+        },
+        {
+            "description": "input is too long but contains a valid isbn",
+            "property": "isValid",
+            "input": {
+                "isbn": "98245726788"
             },
             "expected": false
         }


### PR DESCRIPTION
This commit adds an input that will be incorrectly validated by
algorithms that don't explicitly check the length of their inputs, as
discussed in #1199 and #993.

For example, if an algorithm only checks the first (or last) ten
digits of the input, ignoring leftovers, it will pass the current test
suite even though it doesn't correctly implement the spec.

closes #1199