### PR TITLE
simple-cipher: remove checks for invalid input

### DIFF
--- a/exercises/simple-cipher/canonical-data.json
+++ b/exercises/simple-cipher/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "simple-cipher",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "comments":
     ["Some of the strings used in this file are symbolic and do not represent their literal value. They are:",
       "cipher.key - Represents the Cipher key",
@@ -112,35 +112,6 @@
             "plaintext": "iamapandabear"
           },
           "expected": "iboaqcnecbfcr"
-        }
-      ]
-    },
-    {
-      "description": "Incorrect key cipher",
-      "cases": [
-        {
-          "description": "Throws an error with an all uppercase key",
-          "property": "new",
-          "input": {
-            "key": "ABCDEF"
-          },
-          "expected": { "error": "Bad key" }
-        },
-        {
-          "description": "Throws an error with a numeric key",
-          "property": "new",
-          "input": {
-            "key": "12345"
-          },
-          "expected": { "error": "Bad key" }
-        },
-        {
-          "description": "Throws an error with empty key",
-          "property": "new",
-          "input": {
-            "key": ""
-          },
-          "expected": { "error": "Bad key" }
         }
       ]
     }

--- a/exercises/simple-cipher/description.md
+++ b/exercises/simple-cipher/description.md
@@ -59,10 +59,7 @@ substitution cipher a little more fault tolerant by providing a source
 of randomness and ensuring that the key contains only lowercase letters.
 
 If someone doesn't submit a key at all, generate a truly random key of
-at least 100 characters in length.
-
-If the key submitted is not composed only of lowercase letters, your
-solution should handle the error in a language-appropriate way.
+at least 100 alphanumeric characters in length.
 
 ## Extensions
 


### PR DESCRIPTION
- Mention of invalid input removed from README.
- Removed cases that test for invalid input.

These changes follow on the discussion that has taken place in  #902 and #523.  There may be some other examples regarding the discussion that I am missing.  Feel free to point them out.

This PR is intended to be an alternate solution to #1298 to replace #1316.