### PR TITLE
dnd-character: add new exercise

### DIFF
--- a/exercises/dnd-character/canonical-data.json
+++ b/exercises/dnd-character/canonical-data.json
@@ -1,0 +1,176 @@
+{
+  "exercise": "dnd-character",
+  "version": "1.0.0",
+  "comments": [
+    "The random generator 'ability' can be property-tested.",
+    "The pure function 'modifier' can be tested totally.",
+    "The random generator 'character' should return some",
+    "kind of structure with six random abilities and a",
+    "hitpoint score. This structure can be property-tested",
+    "in the same way as 'ability' and 'modifier'.",
+    "",
+    "It may be fun to provide a 'name' property for characters",
+    "that may or may not be randomly generated but not tested.",
+    "",
+    "Many programming languages feature property-based test",
+    "frameworks. For a language-agnostic introduction to",
+    "property-based testing, see:",
+    "",
+    "https://hypothesis.works/articles/what-is-property-based-testing/"
+  ],
+  "cases": [
+    {
+      "description": "ability modifier",
+      "cases": [
+        {
+          "description": "ability modifier for score 3 is -4",
+          "property": "modifier",
+          "input": {
+            "score": 3
+          },
+          "expected": -4
+        },
+        {
+          "description": "ability modifier for score 4 is -3",
+          "property": "modifier",
+          "input": {
+            "score": 4
+          },
+          "expected": -3
+        },
+        {
+          "description": "ability modifier for score 5 is -3",
+          "property": "modifier",
+          "input": {
+            "score": 5
+          },
+          "expected": -3
+        },
+        {
+          "description": "ability modifier for score 6 is -2",
+          "property": "modifier",
+          "input": {
+            "score": 6
+          },
+          "expected": -2
+        },
+        {
+          "description": "ability modifier for score 7 is -2",
+          "property": "modifier",
+          "input": {
+            "score": 7
+          },
+          "expected": -2
+        },
+        {
+          "description": "ability modifier for score 8 is -1",
+          "property": "modifier",
+          "input": {
+            "score": 8
+          },
+          "expected": -1
+        },
+        {
+          "description": "ability modifier for score 9 is -1",
+          "property": "modifier",
+          "input": {
+            "score": 9
+          },
+          "expected": -1
+        },
+        {
+          "description": "ability modifier for score 10 is 0",
+          "property": "modifier",
+          "input": {
+            "score": 10
+          },
+          "expected": 0
+        },
+        {
+          "description": "ability modifier for score 11 is 0",
+          "property": "modifier",
+          "input": {
+            "score": 11
+          },
+          "expected": 0
+        },
+        {
+          "description": "ability modifier for score 12 is +1",
+          "property": "modifier",
+          "input": {
+            "score": 12
+          },
+          "expected": 1
+        },
+        {
+          "description": "ability modifier for score 13 is +1",
+          "property": "modifier",
+          "input": {
+            "score": 13
+          },
+          "expected": 1
+        },
+        {
+          "description": "ability modifier for score 14 is +2",
+          "property": "modifier",
+          "input": {
+            "score": 14
+          },
+          "expected": 2
+        },
+        {
+          "description": "ability modifier for score 15 is +2",
+          "property": "modifier",
+          "input": {
+            "score": 15
+          },
+          "expected": 2
+        },
+        {
+          "description": "ability modifier for score 16 is +3",
+          "property": "modifier",
+          "input": {
+            "score": 16
+          },
+          "expected": 3
+        },
+        {
+          "description": "ability modifier for score 17 is +3",
+          "property": "modifier",
+          "input": {
+            "score": 17
+          },
+          "expected": 3
+        },
+        {
+          "description": "ability modifier for score 18 is +4",
+          "property": "modifier",
+          "input": {
+            "score": 18
+          },
+          "expected": 4
+        }
+      ]
+    },
+    {
+      "description": "random ability is within range",
+      "property": "ability",
+      "input": {},
+      "expected": "score >= 3 && score <= 18"
+    },
+    {
+      "description": "random character is valid",
+      "property": "character",
+      "input": {},
+      "expected": {
+        "strength": "strength >= 3 && strength <= 18",
+        "dexterity": "dexterity >= 3 && dexterity <= 18",
+        "constitution": "constitution >= 3 && constitution <= 18",
+        "intelligence": "intelligence >= 3 && intelligence <= 18",
+        "wisdom": "wisdom >= 3 && wisdom <= 18",
+        "charisma": "charisma >= 3 && charisma <= 18",
+        "hitpoints": "hitpoints == 10 + modifier(constitution)"
+      }
+    }
+  ]
+}

--- a/exercises/dnd-character/description.md
+++ b/exercises/dnd-character/description.md
@@ -1,0 +1,31 @@
+For a game of [Dungeons & Dragons][DND], each player starts by generating a
+character they can play with. This character has, among other things, six
+abilities; strength, dexterity, constitution, intelligence, wisdom and
+charisma. These six abilities have scores that are determined randomly. You
+do this by rolling four 6-sided dice and record the sum of the largest three
+dice. You do this six times, once for each ability.
+
+Your character's initial hitpoints are 10 + your character's constitution
+modifier. You find your character's constitution modifier by subtracting 10
+from your character's constitution, divide by 2 and round down.
+
+Write a random character generator that follows the rules above.
+
+For example, the six throws of four dice may look like:
+
+* 5, 3, 1, 6: You discard the 1 and sum 5 + 3 + 6 = 14, which you assign to strength.
+* 3, 2, 5, 3: You discard the 2 and sum 3 + 5 + 3 = 11, which you assign to dexterity.
+* 1, 1, 1, 1: You discard the 1 and sum 1 + 1 + 1 = 3, which you assign to constitution.
+* 2, 1, 6, 6: You discard the 1 and sum 2 + 6 + 6 = 14, which you assign to intelligence.
+* 3, 5, 3, 4: You discard the 3 and sum 5 + 3 + 4 = 12, which you assign to wisdom.
+* 6, 6, 6, 6: You discard the 6 and sum 6 + 6 + 6 = 18, which you assign to charisma.
+
+Because constitution is 3, the constitution modifier is -4 and the hitpoints are 6.
+
+## Notes
+
+Most programming languages feature (pseudo-)random generators, but few
+programming languages are designed to roll dice. One such language is [Troll].
+
+[DND]: https://en.wikipedia.org/wiki/Dungeons_%26_Dragons
+[Troll]: http://hjemmesider.diku.dk/~torbenm/Troll/

--- a/exercises/dnd-character/metadata.yml
+++ b/exercises/dnd-character/metadata.yml
@@ -1,0 +1,4 @@
+---
+blurb: "Randomly generate Dungeons & Dragons characters"
+source: "Simon Shine, Erik Schierboom"
+source_url: "https://github.com/exercism/problem-specifications/issues/616#issuecomment-437358945"


### PR DESCRIPTION
Dungeons & Dragons character generation involves rolling and picking dice.

This seems like a nice and easy introduction to (pseudo-)random generators.

There were some uncertainties with regards to how to express non-unit properties in canonical data.

Also, I'm not sure if the `[Troll]` reference was correctly formatted in Markdown.