### PR TITLE
anagram: Change property to be more descriptive

### DIFF
--- a/exercises/anagram/canonical-data.json
+++ b/exercises/anagram/canonical-data.json
@@ -1,10 +1,10 @@
 {
   "exercise": "anagram",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "cases": [
     {
       "description": "no matches",
-      "property": "anagrams",
+      "property": "findAnagrams",
       "input": {
         "subject": "diaper",
         "candidates": ["hello", "world", "zombies", "pants"]
@@ -13,7 +13,7 @@
     },
     {
       "description": "detects two anagrams",
-      "property": "anagrams",
+      "property": "findAnagrams",
       "input": {
         "subject": "master",
         "candidates": ["stream", "pigeon", "maters"]
@@ -22,7 +22,7 @@
     },
     {
       "description": "does not detect anagram subsets",
-      "property": "anagrams",
+      "property": "findAnagrams",
       "input": {
         "subject": "good",
         "candidates": ["dog", "goody"]
@@ -31,7 +31,7 @@
     },
     {
       "description": "detects anagram",
-      "property": "anagrams",
+      "property": "findAnagrams",
       "input": {
         "subject": "listen",
         "candidates": ["enlists", "google", "inlets", "banana"]
@@ -40,7 +40,7 @@
     },
     {
       "description": "detects three anagrams",
-      "property": "anagrams",
+      "property": "findAnagrams",
       "input": {
         "subject": "allergy",
         "candidates": [
@@ -56,7 +56,7 @@
     },
     {
       "description": "does not detect non-anagrams with identical checksum",
-      "property": "anagrams",
+      "property": "findAnagrams",
       "input": {
         "subject": "mass",
         "candidates": ["last"]
@@ -65,7 +65,7 @@
     },
     {
       "description": "detects anagrams case-insensitively",
-      "property": "anagrams",
+      "property": "findAnagrams",
       "input": {
         "subject": "Orchestra",
         "candidates": ["cashregister", "Carthorse", "radishes"]
@@ -74,7 +74,7 @@
     },
     {
       "description": "detects anagrams using case-insensitive subject",
-      "property": "anagrams",
+      "property": "findAnagrams",
       "input": {
         "subject": "Orchestra",
         "candidates": ["cashregister", "carthorse", "radishes"]
@@ -83,7 +83,7 @@
     },
     {
       "description": "detects anagrams using case-insensitive possible matches",
-      "property": "anagrams",
+      "property": "findAnagrams",
       "input": {
         "subject": "orchestra",
         "candidates": ["cashregister", "Carthorse", "radishes"]
@@ -92,7 +92,7 @@
     },
     {
       "description": "does not detect a anagram if the original word is repeated",
-      "property": "anagrams",
+      "property": "findAnagrams",
       "input": {
         "subject": "go",
         "candidates": ["go Go GO"]
@@ -101,7 +101,7 @@
     },
     {
       "description": "anagrams must use all letters exactly once",
-      "property": "anagrams",
+      "property": "findAnagrams",
       "input": {
         "subject": "tapper",
         "candidates": ["patter"]
@@ -110,7 +110,7 @@
     },
     {
       "description": "capital word is not own anagram",
-      "property": "anagrams",
+      "property": "findAnagrams",
       "input": {
         "subject": "BANANA",
         "candidates": ["Banana"]


### PR DESCRIPTION
I find `anagrams` to be a generic name for a method or function. I think the property should be description of either the action or the result.

Since the property is about returning a list of anagrams found of a given word, I think `findAnagrams` would be alright.