### PR TITLE
sum-of-multiples: describe the importance of each test

### DIFF
--- a/exercises/sum-of-multiples/canonical-data.json
+++ b/exercises/sum-of-multiples/canonical-data.json
@@ -1,9 +1,9 @@
 {
   "exercise": "sum-of-multiples",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "cases": [
     {
-      "description": "multiples of 3 or 5 up to 1",
+      "description": "no multiples within limit",
       "property": "sum",
       "input": {
         "factors": [3, 5],
@@ -12,7 +12,7 @@
       "expected": 0
     },
     {
-      "description": "multiples of 3 or 5 up to 4",
+      "description": "one factor has multiples within limit",
       "property": "sum",
       "input": {
         "factors": [3, 5],
@@ -21,7 +21,7 @@
       "expected": 3
     },
     {
-      "description": "multiples of 3 up to 7",
+      "description": "more than one multiple within limit",
       "property": "sum",
       "input": {
         "factors": [3],
@@ -30,7 +30,7 @@
       "expected": 9
     },
     {
-      "description": "multiples of 3 or 5 up to 10",
+      "description": "more than one factor with multiples within limit",
       "property": "sum",
       "input": {
         "factors": [3, 5],
@@ -39,7 +39,7 @@
       "expected": 23
     },
     {
-      "description": "multiples of 3 or 5 up to 100",
+      "description": "each multiple is only counted once",
       "property": "sum",
       "input": {
         "factors": [3, 5],
@@ -48,7 +48,7 @@
       "expected": 2318
     },
     {
-      "description": "multiples of 3 or 5 up to 1000",
+      "description": "a much larger limit",
       "property": "sum",
       "input": {
         "factors": [3, 5],
@@ -57,7 +57,7 @@
       "expected": 233168
     },
     {
-      "description": "multiples of 7, 13 or 17 up to 20",
+      "description": "three factors",
       "property": "sum",
       "input": {
         "factors": [7, 13, 17],
@@ -66,7 +66,7 @@
       "expected": 51
     },
     {
-      "description": "multiples of 4 or 6 up to 15",
+      "description": "factors not relatively prime",
       "property": "sum",
       "input": {
         "factors": [4, 6],
@@ -75,7 +75,7 @@
       "expected": 30
     },
     {
-      "description": "multiples of 5, 6 or 8 up to 150",
+      "description": "some pairs of factors relatively prime and some not",
       "property": "sum",
       "input": {
         "factors": [5, 6, 8],
@@ -84,7 +84,7 @@
       "expected": 4419
     },
     {
-      "description": "multiples of 5 or 25 up to 51",
+      "description": "one factor is a multiple of another",
       "property": "sum",
       "input": {
         "factors": [5, 25],
@@ -93,7 +93,7 @@
       "expected": 275
     },
     {
-      "description": "multiples of 43 or 47 up to 10000",
+      "description": "much larger factors",
       "property": "sum",
       "input": {
         "factors": [43, 47],
@@ -102,7 +102,7 @@
       "expected": 2203160
     },
     {
-      "description": "multiples of 1 up to 100",
+      "description": "all numbers are multiples of 1",
       "property": "sum",
       "input": {
         "factors": [1],
@@ -111,7 +111,7 @@
       "expected": 4950
     },
     {
-      "description": "multiples of an empty list up to 10000",
+      "description": "no factors means an empty sum",
       "property": "sum",
       "input": {
         "factors": [],


### PR DESCRIPTION
sum-of-multiples 1.3.1

As stated in our guidelines, we want descriptions that tell us why each
case is being tested:
https://github.com/exercism/problem-specifications#test-data-format-canonical-datajson

The canonical data was added in
https://github.com/exercism/problem-specifications/pull/206 during a
time when descriptions were not required.

Then, placeholder descriptions were added in
aaa47eef1af516f96cdffc0aa23b63e06367c6fd and it was acknowledged at the
time that these descriptions were purely for *schema* compliance, and
not compliance with the guidelines nor a motivation for each case.

By examining the issues that led to each case being added, it is
possible to understand the descriptions.

With more cases being added to sum-of-multiples with clear descriptions,
it's time to bring the other descriptions up to speed as well.

Original exercise:
https://github.com/exercism/exercism/commit/607be68494d30487c001303b6dc56c2b7b975409

Additional cases:
https://github.com/exercism/exercism/issues/2486
https://github.com/exercism/exercism/issues/2341
https://github.com/exercism/haskell/pull/50
https://github.com/exercism/go/pull/53
https://github.com/exercism/problem-specifications/pull/896