### PR TITLE
Pangram: Diacritics and ligatures

### DIFF
--- a/exercises/pangram/canonical-data.json
+++ b/exercises/pangram/canonical-data.json
@@ -90,6 +90,14 @@
             "sentence": "the quick brown fox jumps over with lazy FX"
           },
           "expected": false
+        },
+        {
+          "description": "can handle diacritics and ligatures",
+          "property": "isPangram",
+          "input": {
+            "sentence": "àbçdfghîjklmnpqrßtÛvWxyzœ"
+          },
+          "expected": true
         }
       ]
     }


### PR DESCRIPTION
What about checking if it can handle diacritics and ligatures ? (é è ç œ ß …)

That could seem secondary, but that is a must for lot of languages that use more characters than the plain ASCII (French, Deutsch, Spanish, …)

What do you think ?