### PR TITLE
rotational-cipher: Added negative shiftKey test cases

### DIFF
--- a/exercises/rotational-cipher/canonical-data.json
+++ b/exercises/rotational-cipher/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "rotational-cipher",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "comments": [
     "The tests are a series of rotation tests: "
   ],

--- a/exercises/rotational-cipher/canonical-data.json
+++ b/exercises/rotational-cipher/canonical-data.json
@@ -54,6 +54,24 @@
           "expected": "a"
         },
         {
+          "description": "rotate m by negative 1",
+          "property": "rotate",
+          "input": {
+            "text": "m",
+            "shiftKey": -1
+          },
+          "expected": "l"
+        },
+        {
+          "description": "rotate letters by negative 26",
+          "property": "rotate",
+          "input": {
+            "text": "omg",
+            "shiftKey": -26
+          },
+          "expected": "omg"
+        },
+        {
           "description": "rotate capital letters",
           "property": "rotate",
           "input": {


### PR DESCRIPTION
New test cases ask students to handle negative shift keys, which makes the exercise a little more challenging and could increase learning.