### PR TITLE
Hamming: Add a test case to avoid wrong recursion solution

### DIFF
--- a/exercises/hamming/canonical-data.json
+++ b/exercises/hamming/canonical-data.json
@@ -81,7 +81,7 @@
         "strand1": "",
         "strand2": "G"
       },
-      "expected": {"error": "left and right strands must be of equal length"}
+      "expected": {"error": "left strand must not be empty"}
     },
     {
       "description": "disallow right empty strand",

--- a/exercises/hamming/canonical-data.json
+++ b/exercises/hamming/canonical-data.json
@@ -90,7 +90,7 @@
         "strand1": "G",
         "strand2": ""
       },
-      "expected": {"error": "left and right strands must be of equal length"}
+      "expected": {"error": "right strand must not be empty"}
     }
   ]
 }

--- a/exercises/hamming/canonical-data.json
+++ b/exercises/hamming/canonical-data.json
@@ -75,13 +75,22 @@
       "expected": {"error": "left and right strands must be of equal length"}
     },
     {
-  "description": "disallow only one empty strand",
-  "property": "distance",
-  "input": {
-    "strand1": "",
-    "strand2": "G"
-  },
-  "expected": {"error": "left and right strands must be of equal length"}
-}
+      "description": "disallow left empty strand",
+      "property": "distance",
+      "input": {
+        "strand1": "",
+        "strand2": "G"
+      },
+      "expected": {"error": "left and right strands must be of equal length"}
+    },
+    {
+      "description": "disallow right empty strand",
+      "property": "distance",
+      "input": {
+        "strand1": "G",
+        "strand2": ""
+      },
+      "expected": {"error": "left and right strands must be of equal length"}
+    }
   ]
 }

--- a/exercises/hamming/canonical-data.json
+++ b/exercises/hamming/canonical-data.json
@@ -1,6 +1,6 @@
 {
 "exercise": "hamming",
-"version": "2.2.0",
+"version": "2.3.0",
   "comments": [
     "Language implementations vary on the issue of unequal length strands.",
     "A language may elect to simplify this task by only presenting equal",
@@ -73,6 +73,15 @@
         "strand2": "AGTG"
       },
       "expected": {"error": "left and right strands must be of equal length"}
-    }
+    },
+    {
+  "description": "disallow only one empty strand",
+  "property": "distance",
+  "input": {
+    "strand1": "",
+    "strand2": "G"
+  },
+  "expected": {"error": "left and right strands must be of equal length"}
+}
   ]
 }


### PR DESCRIPTION
Add an extra test case about one empty strand based on the discussion in exercism/haskell#796 to avoid wrong recursion solution.