### PR TITLE
dnd-character: add test for one-time ability init

### DIFF
--- a/exercises/dnd-character/canonical-data.json
+++ b/exercises/dnd-character/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "dnd-character",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "comments": [
     "The random generator 'ability' can be property-tested.",
     "The pure function 'modifier' can be tested totally.",

--- a/exercises/dnd-character/canonical-data.json
+++ b/exercises/dnd-character/canonical-data.json
@@ -171,6 +171,12 @@
         "charisma": "charisma >= 3 && charisma <= 18",
         "hitpoints": "hitpoints == 10 + modifier(constitution)"
       }
+    },
+    {
+      "description": "each ability is only calculated once",
+      "property": "strength",
+      "input": {},
+      "expected": "strength == strength"
     }
   ]
 }


### PR DESCRIPTION
I came across an implementation that simply randomized each property whenever it was called, something like:

```
class Character():
    def strength():
        return randint(3, 18)
```

These values should be calculated only once each. Checking one twice should verify that this is the case.