### PR TITLE
rational-numbers: add abs test case for den < 0

### DIFF
--- a/exercises/rational-numbers/canonical-data.json
+++ b/exercises/rational-numbers/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "rational-numbers",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "comments": [
     " The canonical data assumes mathematically correct real   ",
     " numbers. The testsuites should consider rounding errors  ",
@@ -213,6 +213,14 @@
           "property": "abs",
           "input": {
             "r": [-1, 2]
+          },
+          "expected": [1, 2]
+        },
+        {
+          "description": "Absolute value of a negative rational number with negative denominator",
+          "property": "abs",
+          "input": {
+            "r": [1, -2]
           },
           "expected": [1, 2]
         },

--- a/exercises/rational-numbers/canonical-data.json
+++ b/exercises/rational-numbers/canonical-data.json
@@ -209,6 +209,14 @@
           "expected": [1, 2]
         },
         {
+          "description": "Absolute value of a positive rational number with negative numerator and denominator",
+          "property": "abs",
+          "input": {
+            "r": [-1, -2]
+          },
+          "expected": [1, 2]
+        },
+        {
           "description": "Absolute value of a negative rational number",
           "property": "abs",
           "input": {


### PR DESCRIPTION
Currently there's only a test for a negative num, but not a negative den.