### PR TITLE
collatz-conjecture: fix capitalized description

### DIFF
--- a/exercises/collatz-conjecture/canonical-data.json
+++ b/exercises/collatz-conjecture/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "collatz-conjecture",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "cases": [
     {
       "description": "zero steps for one",

--- a/exercises/collatz-conjecture/canonical-data.json
+++ b/exercises/collatz-conjecture/canonical-data.json
@@ -27,7 +27,7 @@
       "expected": 9
     },
     {
-      "description": "Large number of even and odd steps",
+      "description": "large number of even and odd steps",
       "property": "steps",
       "input": {
         "number": 1000000


### PR DESCRIPTION
It seemed like this description shouldn't be capitalized so that it would fit with the style of the other cases in this problem.