### PR TITLE
list-ops: add description of basic operations

### DIFF
--- a/exercises/list-ops/description.md
+++ b/exercises/list-ops/description.md
@@ -3,3 +3,16 @@ Implement basic list operations.
 In functional languages list operations like `length`, `map`, and
 `reduce` are very common. Implement a series of basic list operations,
 without using existing functions.
+
+The precise number and names of the operations to be implemented will be 
+track dependent to avoid conflicts with existing names, but the general
+operations you will implement include:
+
+* `append` (*given two lists, add all items in the right-hand list to the end of the left-hand list*);
+* `concatenate` (*given a series of lists, combine all items in all lists into one flattened list*);
+* `filter` (*given a predicate and a list, return the list of all items for which `predicate(item)` is True*);
+* `length` (*given a list, return the total number of items within it*);
+* `map` (*given a function and a list, return the list of the results of running `function(item)` on all items*);
+* `foldl` (*given a function, a list, and initial accumulator, fold (reduce) each item into the accumulator from the left using `function(accumulator, item)`*);
+* `foldr` (*given a function, a list, and an initial accumulator, fold (reduce) each item into the accumulator from the right using `function(item, accumulator)`*);
+* `reverse` (*given a list, return a list with all the original items, but in reversed order*);

--- a/exercises/list-ops/description.md
+++ b/exercises/list-ops/description.md
@@ -8,11 +8,11 @@ The precise number and names of the operations to be implemented will be
 track dependent to avoid conflicts with existing names, but the general
 operations you will implement include:
 
-* `append` (*given two lists, add all items in the right-hand list to the end of the left-hand list*);
+* `append` (*given two lists, add all items in the second list to the end of the first list*);
 * `concatenate` (*given a series of lists, combine all items in all lists into one flattened list*);
 * `filter` (*given a predicate and a list, return the list of all items for which `predicate(item)` is True*);
 * `length` (*given a list, return the total number of items within it*);
-* `map` (*given a function and a list, return the list of the results of running `function(item)` on all items*);
+* `map` (*given a function and a list, return the list of the results of applying `function(item)` on all items*);
 * `foldl` (*given a function, a list, and initial accumulator, fold (reduce) each item into the accumulator from the left using `function(accumulator, item)`*);
 * `foldr` (*given a function, a list, and an initial accumulator, fold (reduce) each item into the accumulator from the right using `function(item, accumulator)`*);
 * `reverse` (*given a list, return a list with all the original items, but in reversed order*);


### PR DESCRIPTION
Adds a cursory description of each of the basic operations described in the [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/list-ops/canonical-data.json) for this exercise.

Closes #1369.