### PR TITLE
binary-search: test for when l and r bounds cross

### DIFF
--- a/exercises/binary-search/canonical-data.json
+++ b/exercises/binary-search/canonical-data.json
@@ -80,7 +80,7 @@
       "expected": {"error": "value not in array"}
     },
     {
-      "description": "a value smaller than the array's smallest value is not included",
+      "description": "a value smaller than the array's smallest value is not found",
       "property": "find",
       "input": {
         "array": [1, 3, 4, 6, 8, 9, 11],
@@ -89,7 +89,7 @@
       "expected": {"error": "value not in array"}
     },
     {
-      "description": "a value larger than the array's largest value is not included",
+      "description": "a value larger than the array's largest value is not found",
       "property": "find",
       "input": {
         "array": [1, 3, 4, 6, 8, 9, 11],
@@ -98,7 +98,7 @@
       "expected": {"error": "value not in array"}
     },
     {
-      "description": "nothing is included in an empty array",
+      "description": "nothing is found in an empty array",
       "property": "find",
       "input": {
         "array": [],

--- a/exercises/binary-search/canonical-data.json
+++ b/exercises/binary-search/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "binary-search",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "comments": [
     "The error object is used to indicate that the value is not included in the array.",
     "It should be replaced with the respective expression that is idiomatic",
@@ -103,6 +103,15 @@
       "input": {
         "array": [],
         "value": 1
+      },
+      "expected": {"error": "value not in array"}
+    },
+    {
+      "description": "nothing is found when the left and right bounds cross",
+      "property": "find",
+      "input": {
+        "array": [1, 2],
+        "value": 0
       },
       "expected": {"error": "value not in array"}
     }


### PR DESCRIPTION
this test can catch a solution that explicitly checks for an empty array
but fails to check if the bounds cross

plus test description tweak