### PR TITLE
Acronym: add long instance case to canonical-data.json

### DIFF
--- a/exercises/acronym/canonical-data.json
+++ b/exercises/acronym/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "acronym",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "cases": [
     {
       "description": "Abbreviate a phrase",
@@ -44,6 +44,14 @@
             "phrase": "Complementary metal-oxide semiconductor"
           },
           "expected": "CMOS"
+        },
+        {
+          "description": "very long abbreviation",
+          "property": "abbreviate",
+          "input": {
+            "phrase": "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me"
+          },
+          "expected": "ROTFLSHTMDCOALM"
         }
       ]
     }


### PR DESCRIPTION
A solution on the C track only worked because all the acronyms were shorter than 8 letters. Specifically, the student allocated a buffer the size of a char pointer, instead of a buffer n characters long.