### PR TITLE
affine-cipher: fixed expected policy for errors

### DIFF
--- a/exercises/affine-cipher/canonical-data.json
+++ b/exercises/affine-cipher/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "affine-cipher",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "comments": [
     "The test are divided into two groups: ",
     "* Encoding from English to affine cipher",

--- a/exercises/affine-cipher/canonical-data.json
+++ b/exercises/affine-cipher/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "affine-cipher",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "comments": [
     "The test are divided into two groups: ",
     "* Encoding from English to affine cipher",

--- a/exercises/affine-cipher/canonical-data.json
+++ b/exercises/affine-cipher/canonical-data.json
@@ -117,7 +117,7 @@
               "b": 17
             }
          },
-          "expected": { "error": "Error: a and m must be coprime." }
+          "expected": { "error": "a and m must be coprime." }
         }
       ]
     },
@@ -207,7 +207,7 @@
               "b": 5
             }
           },
-          "expected": { "error": "Error: a and m must be coprime." }
+          "expected": { "error": "a and m must be coprime." }
         }
       ]
     }

--- a/exercises/affine-cipher/canonical-data.json
+++ b/exercises/affine-cipher/canonical-data.json
@@ -117,14 +117,14 @@
               "b": 17
             }
          },
-          "expected": "Error: a and m must be coprime."
+          "expected": { "error": "Error: a and m must be coprime." }
         }
       ]
     },
     {
       "description": "decode",
       "comments": [ "Test decoding from ciphertext to English with keys" ],
-      "cases": [ 
+      "cases": [
         {
           "description": "decode exercism",
           "property": "decode",
@@ -207,7 +207,7 @@
               "b": 5
             }
           },
-          "expected": "Error: a and m must be coprime."
+          "expected": { "error": "Error: a and m must be coprime." }
         }
       ]
     }


### PR DESCRIPTION
It was brought to my attention while implementing a generator in the Ruby track that I did not follow the proper convention in the cases that return an error.