### PR TITLE
pig-latin: Add test case for word starting with `xr`

### DIFF
--- a/exercises/pig-latin/canonical-data.json
+++ b/exercises/pig-latin/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "pig-latin",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "cases": [
     {
       "description": "ay is added to words that start with vowels",
@@ -52,6 +52,14 @@
             "phrase": "equal"
           },
           "expected": "equalay"
+        },
+        {
+          "description": "word beginning with xr",
+          "property": "translate",
+          "input": {
+            "phrase": "xray"
+          },
+          "expected": "xrayay"
         }
       ]
     },


### PR DESCRIPTION
In the README it has the following note for Rule 1:

> Please note that "xr" and "yt" at the beginning of a word make vowel sounds (e.g. "xray" -> "xrayay", "yttria" -> "yttriaay").

This isn't actually tested anywhere! Now it is 😄 

I've not added a test for `yt`, but don't mind if people want that too :)