### PR TITLE
collatz-conjecture: add test for float input and clarify error messages

### DIFF
--- a/exercises/collatz-conjecture/canonical-data.json
+++ b/exercises/collatz-conjecture/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "collatz-conjecture",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "cases": [
     {
       "description": "zero steps for one",
@@ -40,7 +40,7 @@
       "input": {
         "number": 0
       },
-      "expected": { "error": "Only positive numbers are allowed" }
+      "expected": { "error": "Only positive integers are allowed" }
     },
     {
       "description": "negative value is an error",
@@ -48,7 +48,15 @@
       "input": {
         "number": -15
       },
-      "expected": { "error": "Only positive numbers are allowed" }
+      "expected": { "error": "Only positive integers are allowed" }
+    },
+    {
+      "description": "float value is an error",
+      "property": "steps",
+      "input": {
+        "number": 1.5
+      },
+      "expected": { "error": "Only positive integers are allowed" }
     }
   ]
 }


### PR DESCRIPTION
The test suite had no check for float inputs. If an implementation does not ensure it is working with (positive) integers, depending on language, it may run forever or crash.

Furthermore, the error message "only positive numbers are allowed" was in that sense misleading, as numbers _include_ floats.