### PR TITLE
Isogram: Check for duplicates at the end of the alphabet.

### DIFF
--- a/exercises/isogram/canonical-data.json
+++ b/exercises/isogram/canonical-data.json
@@ -3,7 +3,7 @@
   "comments": [
     "An isogram is a word or phrase without a repeating letter."
   ],
-  "version": "1.3.0",
+  "version": "1.4.0",
   "cases": [
     {
       "description": "Check if the given string is an isogram",
@@ -32,6 +32,14 @@
           "property": "isIsogram",
           "input": {
             "phrase": "eleven"
+          },
+          "expected": false
+        },
+        {
+          "description": "word with one duplicated character from the end of the alphabet",
+          "property": "isIsogram",
+          "input": {
+            "phrase": "zzyzx"
           },
           "expected": false
         },


### PR DESCRIPTION
A solution in the C track used a char[4] array instead of an unsigned
int to keep track of seen letters. This caused it to check for
duplicates only in the first 8 letters, and it passed the test suite.

This goes along with PR exercism/c#314.