### PR TITLE
sum-of-multiples: the factor 0 does not affect the sum of multiples of other factors

### DIFF
--- a/exercises/sum-of-multiples/canonical-data.json
+++ b/exercises/sum-of-multiples/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "sum-of-multiples",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "cases": [
     {
       "description": "no multiples within limit",
@@ -127,6 +127,15 @@
         "limit": 1
       },
       "expected": 0
+    },
+    {
+      "description": "the factor 0 does not affect the sum of multiples of other factors",
+      "property": "sum",
+      "input": {
+        "factors": [3, 0],
+        "limit": 4
+      },
+      "expected": 3
     },
     {
       "description": "solutions using include-exclude must extend to cardinality greater than 3",


### PR DESCRIPTION
The factor 0 is being tested since #1362. This adds a test where 0 is tested as a multiple when it isn't the only multiple. This catches errors where, if 0 is a factor, the entire result is said to be 0.