### PR TITLE
Atbash-cipher: Add tests for decoding input with incorrect spacing

### DIFF
--- a/exercises/atbash-cipher/canonical-data.json
+++ b/exercises/atbash-cipher/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "atbash-cipher",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "comments": [
     "The tests are divided into two groups: ",
     "* Encoding from English to atbash cipher",

--- a/exercises/atbash-cipher/canonical-data.json
+++ b/exercises/atbash-cipher/canonical-data.json
@@ -112,6 +112,22 @@
             "phrase": "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"
           },
           "expected": "thequickbrownfoxjumpsoverthelazydog"
+        },
+        {
+          "description": "decode with too many spaces",
+          "property": "decode",
+          "input": {
+            "phrase": "vc vix    r hn"
+          },
+          "expected": "exercism"
+        },
+        {
+          "description": "decode with no spaces",
+          "property": "decode",
+          "input": {
+            "phrase": "zmlyhgzxovrhlugvmzhgvkkrmthglmv"
+          },
+          "expected": "anobstacleisoftenasteppingstone"
         }
       ]
     }

--- a/exercises/atbash-cipher/canonical-data.json
+++ b/exercises/atbash-cipher/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "atbash-cipher",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "comments": [
     "The tests are divided into two groups: ",
     "* Encoding from English to atbash cipher",


### PR DESCRIPTION
I think it needed tests for decoding with incorrect spacing in the ciphertext.
This mirrors some tests that we put in the affine-cipher problem's [canonical-data.json](https://github.com/exercism/problem-specifications/blob/master/exercises/affine-cipher/canonical-data.json).

I also updated the version from `1.1.0` to `1.2.0`.