### PR TITLE
matrix: Switch to canonical notation of matrix indices

### DIFF
--- a/exercises/matrix/canonical-data.json
+++ b/exercises/matrix/canonical-data.json
@@ -1,13 +1,13 @@
 {
   "exercise": "matrix",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "cases": [
     {
       "description": "extract row from one number matrix",
       "property": "row",
       "input": {
         "string": "1",
-        "index": 0
+        "index": 1
       },
       "expected": [1]
     },
@@ -16,7 +16,7 @@
       "property": "row",
       "input": {
         "string": "1 2\n3 4",
-        "index": 1
+        "index": 2
       },
       "expected": [3, 4]
     },
@@ -25,7 +25,7 @@
       "property": "row",
       "input": {
         "string": "1 2\n10 20",
-        "index": 1
+        "index": 2
       },
       "expected": [10, 20]
     },
@@ -34,7 +34,7 @@
       "property": "row",
       "input": {
         "string": "1 2 3\n4 5 6\n7 8 9\n8 7 6",
-        "index": 2
+        "index": 3
       },
       "expected": [7, 8, 9]
     },
@@ -43,7 +43,7 @@
       "property": "column",
       "input": {
         "string": "1",
-        "index": 0
+        "index": 1
       },
       "expected": [1]
     },
@@ -52,7 +52,7 @@
       "property": "column",
       "input": {
         "string": "1 2 3\n4 5 6\n7 8 9",
-        "index": 2
+        "index": 3
       },
       "expected": [3, 6, 9]
     },
@@ -61,7 +61,7 @@
       "property": "column",
       "input": {
         "string": "1 2 3\n4 5 6\n7 8 9\n8 7 6",
-        "index": 2
+        "index": 3
       },
       "expected": [3, 6, 9, 6]
     },
@@ -70,7 +70,7 @@
       "property": "column",
       "input": {
         "string": "89 1903 3\n18 3 1\n9 4 800",
-        "index": 1
+        "index": 2
       },
       "expected": [1903, 3, 4]
     }

--- a/exercises/matrix/description.md
+++ b/exercises/matrix/description.md
@@ -12,11 +12,11 @@ So given a string with embedded newlines like:
 representing this matrix:
 
 ```text
-    0  1  2
+    1  2  3
   |---------
-0 | 9  8  7
-1 | 5  3  2
-2 | 6  6  7
+1 | 9  8  7
+2 | 5  3  2
+3 | 6  6  7
 ```
 
 your code should be able to spit out:


### PR DESCRIPTION
Matrix indices are usually defined so that (1, 1) is the top left entry, not (0, 0). See for example any linear algebra textbook or [wikipedia](https://en.wikipedia.org/wiki/Matrix_(mathematics)#/media/File:Matrix.svg):

![wikipedia](https://upload.wikimedia.org/wikipedia/commons/b/bb/Matrix.svg).

Even in programming, this notation is more commonly used in the context of matrices, not 2d arrays, (e.g. in Matlab, Fortran, Julia, ...) than a 0-based matrix notation.

It's less confusing for a student if the canonical definition and notation is used, so this PR changes the `canonical-data` and `description` accordingly.