### PR TITLE
binary-search: Use error object instead of sentinel -1

### DIFF
--- a/exercises/binary-search/canonical-data.json
+++ b/exercises/binary-search/canonical-data.json
@@ -1,8 +1,8 @@
 {
   "exercise": "binary-search",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "comments": [
-    "Here -1 is used to indicate that the value is not included in the array.",
+    "The error object is used to indicate that the value is not included in the array.",
     "It should be replaced with the respective expression that is idiomatic",
     "for the language that implements the tests.",
 
@@ -77,7 +77,7 @@
         "array": [1, 3, 4, 6, 8, 9, 11],
         "value": 7
       },
-      "expected": -1
+      "expected": {"error": "value not in array"}
     },
     {
       "description": "a value smaller than the array's smallest value is not included",
@@ -86,7 +86,7 @@
         "array": [1, 3, 4, 6, 8, 9, 11],
         "value": 0
       },
-      "expected": -1
+      "expected": {"error": "value not in array"}
     },
     {
       "description": "a value larger than the array's largest value is not included",
@@ -95,7 +95,7 @@
         "array": [1, 3, 4, 6, 8, 9, 11],
         "value": 13
       },
-      "expected": -1
+      "expected": {"error": "value not in array"}
     },
     {
       "description": "nothing is included in an empty array",
@@ -104,7 +104,7 @@
         "array": [],
         "value": 1
       },
-      "expected": -1
+      "expected": {"error": "value not in array"}
     }
   ]
 }


### PR DESCRIPTION
binary-search 1.2.0

As discussed in
https://github.com/exercism/problem-specifications/issues/1312

Although -1 is a sentinel value, using this sentinel value is not the
usual course of action in some languages. In using an error object, we
avoid giving the wrong idea that we are requiring the use of the
sentinel value.

This error value was defined in
https://github.com/exercism/problem-specifications/issues/401

Of course, languages that wish to use a sentinel value may continue to
do so; this commit is not intended to decree that sentinel values are
forbidden.

Neither is this commit decreeing that all languages must represent this
condition as an error; it is simply a declaration that this condition
bears enough consideration that we'll represent it with a different
type.

Closes https://github.com/exercism/problem-specifications/issues/1312
Checks the related box in https://github.com/exercism/problem-specifications/issues/1311