### PR TITLE
anagram: words are not anagrams of themselves

### DIFF
--- a/exercises/anagram/canonical-data.json
+++ b/exercises/anagram/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "anagram",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "cases": [
     {
       "description": "no matches",
@@ -109,11 +109,11 @@
       "expected": []
     },
     {
-      "description": "capital word is not own anagram",
+      "description": "words are not anagrams of themselves (case-insensitive)",
       "property": "findAnagrams",
       "input": {
         "subject": "BANANA",
-        "candidates": ["Banana"]
+        "candidates": ["BANANA", "Banana", "banana"]
       },
       "expected": []
     }


### PR DESCRIPTION
The logical extension of Banana not being an anagram of BANANA must be that words are never anagrams of themselves, and that the test "capital word is not own anagram" only tests this for case insensitivity.

Otherwise, I'm unsure what the rule is. If the rule has to do with grammar, e.g. the first letter can be insensitive, but the rest can't, then perhaps the problem needs to be explained in the README or in the test-case "capital word is not own anagram".