### PR TITLE
sum-of-multiples: test added, multiples of 3 or 5 up to 20

### DIFF
--- a/exercises/sum-of-multiples/canonical-data.json
+++ b/exercises/sum-of-multiples/canonical-data.json
@@ -39,7 +39,7 @@
       "expected": 23
     },
     {
-      "description": "multiples of 3 or 5 up to 20 with distinct multiples of 3 or 5",
+      "description": "distinct multiples of 3 or 5 up to 20",
       "property": "sum",
       "input": {
         "factors": [3, 5],
@@ -48,7 +48,7 @@
       "expected": 78
     },
     {
-      "description": "multiples of 3 or 5 up to 100",
+      "description": "distinct multiples of 3 or 5 up to 100",
       "property": "sum",
       "input": {
         "factors": [3, 5],
@@ -57,7 +57,7 @@
       "expected": 2318
     },
     {
-      "description": "multiples of 3 or 5 up to 1000",
+      "description": "distinct multiples of 3 or 5 up to 1000",
       "property": "sum",
       "input": {
         "factors": [3, 5],
@@ -75,7 +75,7 @@
       "expected": 51
     },
     {
-      "description": "multiples of 4 or 6 up to 15",
+      "description": "distinct multiples of 4 or 6 up to 15",
       "property": "sum",
       "input": {
         "factors": [4, 6],
@@ -84,7 +84,7 @@
       "expected": 30
     },
     {
-      "description": "multiples of 5, 6 or 8 up to 150",
+      "description": "distinct multiples of 5, 6 or 8 up to 150",
       "property": "sum",
       "input": {
         "factors": [5, 6, 8],
@@ -93,7 +93,7 @@
       "expected": 4419
     },
     {
-      "description": "multiples of 5 or 25 up to 51",
+      "description": "distinct multiples of 5 or 25 up to 51",
       "property": "sum",
       "input": {
         "factors": [5, 25],
@@ -102,7 +102,7 @@
       "expected": 275
     },
     {
-      "description": "multiples of 43 or 47 up to 10000",
+      "description": "distinct multiples of 43 or 47 up to 10000",
       "property": "sum",
       "input": {
         "factors": [43, 47],

--- a/exercises/sum-of-multiples/canonical-data.json
+++ b/exercises/sum-of-multiples/canonical-data.json
@@ -39,6 +39,15 @@
       "expected": 23
     },
     {
+      "description": "multiples of 3 or 5 up to 20",
+      "property": "sum",
+      "input": {
+        "factors": [3, 5],
+        "limit": 10
+      },
+      "expected": 78
+    },
+    {
       "description": "multiples of 3 or 5 up to 100",
       "property": "sum",
       "input": {

--- a/exercises/sum-of-multiples/canonical-data.json
+++ b/exercises/sum-of-multiples/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "sum-of-multiples",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "cases": [
     {
       "description": "multiples of 3 or 5 up to 1",
@@ -39,11 +39,11 @@
       "expected": 23
     },
     {
-      "description": "multiples of 3 or 5 up to 20",
+      "description": "multiples of 3 or 5 up to 20 with distinct multiples of 3 or 5",
       "property": "sum",
       "input": {
         "factors": [3, 5],
-        "limit": 10
+        "limit": 20
       },
       "expected": 78
     },


### PR DESCRIPTION
follow up of https://github.com/exercism/kotlin/pull/235

This PR adds a test about an interesting case:

Given a set of 2 items `setOf(3, 5)` and the natural number of _20_ as threshold the result can be **78** or **93**. This is because: 15 is part of the interim results for both, `3` and `5`.
I believe 15 should be counted only once for the final result, so I am a fan of the final result **78**. In case you'd count 15 twice, you'd end up with a final result of **93**

This debug screenshot based on a kotlin solution hopefully helps to understand my point of view:

![screenshot_2018-10-02_08-33-36](https://user-images.githubusercontent.com/1148268/46332845-4e503d00-c61e-11e8-8112-34a49a5d5422.png)


All other existing test cases passed in my tests with both implementations. The additional test case I propose shall make sure only one implementation as described above is valid and thus shape the expected overall result.
