### PR TITLE
high-scores: Remove report method

### DIFF
--- a/exercises/high-scores/canonical-data.json
+++ b/exercises/high-scores/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "high-scores",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "comments": [
     "This is meant to be an easy exercise to practise: ",
     "* arrays as simple lists",
@@ -78,30 +78,6 @@
           "expected": [40]
         }
       ]
-    },
-    {
-      "description": "Message for new personal best",
-      "property": "report",
-      "input": {
-        "scores": [20, 40, 0, 30, 70]
-      },
-      "expected": "Your latest score was 70. That's your personal best!"
-    },
-    {
-      "description": "Message when latest score is not the highest score",
-      "property": "report",
-      "input": {
-        "scores": [20, 100, 0, 30, 70]
-      },
-      "expected": "Your latest score was 70. That's 30 short of your personal best!"
-    },
-    {
-      "description": "Message for repeated personal best",
-      "property": "report",
-      "input": {
-        "scores": [20, 70, 50, 70, 30]
-      },
-      "expected": "Your latest score was 30. That's 40 short of your personal best!"
     }
   ]
 }

--- a/exercises/high-scores/description.md
+++ b/exercises/high-scores/description.md
@@ -1,3 +1,3 @@
 Manage a game player's High Score list.
 
-Your task is to build a high-score component of the classic Frogger game, one of the highest selling and addictive games of all time, and a classic of the arcade era. Your task is to write methods that return the highest score from the list, the last added score, the three highest scores, and a report on the difference between the last and the highest scores.
+Your task is to build a high-score component of the classic Frogger game, one of the highest selling and addictive games of all time, and a classic of the arcade era. Your task is to write methods that return the highest score from the list, the last added score and the three highest scores.


### PR DESCRIPTION
After the discussion on #1456, @F3PiX and I suggest removing the `report` method entirely. That's the single change in this PR.

closes #1456 