### PR TITLE
darts: augment test suite

### DIFF
--- a/exercises/darts/canonical-data.json
+++ b/exercises/darts/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "darts",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "cases": [
     {
       "description": "Return the correct amount earned by a dart landing in a given point in the target problem.",
@@ -9,8 +9,8 @@
          "property": "score",
          "description": "A dart lands outside the target",
          "input": {
-           "x": 15.3,
-           "y": 13.2
+           "x": -9,
+           "y": 9
          },
          "expected": 0
         },
@@ -18,35 +18,53 @@
          "property": "score",
          "description": "A dart lands just in the border of the target",
          "input": {
-           "x": 10,
-           "y": 0
+           "x": 0,
+           "y": 10
          },
          "expected": 1
         },
         {
          "property": "score",
-         "description": "A dart lands in the middle circle",
+         "description": "A dart lands in the outer circle",
          "input": {
-           "x": 3,
-           "y": 3.7
+           "x": 4,
+           "y": 4
+         },
+         "expected": 1
+        },
+        {
+         "property": "score",
+         "description": "A dart lands right in the border between outer and middle circles",
+         "input": {
+           "x": 5,
+           "y": 0
          },
          "expected": 5
         },
         {
          "property": "score",
-         "description": "A dart lands right in the border between outside and middle circles",
+         "description": "A dart lands in the middle circle",
          "input": {
-           "x": 0,
-           "y": 5
+           "x": 0.8,
+           "y": -0.8
          },
          "expected": 5
+        },
+        {
+         "property": "score",
+         "description": "A dart lands right in the border between middle and inner circles",
+         "input": {
+           "x": 0,
+           "y": -1
+         },
+         "expected": 10
         },
         {
          "property": "score",
          "description": "A dart lands in the inner circle",
          "input": {
-           "x": 0,
-           "y": 0
+           "x": -0.1,
+           "y": -0.1
          },
          "expected": 10
         }


### PR DESCRIPTION
I was just mentoring an exercise where the students solution treated the target as a square (as opposed to a circle), and was surprised that it nevertheless passed the tests.

I found that they only (except for one, that accidentially works still) use coordinates where one of them is `0`, which also works if the solution calculates scores as if the target was a square.

I also noticed that, while the target is supposed to be a circle centered at `(0, 0)`, so that there are valid target areas with negative coordinates, there are no test cases that provide negative coordinates at all.