### PR TITLE
rest-api - add new test "lender owes borrower same as new loan"

### DIFF
--- a/exercises/rest-api/canonical-data.json
+++ b/exercises/rest-api/canonical-data.json
@@ -1,6 +1,6 @@
 {
     "exercise": "rest-api",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "comments": [
       "The state of the API database before the request is represented",
       "by the input->database object. Your track may determine how this",
@@ -355,6 +355,54 @@
                                 },
                                 "owed_by": {},
                                 "balance": -1.0
+                            }
+                        ]
+                    }
+                },
+                {
+                    "description": "lender owes borrower same as new loan",
+                    "property": "post",
+                    "input": {
+                        "database": {
+                            "users": [
+                                {
+                                    "name": "Adam",
+                                    "owes": {
+                                        "Bob": 3.0
+                                    },
+                                    "owed_by": {},
+                                    "balance": -3.0
+                                },
+                                {
+                                    "name": "Bob",
+                                    "owes": {},
+                                    "owed_by": {
+                                        "Adam": 3.0
+                                    },
+                                    "balance": 3.0
+                                }
+                            ]
+                        },
+                        "url": "/iou",
+                        "payload": {
+                            "lender": "Adam",
+                            "borrower": "Bob",
+                            "amount": 3.0
+                        }
+                    },
+                    "expected": {
+                        "users": [
+                            {
+                                "name": "Adam",
+                                "owes": {},
+                                "owed_by": {},
+                                "balance": 0
+                            },
+                            {
+                                "name": "Bob",
+                                "owes": {},
+                                "owed_by": {},
+                                "balance": 0
                             }
                         ]
                     }

--- a/exercises/rest-api/canonical-data.json
+++ b/exercises/rest-api/canonical-data.json
@@ -1,6 +1,6 @@
 {
     "exercise": "rest-api",
-    "version": "1.0.3",
+    "version": "1.1.0",
     "comments": [
       "The state of the API database before the request is represented",
       "by the input->database object. Your track may determine how this",


### PR DESCRIPTION
Resolves #1439 by adding a test case when the previous lender becomes the borrower and borrows the same amount as the current balance thus zeroing the balances and removing the respective owes and owed_by for both parties.   This exercises some necessary code for this case that was previously not covered.  In zeroing balances it is self consistent with the previous two exercises that change balances and whom is owed/owes.