### PR TITLE
anagram: Remove comment from canonical data

### DIFF
--- a/exercises/anagram/canonical-data.json
+++ b/exercises/anagram/canonical-data.json
@@ -1,12 +1,6 @@
 {
   "exercise": "anagram",
-  "version": "1.2.0",
-  "comments": [
-    "The string argument cases possible matches are passed in as",
-    "individual arguments rather than arrays. Languages can include",
-    "these string argument cases if passing individual arguments is",
-    "idiomatic in that language."
-  ],
+  "version": "1.2.1",
   "cases": [
     {
       "description": "no matches",


### PR DESCRIPTION
The comment is referring to a `string argument cases` key which was removed in PR https://github.com/exercism/problem-specifications/pull/308