### PR TITLE
topics.txt: Change topic 'mathematics' to 'math'

### DIFF
--- a/TOPICS.txt
+++ b/TOPICS.txt
@@ -55,7 +55,7 @@ filtering
 games
 globalization
 logic
-mathematics
+math
 memory_management
 networking
 parallelism


### PR DESCRIPTION
See exercism/exercism#4110
Stumpled upon this while implementing a new exercise.
I would suggest to keep the topics list naming conventions consistent with the topics that should be used in the config.json of each track.