### PR TITLE
phone-number: invalid when 12 digits and starting with "1" "1"

### DIFF
--- a/exercises/phone-number/canonical-data.json
+++ b/exercises/phone-number/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "phone-number",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "cases": [
     {
       "description": "Cleanup user-entered phone numbers",
@@ -71,6 +71,14 @@
           "property": "clean",
           "input": {
             "phrase": "321234567890"
+          },
+          "expected": null
+        },
+        {
+          "description": "invalid when 12 digits and starting with 11",
+          "property": "clean",
+          "input": {
+            "phrase": "112345678987"
           },
           "expected": null
         },


### PR DESCRIPTION
This should catch solutions with a validation function that calls itself recursively when the first digit is '1'.