### PR TITLE
palindrome-products: remove inconsistencies from canonical data

### DIFF
--- a/exercises/palindrome-products/canonical-data.json
+++ b/exercises/palindrome-products/canonical-data.json
@@ -1,6 +1,6 @@
 {
     "exercise": "palindrome-products",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "cases": [{
             "description": "finds the smallest palindrome from single digit factors",
             "property": "smallest",
@@ -121,9 +121,7 @@
               "min": 1002,
               "max": 1003
             },
-            "expected": {
-                "error": "no palindrome with factors in the range 1002 to 1003"
-            }
+            "expected": []
         },
         {
             "description": "empty result for largest if no palindrome in the range",
@@ -132,9 +130,7 @@
               "min": 15,
               "max": 15
             },
-            "expected": {
-                "error": "no palindrome with factors in the range 15 to 15"
-            }
+            "expected": []
         },
         {
             "description": "error result for smallest if min is more than max",
@@ -144,7 +140,7 @@
               "max": 1
             },
             "expected": {
-                "error": "invalid input: min is 10000 and max is 1"
+                "error": "min must be <= max"
             }
         },
         {
@@ -155,7 +151,7 @@
               "max": 1
             },
             "expected": {
-                "error": "invalid input: min is 2 and max is 1"
+                "error": "min must be <= max"
             }
         }
     ]


### PR DESCRIPTION
Finding no palindromes in the given range should not be an error, but result in an empty result. The descriptions of the two tests in question even state "_empty_ result for...", for that matter.

The two tests where the range is invalid (`min>max`) produce a bad error message, stating "invalid input: `min` is X and `max` is Y", which is something of a "go figure". Instead, they should specify the expectation that has been violated, namely that `min` must be smaller or equal to `max`