### PR TITLE
alphametics: v1.3.0 Add test for two digits carry

### DIFF
--- a/exercises/alphametics/canonical-data.json
+++ b/exercises/alphametics/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "alphametics",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "cases": [
     {
       "description": "Solve the alphametics puzzle",
@@ -32,6 +32,18 @@
             "puzzle": "ACA + DD == BD"
           },
           "expected": null
+        },
+        {
+          "description": "puzzle with two digits final carry",
+          "property": "solve",
+          "input": {
+            "puzzle": "A + A + A + A + A + A + A + A + A + A + A + B == BCC"
+          },
+          "expected": {
+            "A": 9,
+            "B": 1,
+            "C": 0
+          }
         },
         {
           "description": "puzzle with four letters",


### PR DESCRIPTION
Add test where result is longer than largest addendum by more than one
digit. In solutions that sum each digit separately this could be useful
to make sure final carry is handled correctly. For example: not
treated as a single digit.

Resolves: 1342