### PR TITLE
simple-cipher: test that messages longer than the key can be decoded

### DIFF
--- a/exercises/simple-cipher/canonical-data.json
+++ b/exercises/simple-cipher/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "simple-cipher",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "comments":
     ["Some of the strings used in this file are symbolic and do not represent their literal value. They are:",
       "cipher.key - Represents the Cipher key",
@@ -105,13 +105,22 @@
           "expected": "zzzzzzzzzz"
         },
         {
-          "description": "Can handle messages longer than the key",
+          "description": "Can encode messages longer than the key",
           "property": "encode",
           "input": {
             "key": "abc",
             "plaintext": "iamapandabear"
           },
           "expected": "iboaqcnecbfcr"
+        },
+        {
+          "description": "Can decode messages longer than the key",
+          "property": "decode",
+          "input": {
+            "key": "abc",
+            "plaintext": "iboaqcnecbfcr"
+          },
+          "expected": "iamapandabear"
         }
       ]
     }


### PR DESCRIPTION
I just come across a solution for the "Simple Cipher" exercise from a student, which could encode messages longer than the key but failed to _decode_ messages longer than the key, and yet, because we haven't a test to cover this, all tests would pass giving an illusion of correctness.

This pull request adds a test to also check that a message longer than the key can be decoded.