### PR TITLE
REST-API: Update expected user balance of last test

### DIFF
--- a/exercises/rest-api/canonical-data.json
+++ b/exercises/rest-api/canonical-data.json
@@ -396,13 +396,13 @@
                                 "name": "Adam",
                                 "owes": {},
                                 "owed_by": {},
-                                "balance": 0
+                                "balance": 0.0
                             },
                             {
                                 "name": "Bob",
                                 "owes": {},
                                 "owed_by": {},
-                                "balance": 0
+                                "balance": 0.0
                             }
                         ]
                     }

--- a/exercises/rest-api/canonical-data.json
+++ b/exercises/rest-api/canonical-data.json
@@ -1,6 +1,6 @@
 {
     "exercise": "rest-api",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "comments": [
       "The state of the API database before the request is represented",
       "by the input->database object. Your track may determine how this",


### PR DESCRIPTION
User balance of test "lender owes borrower same as new loan" is not formatted as the previous cases. For example "lender has negative balance" has an expected user balance of zero formatted as "0.0" as all other values while the last test has zero formatted as "0".