### PR TITLE
leap: Add test case for year divisible by 2 but not by 4

### DIFF
--- a/exercises/leap/canonical-data.json
+++ b/exercises/leap/canonical-data.json
@@ -1,12 +1,20 @@
 {
   "exercise": "leap",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "cases": [
     {
       "description": "year not divisible by 4: common year",
       "property": "leapYear",
       "input": {
         "year": 2015
+      },
+      "expected": false
+    },
+    {
+      "description": "year divisible by 2, not divisible by 4: common year",
+      "property": "leapYear",
+      "input": {
+        "year": 1970
       },
       "expected": false
     },


### PR DESCRIPTION
This adds a new test that will fail if students use `year % 2 === 0` instead of `year % 4 === 0`.