### PR TITLE
sum-of-multiples-1.3.0: the only multiple of 0 is 0

### DIFF
--- a/exercises/sum-of-multiples/canonical-data.json
+++ b/exercises/sum-of-multiples/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "sum-of-multiples",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "cases": [
     {
       "description": "multiples of 3 or 5 up to 1",
@@ -116,6 +116,15 @@
       "input": {
         "factors": [],
         "limit": 10000
+      },
+      "expected": 0
+    },
+    {
+      "description": "the only multiple of 0 is 0",
+      "property": "sum",
+      "input": {
+        "factors": [0],
+        "limit": 1
       },
       "expected": 0
     }


### PR DESCRIPTION
This change addresses 0 as a possible input factor with a test case.

As I was solving this exercise on the Haskell track, Frerich pointed out that my solution didn't terminate for `sumOfMultiples [0] 1`. This was due to `[0,factor..limit-1]` producing an infinite stream of zeroes. Since the only multiple of 0 is 0 itself, the result should be 0.

The problem description is (perhaps deliberately) vague about the sign on the input types ("Given a number", "particular numbers") and the output type ("unique multiples"). But it still sort of implies that all are non-negative, since otherwise there would be infinitely many negative multiples *up to but not including that number*, given no lower bound.

I propose that we keep things simple and continue to not test for or make any rewording regarding negative input factors or negative multiples.

For 0 as a possible input factor we could either:

 1. Not test for 0 and continue to be vague in the problem description. (What we currently do.)

 2. Test 0 as an input factor and change to "particular *non-negative* numbers" in problem description.

 3. **Test 0 as an input factor, but continue to be vague in the problem description.**

I prefer (3) over (1) because this seems like an edge case more than a generalisation of the problem (handling negative factors/multiples). And I prefer (3) over (2) because it is unsatisfying to add "*non-negative*" in *one* place where this is assumed without adding it to *all* places. Adding it to all places will make the problem description mathematically verbose.