### PR TITLE
list-ops: add test case for reversing nested lists

### DIFF
--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -212,7 +212,7 @@
           "description": "empty list",
           "property": "reverse",
           "input": {
-            "list": []-patch-1
+            "list": []
           },
           "expected": []
         },

--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -225,7 +225,7 @@
           "expected": [7, 5, 3, 1]
         },
         {
-          "description": "list of nested lists",
+          "description": "list of lists",
           "property": "reverse",
           "input": {
             "list": [[1, 2], [3], [], [4, 5, 6]]

--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "list-ops",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "comments": [
     "Though there are no specifications here for dealing with large lists,",
     "implementers may add tests for handling large lists to ensure that the",
@@ -223,6 +223,14 @@
             "list": [1, 3, 5, 7]
           },
           "expected": [7, 5, 3, 1]
+        },
+        {
+          "description": "nested lists",
+          "property": "reverse",
+          "input": {
+            "list": [0, [1], [2, 3], [4, [5, 6]]]
+          },
+          "expected": [[4, [5, 6]], [2, 3], [1], 0]
         }
       ]
     }

--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -212,7 +212,7 @@
           "description": "empty list",
           "property": "reverse",
           "input": {
-            "list": []
+            "list": []-patch-1
           },
           "expected": []
         },
@@ -225,7 +225,7 @@
           "expected": [7, 5, 3, 1]
         },
         {
-          "description": "nested lists",
+          "description": "list of nested lists",
           "property": "reverse",
           "input": {
             "list": [0, [1], [2, 3], [4, [5, 6]]]

--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -228,9 +228,9 @@
           "description": "list of nested lists",
           "property": "reverse",
           "input": {
-            "list": [0, [1], [2, 3], [4, [5, 6]]]
+            "list": [[1, 2], [3], [], [4, 5, 6]]
           },
-          "expected": [[4, [5, 6]], [2, 3], [1], 0]
+          "expected": [[4, 5, 6], [], [3], [1, 2]]
         }
       ]
     }

--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -225,7 +225,7 @@
           "expected": [7, 5, 3, 1]
         },
         {
-          "description": "list of lists",
+          "description": "list of lists is not flattened",
           "property": "reverse",
           "input": {
             "list": [[1, 2], [3], [], [4, 5, 6]]


### PR DESCRIPTION
The following implementation of `reverse` passes all existing tests but fails the new test:

```Python
# Passes all existing tests for append()
def append(base_list, to_append):
    if isinstance(to_append, list):
        for x in to_append:
            base_list.append(x)
    else:
        base_list.append(to_append)
    return base_list

# Passes existing test for length()
def length(base_list):
    return foldl(lambda a, b: a + 1, base_list, 0)

# Passes existing tests for foldr()
def foldr(function, base_list, acc):
    while length(xs):
        acc = function(base_list.pop(), acc)
    return acc

def reverse(base_list):
    return foldr(lambda b, a: append(a, b), base_list, [])
```