### PR TITLE
two-fer: Add blank test case

### DIFF
--- a/exercises/two-fer/canonical-data.json
+++ b/exercises/two-fer/canonical-data.json
@@ -1,12 +1,20 @@
 {
   "exercise": "two-fer",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "cases": [
     {
       "description": "no name given",
       "property": "twoFer",
       "input": {
         "name": null
+      },
+      "expected": "One for you, one for me."
+    },
+    {
+      "description": "blank name given",
+      "property": "twoFer",
+      "input": {
+        "name": ""
       },
       "expected": "One for you, one for me."
     },


### PR DESCRIPTION
I'd like to propose adding a blank string as a test case. Through mentoring I've definitely noticed that there's some ambiguity in what dictates no name given. 

I personally think both `null` and a blank string should return "you".