### PR TITLE
change: Use error object instead of sentinel -1

### DIFF
--- a/exercises/change/canonical-data.json
+++ b/exercises/change/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "change",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "comments": [
     "Given an infinite supply of coins with different values, ",
     "find the smallest number of coins needed to make a desired ",
@@ -88,7 +88,7 @@
         "coins": [5, 10],
         "target": 3
       },
-      "expected": -1
+      "expected": {"error": "can't make target with given coins"}
     },
     {
       "description": "error if no combination can add up to target",
@@ -97,7 +97,7 @@
         "coins": [5, 10],
         "target": 94
       },
-      "expected": -1
+      "expected": {"error": "can't make target with given coins"}
     },
     {
       "description": "cannot find negative change values",
@@ -106,7 +106,7 @@
         "coins": [1, 2, 5],
         "target": -5
       },
-      "expected": -1
+      "expected": {"error": "target can't be negative"}
     }
   ]
 }


### PR DESCRIPTION
change 1.3.0

As proposed in
https://github.com/exercism/problem-specifications/issues/1313
https://github.com/exercism/problem-specifications/issues/905#issuecomment-330184896

In contrast to the proposal in
https://github.com/exercism/problem-specifications/issues/336#issuecomment-280231149

Although -1 is a sentinel value, the sentinel value had been overloaded
in this JSON file to mean two separate conditions:

* "Can't make target" (ostensibly, we might be able to make the target
  with a different set of coins)
* "Target is negative" (no matter what coins we provide, this target is
  always invalid)

To make clear that these two conditions are different, we use an error
object describing each.

This error object was defined in
https://github.com/exercism/problem-specifications/issues/401

Note that this commit is not a decree that all languages must represent
these conditions as errors; languages should continue to represent the
conditions in the usual way for that language. It is simply a
declaration that these two conditions bear enough consideration that
we'll represent them with a different type and also clearly
differentiate between the two.

Closes https://github.com/exercism/problem-specifications/issues/1313
Checks the related box in https://github.com/exercism/problem-specifications/issues/1311