### PR TITLE
luhn: non-digit at end is invalid

### DIFF
--- a/exercises/luhn/canonical-data.json
+++ b/exercises/luhn/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "luhn",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "cases": [
     {
       "description": "single digit strings can not be valid",
@@ -71,6 +71,14 @@
       "property": "valid",
       "input": {
         "value": "055a 444 285"
+      },
+      "expected": false
+    },
+    {
+      "description": "valid strings with a non-digit added at the end become invalid",
+      "property": "valid",
+      "input": {
+        "value": "059a"
       },
       "expected": false
     },


### PR DESCRIPTION
From [luhn: add test case with non-digit at the end](https://github.com/exercism/go/pull/1186):

> Problem: I had a student only include the digits before the first invalid character. There was no test that failed his solution.

> Solution: Added a test that should return false but does not if the student takes only the numbers up to first non-digit.

