### PR TITLE
Trying to simplify the Twofer exercise specification

### DIFF
--- a/exercises/two-fer/description.md
+++ b/exercises/two-fer/description.md
@@ -1,11 +1,24 @@
 `Two-fer` or `2-fer` is short for two for one. One for you and one for me.
 
+Given a name, return a string with the message:
+
 ```text
-"One for X, one for me."
+One for X, one for me.
 ```
 
-When X is a name or "you".
+Where X is the given name.
 
-If the given name is "Alice", the result should be "One for Alice, one for me."
-If no name is given, the result should be "One for you, one for me."
+However, if the name is missing, return the string:
 
+```text
+One for you, one for me.
+```
+
+Here are some examples:
+
+|Name    | String to return 
+|:------:|:-----------------: 
+|Alice   | One for Alice, one for me. 
+|Bob     | One for Bob, one for me.
+|        | One for you, one for me.
+|Zaphod  | One for Zaphod, one for me.


### PR DESCRIPTION
As a mentor, I often see solutions of two-fer where the mentee simply didn't understand the exercise. Sometimes they just check for the names **Alice** and **Bob** and return a string with these names. If the given name is neither, they return the string with **you** instead. See for example here: https://exercism.io/mentor/solutions/93be9a7ec7014a38920063a683963ffa

I believe this problem stem from the fact that the description is unclear. This PR contains my suggestion for making it a bit clearer by being more thorough and by giving some examples. 