### PR TITLE
Grains: Fixed canonical data to have standard error indicator

### DIFF
--- a/exercises/grains/canonical-data.json
+++ b/exercises/grains/canonical-data.json
@@ -3,7 +3,6 @@
   "version": "1.2.0",
   "comments": [
     "The final tests of square test error conditions",
-    "The expectation for these tests is -1, indicating an error",
     "In these cases you should expect an error as is idiomatic for your language"
   ],
   "cases": [

--- a/exercises/grains/canonical-data.json
+++ b/exercises/grains/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "grains",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "comments": [
     "The final tests of square test error conditions",
     "The expectation for these tests is -1, indicating an error",
@@ -72,7 +72,7 @@
           "input": {
             "square": 0
           },
-          "expected": -1
+          "expected": {"error": "square must be between 1 and 64"}
         },
         {
           "description": "negative square raises an exception",
@@ -80,7 +80,7 @@
           "input": {
             "square": -1
           },
-          "expected": -1
+          "expected": {"error": "square must be between 1 and 64"}
         },
         {
           "description": "square greater than 64 raises an exception",
@@ -88,7 +88,7 @@
           "input": {
             "square": 65
           },
-          "expected": -1
+          "expected": {"error": "square must be between 1 and 64"}
         }
       ]
     },


### PR DESCRIPTION
Fixes https://github.com/exercism/problem-specifications/issues/1309. 

Also, modified the comments so that it reflects the current state of how the error is indicated.