### PR TITLE
Bob: Fix grammatical error in testdata

### DIFF
--- a/exercises/bob/canonical-data.json
+++ b/exercises/bob/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "bob",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "cases": [
     {
       "description": "stating something",
@@ -166,7 +166,7 @@
       "description": "multiple line question",
       "property": "response",
       "input": {
-        "heyBob": "\nDoes this cryogenic chamber make me look fat?\nno"
+        "heyBob": "\nDoes this cryogenic chamber make me look fat?\nNo."
       },
       "expected": "Whatever."
     },


### PR DESCRIPTION
In the Bob exercise it says:

> Bob's conversational partner is a purist when it comes to written
> communication and always follows normal rules regarding sentence
> punctuation in English.

But in the unit test the following input is fed to `responseFor`:

    "\nDoes this cryogenic chamber make me look fat?\nno"

This is a rhetorical question, and by the expected value, this is deemed
to not be an actual question, which is very reasonable. But if Bob's
conversational partner is a punctuation purist, it should at least end
with a period.

I found this when exercising the Haskell track and wanting to grab the
last character that `isPunctuation`, but had to go with `not . isSpace`
(like the reference solution). But this really sounds wrong when I think
about it: I actually want the last punctuation character and am allowed
to assume "normal rules".

Making this change will not render `not . isSpace` solutions in the
Haskell track incorrect. I don't know what the implications are in other
language tracks that use this test case, and I don't know how to test
this.