### PR TITLE
gigasecond: define gigasecond only once

### DIFF
--- a/exercises/gigasecond/description.md
+++ b/exercises/gigasecond/description.md
@@ -1,4 +1,4 @@
 Given a moment, determine the moment that would be after a gigasecond
-(10^9 seconds) has passed.
+has passed.
 
 A gigasecond is 10^9 (1,000,000,000) seconds.


### PR DESCRIPTION
That a gigasecond is 10^9 seconds only needs to be stated once.