### PR TITLE
sgf-parsing: Added the description of the missing SZ property in the SGF format example

### DIFF
--- a/exercises/sgf-parsing/description.md
+++ b/exercises/sgf-parsing/description.md
@@ -16,9 +16,10 @@ An SGF file may look like this:
 
 This is a tree with three nodes:
 
-- The top level node has two properties: FF\[4\] (key = "FF", value =
-  "4") and C\[root\](key = "C", value = "root"). (FF indicates the
-  version of SGF and C is a comment.)
+- The top level node has three properties: FF\[4\] (key = "FF", value
+  = "4"), C\[root\](key = "C", value = "root") and SZ\[19\] (key =
+  "SZ", value = "19"). (FF indicates the version of SGF, C is a
+  comment and SZ is the size of the board.)
   - The top level node has a single child which has a single property:
     B\[aa\].  (Black plays on the point encoded as "aa", which is the
     1-1 point (which is a stupid place to play)).


### PR DESCRIPTION
Was confused the first time I have read the example of the SGF format, since there are three properties (`FF`, `C` and `SZ`), but the description mentions only two