### PR TITLE
bracket-push: Add test case v1.5.0

### DIFF
--- a/exercises/bracket-push/canonical-data.json
+++ b/exercises/bracket-push/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "bracket-push",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "cases": [
     {
       "description": "paired square brackets",
@@ -114,6 +114,14 @@
       },
       "expected": false
     },
+    {
+      "description": "too many closing brackets",
+      "property": "isPaired",
+      "input": {
+        "value": "[]]"
+      },
+      "expected": false
+    },    
     {
       "description": "math expression",
       "property": "isPaired",


### PR DESCRIPTION
Add test case for too many closing brackets. Without the extra
closing bracket the string is legal, so this may fail certain
stack based solutions that pass the other tests.

Resolves #1386