### PR TITLE
wordy: test that problems with zero operations give the correct answer

### DIFF
--- a/exercises/wordy/canonical-data.json
+++ b/exercises/wordy/canonical-data.json
@@ -1,12 +1,20 @@
 {
   "exercise": "wordy",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "comments": [
     "The tests that expect an 'error' should be implemented to raise",
     "an error, or indicate a failure. Implement this in a way that",
     "makes sense for your language."
   ],
   "cases": [
+    {
+      "description": "just a number",
+      "property": "answer",
+      "input": {
+        "question": "What is 5?"
+      },
+      "expected": 5
+    },
     {
       "description": "addition",
       "property": "answer",

--- a/exercises/wordy/description.md
+++ b/exercises/wordy/description.md
@@ -1,5 +1,13 @@
 Parse and evaluate simple math word problems returning the answer as an integer.
 
+## Iteration 0 — Numbers
+
+Problems with no operations simply evaluate to the number given.
+
+> What is 5?
+
+Evaluates to 5.
+
 ## Iteration 1 — Addition
 
 Add two numbers together.


### PR DESCRIPTION
It's possible to have a healthy debate about whether a problem with zero
operations really should count as in scope.

One might expect that a generically-written solution would indeed accept
such a problem.

Consider an implementation that strips away all tokens except for
numbers and the four recognised operators (ignoring the intro like "What
is"). Such an implementation would now be required to distinguish
between the valid "What is 5?" versus the invalid "What is 4 cubed"
instead of simply stripping away the "cubed" and declaring the problem
invalid because it only contains the single token `4` (for that would
also declare `What is 5?` invalid)

Note that this PR intentionally has a merge conflict to prevent accidental merges. The merge conflict is trivially resolvable if it is decided this should be merged, but it should not be resolved unless discussion indicates so.