### PR TITLE
sum-of-multiples: handle cardinality > 3 correctly

### DIFF
--- a/exercises/sum-of-multiples/canonical-data.json
+++ b/exercises/sum-of-multiples/canonical-data.json
@@ -133,9 +133,9 @@
       "property": "sum",
       "input": {
         "factors": [2, 3, 5, 7, 11],
-        "limit": 100
+        "limit": 10000
       },
-      "expected": 3917
+      "expected": 39614537
     }
   ]
 }

--- a/exercises/sum-of-multiples/canonical-data.json
+++ b/exercises/sum-of-multiples/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "sum-of-multiples",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "cases": [
     {
       "description": "multiples of 3 or 5 up to 1",
@@ -127,6 +127,15 @@
         "limit": 1
       },
       "expected": 0
+    },
+    {
+      "description": "multiples of 5 primes up to 100",
+      "property": "sum",
+      "input": {
+        "factors": [2, 3, 5, 7, 11],
+        "limit": 100
+      },
+      "expected": 3917
     }
   ]
 }

--- a/exercises/sum-of-multiples/canonical-data.json
+++ b/exercises/sum-of-multiples/canonical-data.json
@@ -129,7 +129,7 @@
       "expected": 0
     },
     {
-      "description": "multiples of 5 primes up to 100",
+      "description": "solutions using include-exclude must extend to cardinality greater than 3",
       "property": "sum",
       "input": {
         "factors": [2, 3, 5, 7, 11],


### PR DESCRIPTION
Closes #1367.

For some reason the diff is currently showing against the 1.2.0 version, but that's not what appears to be in master (1.3.0). My only change is the addition of the `multiples of 5 primes up to 100` test case.