### PR TITLE
markdown: Extra tests to ensure markdown symbols are not incorrectly interpreted

### DIFF
--- a/exercises/markdown/canonical-data.json
+++ b/exercises/markdown/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "markdown",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "comments": [
     "Markdown is a shorthand for creating HTML from text strings."
   ],
@@ -76,6 +76,30 @@
         "markdown": "# Header!\n* __Bold Item__\n* _Italic Item_"
       },
       "expected": "<h1>Header!</h1><ul><li><strong>Bold Item</strong></li><li><em>Italic Item</em></li></ul>"
+    },
+    {
+        "description": "with markdown symbols in the header text that should not be interpreted",
+        "property": "parse",
+        "input": {
+            "markdown": "# This is a header with # and *** in the text"
+        },
+        "expected": "<h1>This is a header with # and *** in the text</h1>"
+    },
+    {
+        "description": "with markdown symbols in the list item text that should not be interpreted",
+        "property": "parse",
+        "input": {
+            "markdown": "* Item 1 with a # in the text\n* Item 2 with *** in the text"
+        },
+        "expected": "<ul><li>Item 1 with a # in the text</li><li>Item 2 with *** in the text</li></ul>"
+    },
+    {
+        "description": "with markdown symbols in the paragraph text that should not be interpreted",
+        "property": "parse",
+        "input": {
+            "markdown": "This is a paragraph with # and *** in the text"
+        },
+        "expected": "<p>This is a paragraph with # and *** in the text</p>"
     }
   ]
 }

--- a/exercises/markdown/canonical-data.json
+++ b/exercises/markdown/canonical-data.json
@@ -81,25 +81,25 @@
         "description": "with markdown symbols in the header text that should not be interpreted",
         "property": "parse",
         "input": {
-            "markdown": "# This is a header with # and *** in the text"
+            "markdown": "# This is a header with # and * in the text"
         },
-        "expected": "<h1>This is a header with # and *** in the text</h1>"
+        "expected": "<h1>This is a header with # and * in the text</h1>"
     },
     {
         "description": "with markdown symbols in the list item text that should not be interpreted",
         "property": "parse",
         "input": {
-            "markdown": "* Item 1 with a # in the text\n* Item 2 with *** in the text"
+            "markdown": "* Item 1 with a # in the text\n* Item 2 with * in the text"
         },
-        "expected": "<ul><li>Item 1 with a # in the text</li><li>Item 2 with *** in the text</li></ul>"
+        "expected": "<ul><li>Item 1 with a # in the text</li><li>Item 2 with * in the text</li></ul>"
     },
     {
         "description": "with markdown symbols in the paragraph text that should not be interpreted",
         "property": "parse",
         "input": {
-            "markdown": "This is a paragraph with # and *** in the text"
+            "markdown": "This is a paragraph with # and * in the text"
         },
-        "expected": "<p>This is a paragraph with # and *** in the text</p>"
+        "expected": "<p>This is a paragraph with # and * in the text</p>"
     }
   ]
 }


### PR DESCRIPTION
I recently reviewed a nicely refactored solution for the markdown exercise, but I noticed that while the original code passes for the tests I'm suggesting, the student's newly refactored code did not. It's not the student's fault, since the existing tests all passed, but I think these additional ones may be helpful.

I suggested these tests to the student, who was able to rework the code in a second iteration and make them pass.

My reasoning was that it's entirely reasonable to have a header where the text has a hash in it (like `# My C# Header` and that shouldn't be interpreted as an H2 header.

What does everyone think? If it's too much, or gets away from the goals of this exercise too much, I'm fine with leaving them out.