### PR TITLE
simple-cipher: Fix property name and major bump

### DIFF
--- a/exercises/simple-cipher/canonical-data.json
+++ b/exercises/simple-cipher/canonical-data.json
@@ -118,7 +118,7 @@
           "property": "decode",
           "input": {
             "key": "abc",
-            "plaintext": "iboaqcnecbfcr"
+            "ciphertext": "iboaqcnecbfcr"
           },
           "expected": "iamapandabear"
         }

--- a/exercises/simple-cipher/canonical-data.json
+++ b/exercises/simple-cipher/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "simple-cipher",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "comments":
     ["Some of the strings used in this file are symbolic and do not represent their literal value. They are:",
       "cipher.key - Represents the Cipher key",


### PR DESCRIPTION
#1460 erroneously named a property `plaintext`. This fixes it to `ciphertext`.

Also the version bump is made a major bump according to versioning guidelines.