### PR TITLE
dnd-character: Add title to metadata

### DIFF
--- a/exercises/dnd-character/metadata.yml
+++ b/exercises/dnd-character/metadata.yml
@@ -2,4 +2,4 @@
 blurb: "Randomly generate Dungeons & Dragons characters"
 source: "Simon Shine, Erik Schierboom"
 source_url: "https://github.com/exercism/problem-specifications/issues/616#issuecomment-437358945"
-title: "DND Character"
+title: "D&D Character"

--- a/exercises/dnd-character/metadata.yml
+++ b/exercises/dnd-character/metadata.yml
@@ -2,3 +2,4 @@
 blurb: "Randomly generate Dungeons & Dragons characters"
 source: "Simon Shine, Erik Schierboom"
 source_url: "https://github.com/exercism/problem-specifications/issues/616#issuecomment-437358945"
+title: "DND Character"


### PR DESCRIPTION
Currently, the exercise shows up as 'Dnd Character' when 'DND Character' would be more appropriate.

I don't need to bump any version number for this change, right?