### PR TITLE
robot-simulator: remove ambiguity from test data

### DIFF
--- a/exercises/robot-simulator/canonical-data.json
+++ b/exercises/robot-simulator/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "robot-simulator",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "comments": [
     "Some tests have two expectations: one for the position, one for the direction",
     "Optionally, you can also test",
@@ -54,23 +54,6 @@
       "description": "rotates the robot's direction 90 degrees clockwise",
       "cases": [
         {
-          "description": "does not change the position",
-          "property": "turnRight",
-          "input": {
-            "position": {
-              "x": 0,
-              "y": 0
-            },
-            "direction": "north"
-          },
-          "expected": {
-            "position": {
-              "x": 0,
-              "y": 0
-            }
-          }
-        },
-        {
           "description": "changes the direction from north to east",
           "property": "turnRight",
           "input": {
@@ -81,6 +64,10 @@
             "direction": "north"
           },
           "expected": {
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "east"
           }
         },
@@ -95,6 +82,10 @@
             "direction": "east"
           },
           "expected": {
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "south"
           }
         },
@@ -109,6 +100,10 @@
             "direction": "south"
           },
           "expected": {
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "west"
           }
         },
@@ -123,6 +118,10 @@
             "direction": "west"
           },
           "expected": {
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "north"
           }
         }
@@ -131,23 +130,6 @@
     {
       "description": "rotates the robot's direction 90 degrees counter-clockwise",
       "cases": [
-        {
-          "description": "does not change the position",
-          "property": "turnLeft",
-          "input": {
-            "position": {
-              "x": 0,
-              "y": 0
-            },
-            "direction": "north"
-          },
-          "expected": {
-            "position": {
-              "x": 0,
-              "y": 0
-            }
-          }
-        },
         {
           "description": "changes the direction from north to west",
           "property": "turnLeft",
@@ -159,6 +141,10 @@
             "direction": "north"
           },
           "expected": {
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "west"
           }
         },
@@ -173,6 +159,10 @@
             "direction": "west"
           },
           "expected": {
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "south"
           }
         },
@@ -187,6 +177,10 @@
             "direction": "south"
           },
           "expected": {
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "east"
           }
         },
@@ -201,6 +195,10 @@
             "direction": "east"
           },
           "expected": {
+            "position": {
+              "x": 0,
+              "y": 0
+            },
             "direction": "north"
           }
         }
@@ -209,20 +207,6 @@
     {
       "description": "moves the robot forward 1 space in the direction it is pointing",
       "cases": [
-        {
-          "description": "does not change the direction",
-          "property": "advance",
-          "input": {
-            "position": {
-              "x": 0,
-              "y": 0
-            },
-            "direction": "north"
-          },
-          "expected": {
-            "direction": "north"
-          }
-        },
         {
           "description": "increases the y coordinate one when facing north",
           "property": "advance",
@@ -237,7 +221,8 @@
             "position": {
               "x": 0,
               "y": 1
-            }
+            },
+            "direction": "north"
           }
         },
         {
@@ -254,7 +239,8 @@
             "position": {
               "x": 0,
               "y": -1
-            }
+            },
+            "direction": "south"
           }
         },
         {
@@ -271,7 +257,8 @@
             "position": {
               "x": 1,
               "y": 0
-            }
+            },
+            "direction": "east"
           }
         },
         {
@@ -288,7 +275,8 @@
             "position": {
               "x": -1,
               "y": 0
-            }
+            },
+            "direction": "west"
           }
         }
       ]


### PR DESCRIPTION
Several cases do not have completely clear "expected" results documented.  Some of the exercises did not indicate what compass direction was related to "x" or "y", those cases were removed as follow on cases did clearly indicate compass direction association.  Also cases that only changed direction, without advancing, were not checking that the expected position was still the same as the input position.