### PR TITLE
wordy: Test question `What is?` because it's too short

### DIFF
--- a/exercises/wordy/canonical-data.json
+++ b/exercises/wordy/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "wordy",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "comments": [
     "The tests that expect an 'error' should be implemented to raise",
     "an error, or indicate a failure. Implement this in a way that",
@@ -144,7 +144,7 @@
       "expected": {"error": "unknown operation"}
     },
     {
-      "description": "reject incomplete problem",
+      "description": "reject problem missing an operand",
       "property": "answer",
       "input": {
         "question": "What is 1 plus?"

--- a/exercises/wordy/canonical-data.json
+++ b/exercises/wordy/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "wordy",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "comments": [
     "The tests that expect an 'error' should be implemented to raise",
     "an error, or indicate a failure. Implement this in a way that",
@@ -148,6 +148,14 @@
       "property": "answer",
       "input": {
         "question": "What is 1 plus?"
+      },
+      "expected": {"error": "syntax error"}
+    },
+    {
+      "description": "reject problem with no operands or operators",
+      "property": "answer",
+      "input": {
+        "question": "What is?"
       },
       "expected": {"error": "syntax error"}
     },


### PR DESCRIPTION
wordy 1.5.0

In keeping with [1.3.0][], we want to test that these fail in an
expected way rather than an unexpected way.

[1.3.0]: https://github.com/exercism/problem-specifications/pull/1383

For example, imagine a language that uses an optional as the answer. We
would want to make sure an implementation written in that language would
return `None`, rather than (say) accessing an out-of-bounds index due to
always assuming that the inputs will have at least three space-separated
elements (of the form "What is X...?").