### PR TITLE
Update URL for Exercism Code of Conduct link.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ email Katrina at kytrinyx@exercism.io.
 ## Code of Conduct
 
 Help us keep Exercism welcoming. Please read and abide by the
-[Code of Conduct](https://github.com/exercism/exercism.io/blob/master/CODE_OF_CONDUCT.md).
+[Code of Conduct](https://exercism.io/code-of-conduct).
 
 ## Overview
 


### PR DESCRIPTION
See https://github.com/exercism/exercism/issues/4441.