### PR TITLE
Acronym: New test case for apostrophe

### DIFF
--- a/exercises/acronym/canonical-data.json
+++ b/exercises/acronym/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "acronym",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "cases": [
     {
       "description": "Abbreviate a phrase",
@@ -60,6 +60,14 @@
             "phrase": "Something - I made up from thin air"
           },
           "expected": "SIMUFTA"
+        },
+        {
+          "description": "apostrophes",
+          "property": "abbreviate",
+          "input": {
+            "phrase": "Haley's Comet"
+          },
+          "expected": "HC"
         }
       ]
     }

--- a/exercises/acronym/canonical-data.json
+++ b/exercises/acronym/canonical-data.json
@@ -65,7 +65,7 @@
           "description": "apostrophes",
           "property": "abbreviate",
           "input": {
-            "phrase": "Haley's Comet"
+            "phrase": "Halley's Comet"
           },
           "expected": "HC"
         }


### PR DESCRIPTION
This is a redo of PR #1375, to be held until later review!

The current solution for Acronym doesn't account for apostrophes, it is a more rare case for acronyms but an edge case nonetheless. Is this useful?

I added a single test case and incremented the version number.