### PR TITLE
saddle-point: use unambiguous coordinates

### DIFF
--- a/exercises/saddle-points/canonical-data.json
+++ b/exercises/saddle-points/canonical-data.json
@@ -1,8 +1,8 @@
 {
   "exercise": "saddle-points",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "comments": [
-    "Matrix rows and columns are 0-indexed."
+    "Matrix rows and columns are 1-indexed."
   ],
   "cases": [
     {
@@ -20,8 +20,8 @@
       },
       "expected": [
         {
-          "row": 1,
-          "column": 0
+          "row": 2,
+          "column": 1
         }
       ]
     },
@@ -59,16 +59,16 @@
       },
       "expected": [
         {
-          "row": 0,
-          "column": 1
-        },
-        {
           "row": 1,
-          "column": 1
+          "column": 2
         },
         {
           "row": 2,
-          "column": 1
+          "column": 2
+        },
+        {
+          "row": 3,
+          "column": 2
         }
       ]
     },
@@ -84,16 +84,16 @@
       },
       "expected": [
         {
-          "row": 1,
-          "column": 0
-        },
-        {
-          "row": 1,
+          "row": 2,
           "column": 1
         },
         {
-          "row": 1,
+          "row": 2,
           "column": 2
+        },
+        {
+          "row": 2,
+          "column": 3
         }
       ]
     },
@@ -113,8 +113,8 @@
       },
       "expected": [
         {
-          "row": 2,
-          "column": 2
+          "row": 3,
+          "column": 3
         }
       ]
     },
@@ -129,12 +129,12 @@
       },
       "expected": [
         {
-          "row": 0,
-          "column": 2
+          "row": 1,
+          "column": 3
         },
         {
-          "row": 0,
-          "column": 0
+          "row": 1,
+          "column": 1
         }
       ]
     },
@@ -151,12 +151,12 @@
       },
       "expected": [
         {
-          "row": 1,
-          "column": 0
+          "row": 2,
+          "column": 1
         },
         {
-          "row": 3,
-          "column": 0
+          "row": 2,
+          "column": 1
         }
       ]
     },
@@ -170,12 +170,12 @@
       },
       "expected": [
         {
-          "row": 0,
-          "column": 1
+          "row": 1,
+          "column": 2
         },
         {
-          "row": 0,
-          "column": 3
+          "row": 1,
+          "column": 4
         }
       ]
     }

--- a/exercises/saddle-points/description.md
+++ b/exercises/saddle-points/description.md
@@ -3,14 +3,14 @@ Detect saddle points in a matrix.
 So say you have a matrix like so:
 
 ```text
-    0  1  2
+    1  2  3
   |---------
-0 | 9  8  7
-1 | 5  3  2     <--- saddle point at column 0, row 1, with value 5
-2 | 6  6  7
+1 | 9  8  7
+2 | 5  3  2     <--- saddle point at column 1, row 2, with value 5
+3 | 6  6  7
 ```
 
-It has a saddle point at column 0, row 1.
+It has a saddle point at column 1, row 2.
 
 It's called a "saddle point" because it is greater than or equal to
 every element in its row and less than or equal to every element in

--- a/exercises/saddle-points/description.md
+++ b/exercises/saddle-points/description.md
@@ -6,11 +6,11 @@ So say you have a matrix like so:
     0  1  2
   |---------
 0 | 9  8  7
-1 | 5  3  2     <--- saddle point at (1,0)
+1 | 5  3  2     <--- saddle point at column 0, row 1, with value 5
 2 | 6  6  7
 ```
 
-It has a saddle point at (1, 0).
+It has a saddle point at column 0, row 1.
 
 It's called a "saddle point" because it is greater than or equal to
 every element in its row and less than or equal to every element in


### PR DESCRIPTION
The description for 'Saddle Point' illustrates what a saddle point is by showing an example matrix:

```text
    0  1  2
  |---------
0 | 9  8  7
1 | 5  3  2     <--- saddle point at (1,0)
2 | 6  6  7
```

Because there are at least two completely reasonable coordinate systems which could apply here, `(1,0)` is ambiguous (does it mean "column 0, row 1", which is in fact correct, or "row 1, column 0"?)

This PR makes it unambiguous:

```text
    0  1  2
  |---------
0 | 9  8  7
1 | 5  3  2     <--- saddle point at column 0, row 1, with value 5
2 | 6  6  7
```

Fixes #313.

This is also a good complement to the test data, which specifies:

```json
      "expected": [
        {
          "row": 1,
          "column": 0
        }
```