### PR TITLE
book-store: Add test case to thwart list-order greedy solutions

### DIFF
--- a/exercises/book-store/canonical-data.json
+++ b/exercises/book-store/canonical-data.json
@@ -87,7 +87,7 @@
         },
         {
          "property": "total",
-         "description": "Two groups of four is cheaper than group of five plus group of three, regardless of order",
+         "description": "Two groups of four is cheaper than group of five and three",
          "comments": ["Suggested grouping, [[1,2,4,5],[1,3,4,5]]. This differs from the other 'two groups of four' test in that it will fail for solutions that add books to groups in the order in which they appear in the list."],
          "input": {
            "basket": [1,1,2,3,4,4,5,5]

--- a/exercises/book-store/canonical-data.json
+++ b/exercises/book-store/canonical-data.json
@@ -87,7 +87,7 @@
         },
         {
          "property": "total",
-         "description": "Two groups of four is cheaper than group of five and three",
+         "description": "Two groups of four is cheaper than groups of five and three",
          "comments": ["Suggested grouping, [[1,2,4,5],[1,3,4,5]]. This differs from the other 'two groups of four' test in that it will fail for solutions that add books to groups in the order in which they appear in the list."],
          "input": {
            "basket": [1,1,2,3,4,4,5,5]

--- a/exercises/book-store/canonical-data.json
+++ b/exercises/book-store/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "book-store",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "cases": [
     {
       "description": "Return the total basket price after applying the best discount.",
@@ -82,6 +82,15 @@
          "comments": ["Suggested grouping, [[1,2,3,4],[1,2,3,5]]."],
          "input": {
            "basket": [1,1,2,2,3,3,4,5]
+         },
+         "expected": 5120
+        },
+        {
+         "property": "total",
+         "description": "Two groups of four is cheaper than group of five plus group of three, regardless of order",
+         "comments": ["Suggested grouping, [[1,2,4,5],[1,3,4,5]]. This differs from the other 'two groups of four' test in that it will fail for solutions that add books to groups in the order in which they appear in the list."],
+         "input": {
+           "basket": [1,1,2,3,4,4,5,5]
          },
          "expected": 5120
         },


### PR DESCRIPTION
The current "two groups of four" test allows solutions to pass if they add books to groups in the order in which they appear in the list, which doesn't work in general. I saw two solutions in a row which pass the tests as-is but fail this new test, because adding books 2 and 3 to the first group of four will prevent making a second one.

fixes #1215 