### PR TITLE
sgf-parsing: Added an explicit 'children' field in the 'node without properties' test case

### DIFF
--- a/exercises/sgf-parsing/canonical-data.json
+++ b/exercises/sgf-parsing/canonical-data.json
@@ -1,6 +1,6 @@
 {
     "exercise": "sgf-parsing",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "cases": [
         {
             "description": "empty input",
@@ -39,7 +39,8 @@
                 "encoded": "(;)"
             },
             "expected": {
-                "properties": {}
+                "properties": {},
+                "children": []
             }
         },
         {


### PR DESCRIPTION
Based on [this comment](https://github.com/exercism/problem-specifications/pull/1269#discussion_r206646675) I gathered, that it is OK to add an explicit field