### PR TITLE
Simple-Cipher: Added additional test case

### DIFF
--- a/exercises/simple-cipher/canonical-data.json
+++ b/exercises/simple-cipher/canonical-data.json
@@ -134,6 +134,14 @@
           },
           "expected": { "error": "Bad key" }
         },
+         {
+          "description": "Throws an error with a non-alphanumeric key",
+          "property": "new",
+          "input": {
+            "key": "!@#$%"
+          },
+          "expected": { "error": "Bad key" }
+        },
         {
           "description": "Throws an error with empty key",
           "property": "new",


### PR DESCRIPTION
There are more invalid keys for this exercise than just UPPER-CASE and numer1c.