### PR TITLE
isogram: adding testcase with same first and last character

### DIFF
--- a/exercises/isogram/canonical-data.json
+++ b/exercises/isogram/canonical-data.json
@@ -103,7 +103,7 @@
           "description": "same first and last characters",
           "property": "isIsogram",
           "input": {
-            "phrase": "Angola"
+            "phrase": "angola"
           },
           "expected": false
         }

--- a/exercises/isogram/canonical-data.json
+++ b/exercises/isogram/canonical-data.json
@@ -3,7 +3,7 @@
   "comments": [
     "An isogram is a word or phrase without a repeating letter."
   ],
-  "version": "1.5.0",
+  "version": "1.6.0",
   "cases": [
     {
       "description": "Check if the given string is an isogram",
@@ -96,6 +96,14 @@
           "property": "isIsogram",
           "input": {
             "phrase": "accentor"
+          },
+          "expected": false
+        },
+        {
+          "description": "same first and last characters",
+          "property": "isIsogram",
+          "input": {
+            "phrase": "Angola"
           },
           "expected": false
         }


### PR DESCRIPTION
There are very talented students who exploit every loophole of the test suite. This guy forgot to look at the first and the last character, and still managed to pass all existing tests! (I like the originality of comparing strchr() with strrchr(), though)
```
    for (size_t i = 1; i < len - 1; i++)
    {
        // If the fist occurence of a character is not the last,
        // that's not an isogram.
        if (strchr(str, str[i]) != strrchr(str, str[i]))
        {
            return false;
        }
    }
```
