### PR TITLE
crypto-square, dominoes, simple-cipher: Fix misspellings

### DIFF
--- a/exercises/crypto-square/description.md
+++ b/exercises/crypto-square/description.md
@@ -57,7 +57,7 @@ chunks with a single trailing space.
 ```
 
 Notice that were we to stack these, we could visually decode the
-cyphertext back in to the original message:
+ciphertext back in to the original message:
 
 ```text
 "imtgdvs"

--- a/exercises/dominoes/description.md
+++ b/exercises/dominoes/description.md
@@ -2,8 +2,8 @@ Make a chain of dominoes.
 
 Compute a way to order a given set of dominoes in such a way that they form a
 correct domino chain (the dots on one half of a stone match the dots on the
-neighbouring half of an adjacent stone) and that dots on the halfs of the stones
-which don't have a neighbour (the first and last stone) match each other.
+neighbouring half of an adjacent stone) and that dots on the halves of the
+stones which don't have a neighbour (the first and last stone) match each other.
 
 For example given the stones `[2|1]`, `[2|3]` and `[1|3]` you should compute something
 like `[1|2] [2|3] [3|1]` or `[3|2] [2|1] [1|3]` or `[1|3] [3|2] [2|1]` etc, where the first and last numbers are the same.

--- a/exercises/simple-cipher/description.md
+++ b/exercises/simple-cipher/description.md
@@ -11,8 +11,8 @@ for A, and so with the others."
 
 Ciphers are very straight-forward algorithms that allow us to render
 text less readable while still allowing easy deciphering. They are
-vulnerable to many forms of cryptoanalysis, but we are lucky that
-generally our little sisters are not cryptoanalysts.
+vulnerable to many forms of cryptanalysis, but we are lucky that
+generally our little sisters are not cryptanalysts.
 
 The Caesar Cipher was used for some messages from Julius Caesar that
 were sent afield. Now Caesar knew that the cipher wasn't very good, but


### PR DESCRIPTION
Ran a spell check on the Rust exercises.

exercism/rust#656