### PR TITLE
triangle: More combinations of non-isosceles triangles

### DIFF
--- a/exercises/triangle/canonical-data.json
+++ b/exercises/triangle/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "triangle",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "comments": [
     " Pursuant to discussion in #202, we have decided NOT to test triangles ",
     " where all side lengths are positive but a + b = c. e.g:               ",
@@ -111,10 +111,26 @@
           "expected": false
         },
         {
-          "description": "Sides that violate triangle inequality are not isosceles, even if two are equal",
+          "description": "Sides that violate triangle inequality are not isosceles, even if two are equal (1)",
           "property": "isosceles",
           "input": {
             "sides": [1, 1, 3]
+          },
+          "expected": false
+        },
+        {
+          "description": "Sides that violate triangle inequality are not isosceles, even if two are equal (2)",
+          "property": "isosceles",
+          "input": {
+            "sides": [1, 3, 1]
+          },
+          "expected": false
+        },
+        {
+          "description": "Sides that violate triangle inequality are not isosceles, even if two are equal (3)",
+          "property": "isosceles",
+          "input": {
+            "sides": [3, 1, 1]
           },
           "expected": false
         },


### PR DESCRIPTION
A wrong implementation of `is_isosceles` might look like:

    let is_isosceles a b c =
      is_triangle a b c &&
        a = b || b = c || a = c

when the intention was:

    let is_isosceles a b c =
      is_triangle a b c &&
        (a = b || b = c || a = c)

The current test suite doesn't catch that because of order.