### PR TITLE
bob: improve test descriptions re: absence of letters

### DIFF
--- a/exercises/bob/canonical-data.json
+++ b/exercises/bob/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "bob",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "cases": [
     {
       "description": "stating something",
@@ -83,7 +83,7 @@
       "expected": "Whoa, chill out!"
     },
     {
-      "description": "only numbers",
+      "description": "no letters",
       "property": "response",
       "input": {
         "heyBob": "1, 2, 3"
@@ -91,7 +91,7 @@
       "expected": "Whatever."
     },
     {
-      "description": "question with only numbers",
+      "description": "question with no letters",
       "property": "response",
       "input": {
         "heyBob": "4?"


### PR DESCRIPTION
I ran across a solution that passed the tests but violated the spirit of
the tests. The student was checking for shouting by checking for:
* the absence of lower case letters AND
* (a string ending in `!` OR
* a string without numbers)

This means that "1,2,3!" would be shouting, but "JUST 1 NUMBER"
wouldn't, which seems to violate the spirit of tests titled:
* shouting numbers
* shouting with no exclamation mark
---
Should a test be added for this case, or is changing test descriptions to be more clear enough?