### PR TITLE
Acronym: add underscore test case

### DIFF
--- a/exercises/acronym/canonical-data.json
+++ b/exercises/acronym/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "acronym",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "cases": [
     {
       "description": "Abbreviate a phrase",
@@ -68,6 +68,14 @@
             "phrase": "Halley's Comet"
           },
           "expected": "HC"
+        },
+        {
+          "description": "underscore emphasis",
+          "property": "abbreviate",
+          "input": {
+            "phrase": "The Road _Not_ Taken"
+          },
+          "expected": "TRNT"
         }
       ]
     }


### PR DESCRIPTION
Many regular expression libraries have a way to detect word boundaries,
but their definition of word characters includes underscores.

`\b` and `\w` metacharacters were designed to detect programming language keywords,
and it is a common mistake to use them to match words in natural languages.