### PR TITLE
pascals-triangle:  remove case that is out of scope

### DIFF
--- a/exercises/pascals-triangle/canonical-data.json
+++ b/exercises/pascals-triangle/canonical-data.json
@@ -1,10 +1,9 @@
 {
   "exercise": "pascals-triangle",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "comments": [
     "Expectations are represented here as an array of arrays.",
-    "How you represent this idiomatically in your language is up to you.",
-    "An expectation of 'error' indicates some sort of failure should occur."
+    "How you represent this idiomatically in your language is up to you."
   ],
   "cases": [
     {
@@ -73,14 +72,6 @@
             "count": 10
           },
           "expected": [[1], [1, 1], [1, 2, 1], [1, 3, 3, 1], [1, 4, 6, 4, 1], [1, 5, 10, 10, 5, 1], [1, 6, 15, 20, 15, 6, 1], [1, 7, 21, 35, 35, 21, 7, 1], [1, 8, 28, 56, 70, 56, 28, 8, 1], [1, 9, 36, 84, 126, 126, 84, 36, 9, 1]]
-        },
-        {
-          "description": "negative rows",
-          "property": "rows",
-          "input": {
-            "count": -1
-          },
-          "expected": {"error": "count must be positive"}
         }
       ]
     }


### PR DESCRIPTION
case `negative rows` is out of scope for this exercise.  I would like to remove it.
I have also updated the comments to reflect that no longer do any "error" objects appear in the test data.
per comments made in #1336.