### PR TITLE
simple-cipher: Add a test for mixed-case key

### DIFF
--- a/exercises/simple-cipher/canonical-data.json
+++ b/exercises/simple-cipher/canonical-data.json
@@ -127,6 +127,14 @@
           "expected": { "error": "Bad key" }
         },
         {
+          "description": "Throws an error with a mixed-case key",
+          "property": "new",
+          "input": {
+            "key": "ABcdEF"
+          },
+          "expected": { "error": "Bad key" }
+        },
+        {
           "description": "Throws an error with a numeric key",
           "property": "new",
           "input": {


### PR DESCRIPTION
The [problem specification](https://github.com/exercism/problem-specifications/blob/69a64641e21a50dc8d037e55c1404cf20074ee70/exercises/simple-cipher/description.md#step-3) asserts that "the key contains only lowercase letters", but the test data only tests the key is "not all uppercase".

I have already added this test to the [TypeScript](https://github.com/exercism/typescript/pull/219) and [JavaScript](https://github.com/exercism/javascript/pull/491) tracks. It was suggested it should be added to the canonical test data too.