### PR TITLE
phone-number: add cases to test data that cover invalid use of "1" or "0"

### DIFF
--- a/exercises/phone-number/canonical-data.json
+++ b/exercises/phone-number/canonical-data.json
@@ -121,6 +121,38 @@
             "phrase": "(223) 156-7890"
           },
           "expected": null
+        },
+        {
+          "description": "invalid if area code starts with 0 on valid 11-digit number",
+          "property": "clean",
+          "input": {
+            "phrase": "1 (023) 456-7890"
+          },
+          "expected": null
+        },
+        {
+          "description": "invalid if area code starts with 1 on valid 11-digit number",
+          "property": "clean",
+          "input": {
+            "phrase": "1 (123) 456-7890"
+          },
+          "expected": null
+        },
+        {
+          "description": "invalid if exchange code starts with 0 on valid 11-digit number",
+          "property": "clean",
+          "input": {
+            "phrase": "1 (223) 056-7890"
+          },
+          "expected": null
+        },
+        {
+          "description": "invalid if exchange code starts with 1 on valid 11-digit number",
+          "property": "clean",
+          "input": {
+            "phrase": "1 (223) 156-7890"
+          },
+          "expected": null
         }
       ]
     }

--- a/exercises/phone-number/canonical-data.json
+++ b/exercises/phone-number/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "phone-number",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "cases": [
     {
       "description": "Cleanup user-entered phone numbers",

--- a/exercises/phone-number/canonical-data.json
+++ b/exercises/phone-number/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "phone-number",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "cases": [
     {
       "description": "Cleanup user-entered phone numbers",


### PR DESCRIPTION
…11-digit numbers with invalid area/exchange codes

closes #1320 