### PR TITLE
wordy: test that various syntax errors are in fact syntax errors

### DIFF
--- a/exercises/wordy/canonical-data.json
+++ b/exercises/wordy/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "wordy",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "comments": [
     "The tests that expect an 'error' should be implemented to raise",
     "an error, or indicate a failure. Implement this in a way that",
@@ -134,6 +134,46 @@
         "question": "Who is the President of the United States?"
       },
       "expected": {"error": "unknown operation"}
+    },
+    {
+      "description": "reject incomplete problem",
+      "property": "answer",
+      "input": {
+        "question": "What is 1 plus?"
+      },
+      "expected": {"error": "syntax error"}
+    },
+    {
+      "description": "reject two operations in a row",
+      "property": "answer",
+      "input": {
+        "question": "What is 1 plus plus 2?"
+      },
+      "expected": {"error": "syntax error"}
+    },
+    {
+      "description": "reject two numbers in a row",
+      "property": "answer",
+      "input": {
+        "question": "What is 1 plus 2 1?"
+      },
+      "expected": {"error": "syntax error"}
+    },
+    {
+      "description": "reject postfix notation",
+      "property": "answer",
+      "input": {
+        "question": "What is 1 2 plus?"
+      },
+      "expected": {"error": "syntax error"}
+    },
+    {
+      "description": "reject prefix notation",
+      "property": "answer",
+      "input": {
+        "question": "What is plus 1 2?"
+      },
+      "expected": {"error": "syntax error"}
     }
   ]
 }

--- a/exercises/wordy/description.md
+++ b/exercises/wordy/description.md
@@ -41,6 +41,14 @@ left-to-right, _ignoring the typical order of operations._
 
 15  (i.e. not 9)
 
+## Iteration 4 — Errors
+
+The parser should reject:
+
+* Unsupported operations ("What is 52 cubed?")
+* Non-math questions ("Who is the President of the United States")
+* Word problems with invalid syntax ("What is 1 plus plus 2?")
+
 ## Bonus — Exponentials
 
 If you'd like, handle exponentials.


### PR DESCRIPTION
By explicitly testing these we are making sure that the implementation
fails in an appropriate way, rather than failing in an inappropriate way
or erroneously giving an answer.

For example, in languages using an optional for their answer, ensuring
that [`None` is returned instead of panicking/aborting][1].

[1]: https://github.com/exercism/rust/pull/704#discussion_r230593072

This is beneficial because the problem is partially about building a
parser (even if very rudimentary), and it's common for parsers to have
to deal with errors like this. We may otherwise see some unfortunately
fragile parsers.

~~Intentional merge conflict for the same reason as #1382~~