### PR TITLE
bob: Modify test case to include acronym in shouting

### DIFF
--- a/exercises/bob/canonical-data.json
+++ b/exercises/bob/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "bob",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "cases": [
     {
       "description": "stating something",
@@ -110,7 +110,7 @@
       "description": "shouting with no exclamation mark",
       "property": "response",
       "input": {
-        "heyBob": "I HATE YOU"
+        "heyBob": "I HATE THE DMV"
       },
       "expected": "Whoa, chill out!"
     },


### PR DESCRIPTION
Encountered a submission where someone was addressing `OK` and `DMV` as acronyms and excluding those specifically when checking for shouting.