### PR TITLE
leap 1.4.0: Add negative test: year divisible by 200, not divisible by 400

### DIFF
--- a/exercises/leap/canonical-data.json
+++ b/exercises/leap/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "leap",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "cases": [
     {
       "description": "year not divisible by 4: common year",
@@ -33,6 +33,14 @@
         "year": 2000
       },
       "expected": true
+    },
+    {
+      "description": "year divisible by 200, not divisible by 400: common year",
+      "property": "leapYear",
+      "input": {
+        "year": 1800
+      },
+      "expected": false
     }
   ]
 }


### PR DESCRIPTION
Someone thought they could write `year mod 200 = 0`. Test didn't fail.