### PR TITLE
triangle: Add clarity to test descriptions

### DIFF
--- a/exercises/triangle/canonical-data.json
+++ b/exercises/triangle/canonical-data.json
@@ -111,7 +111,7 @@
           "expected": false
         },
         {
-          "description": "triangle inequality violation (1)",
+          "description": "first triangle inequality violation",
           "property": "isosceles",
           "input": {
             "sides": [1, 1, 3]
@@ -119,7 +119,7 @@
           "expected": false
         },
         {
-          "description": "triangle inequality violation (2)",
+          "description": "second triangle inequality violation",
           "property": "isosceles",
           "input": {
             "sides": [1, 3, 1]
@@ -127,7 +127,7 @@
           "expected": false
         },
         {
-          "description": "triangle inequality violation (3)",
+          "description": "third triangle inequality violation",
           "property": "isosceles",
           "input": {
             "sides": [3, 1, 1]

--- a/exercises/triangle/canonical-data.json
+++ b/exercises/triangle/canonical-data.json
@@ -9,7 +9,7 @@
     " triangles have zero area, however.                                    ",
     " They're degenerate triangles with all three vertices collinear.       ",
     " (In contrast, we will test (0, 0, 0, Illegal), as it is a point)      ",
-    " The tests assert properities of the triangle are true or false.       ",
+    " The tests assert properties of the triangle are true or false.        ",
     " See: https://github.com/exercism/problem-specifications/issues/379 for disscussion  ",
     " of this approach                                                      ",
     " How you handle invalid triangles is up to you. These tests suggest a  ",
@@ -19,10 +19,10 @@
   ],
   "cases": [
     {
-      "description": "returns true if the triangle is equilateral",
+      "description": "equilateral triangle",
       "cases": [
         {
-          "description": "true if all sides are equal",
+          "description": "returns true if all sides are equal",
           "property": "equilateral",
           "input": {
             "sides": [2, 2, 2]
@@ -30,7 +30,7 @@
           "expected": true
         },
         {
-          "description": "false if any side is unequal",
+          "description": "returns false if any side is unequal",
           "property": "equilateral",
           "input": {
             "sides": [2, 3, 2]
@@ -38,7 +38,7 @@
           "expected": false
         },
         {
-          "description": "false if no sides are equal",
+          "description": "returns false if no sides are equal",
           "property": "equilateral",
           "input": {
             "sides": [5, 4, 6]
@@ -46,7 +46,7 @@
           "expected": false
         },
         {
-          "description": "All zero sides are illegal, so the triangle is not equilateral",
+          "description": "returns false if equilateral triangle has all zero sides",
           "property": "equilateral",
           "input": {
             "sides": [0, 0, 0]
@@ -68,10 +68,10 @@
       ]
     },
     {
-      "description": "returns true if the triangle is isosceles",
+      "description": "isosceles triangle",
       "cases": [
         {
-          "description": "true if last two sides are equal",
+          "description": "returns true if last two sides are equal",
           "property": "isosceles",
           "input": {
             "sides": [3, 4, 4]
@@ -79,7 +79,7 @@
           "expected": true
         },
         {
-          "description": "true if first two sides are equal",
+          "description": "returns true if first two sides are equal",
           "property": "isosceles",
           "input": {
             "sides": [4, 4, 3]
@@ -87,7 +87,7 @@
           "expected": true
         },
         {
-          "description": "true if first and last sides are equal",
+          "description": "returns true if first and last sides are equal",
           "property": "isosceles",
           "input": {
             "sides": [4, 3, 4]
@@ -103,7 +103,7 @@
           "expected": true
         },
         {
-          "description": "false if no sides are equal",
+          "description": "returns false if no sides are equal",
           "property": "isosceles",
           "input": {
             "sides": [2, 3, 4]
@@ -149,10 +149,10 @@
       ]
     },
     {
-      "description": "returns true if the triangle is scalene",
+      "description": "scalene triangle",
       "cases": [
         {
-          "description": "true if no sides are equal",
+          "description": "returns true if no sides are equal",
           "property": "scalene",
           "input": {
             "sides": [5, 4, 6]
@@ -160,7 +160,7 @@
           "expected": true
         },
         {
-          "description": "false if all sides are equal",
+          "description": "returns false if all sides are equal",
           "property": "scalene",
           "input": {
             "sides": [4, 4, 4]
@@ -168,7 +168,7 @@
           "expected": false
         },
         {
-          "description": "false if two sides are equal",
+          "description": "returns false if two sides are equal",
           "property": "scalene",
           "input": {
             "sides": [4, 4, 3]

--- a/exercises/triangle/canonical-data.json
+++ b/exercises/triangle/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "triangle",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "comments": [
     " Pursuant to discussion in #202, we have decided NOT to test triangles ",
     " where all side lengths are positive but a + b = c. e.g:               ",
@@ -22,7 +22,7 @@
       "description": "equilateral triangle",
       "cases": [
         {
-          "description": "returns true if all sides are equal",
+          "description": "all sides are equal",
           "property": "equilateral",
           "input": {
             "sides": [2, 2, 2]
@@ -30,7 +30,7 @@
           "expected": true
         },
         {
-          "description": "returns false if any side is unequal",
+          "description": "any side is unequal",
           "property": "equilateral",
           "input": {
             "sides": [2, 3, 2]
@@ -38,7 +38,7 @@
           "expected": false
         },
         {
-          "description": "returns false if no sides are equal",
+          "description": "no sides are equal",
           "property": "equilateral",
           "input": {
             "sides": [5, 4, 6]
@@ -46,7 +46,7 @@
           "expected": false
         },
         {
-          "description": "returns false if equilateral triangle has all zero sides",
+          "description": "all zero sides is not a triangle",
           "property": "equilateral",
           "input": {
             "sides": [0, 0, 0]
@@ -71,7 +71,7 @@
       "description": "isosceles triangle",
       "cases": [
         {
-          "description": "returns true if last two sides are equal",
+          "description": "last two sides are equal",
           "property": "isosceles",
           "input": {
             "sides": [3, 4, 4]
@@ -79,7 +79,7 @@
           "expected": true
         },
         {
-          "description": "returns true if first two sides are equal",
+          "description": "first two sides are equal",
           "property": "isosceles",
           "input": {
             "sides": [4, 4, 3]
@@ -87,7 +87,7 @@
           "expected": true
         },
         {
-          "description": "returns true if first and last sides are equal",
+          "description": "first and last sides are equal",
           "property": "isosceles",
           "input": {
             "sides": [4, 3, 4]
@@ -103,7 +103,7 @@
           "expected": true
         },
         {
-          "description": "returns false if no sides are equal",
+          "description": "no sides are equal",
           "property": "isosceles",
           "input": {
             "sides": [2, 3, 4]
@@ -111,7 +111,7 @@
           "expected": false
         },
         {
-          "description": "Sides that violate triangle inequality are not isosceles, even if two are equal (1)",
+          "description": "triangle inequality violation (1)",
           "property": "isosceles",
           "input": {
             "sides": [1, 1, 3]
@@ -119,7 +119,7 @@
           "expected": false
         },
         {
-          "description": "Sides that violate triangle inequality are not isosceles, even if two are equal (2)",
+          "description": "triangle inequality violation (2)",
           "property": "isosceles",
           "input": {
             "sides": [1, 3, 1]
@@ -127,7 +127,7 @@
           "expected": false
         },
         {
-          "description": "Sides that violate triangle inequality are not isosceles, even if two are equal (3)",
+          "description": "triangle inequality violation (3)",
           "property": "isosceles",
           "input": {
             "sides": [3, 1, 1]
@@ -152,7 +152,7 @@
       "description": "scalene triangle",
       "cases": [
         {
-          "description": "returns true if no sides are equal",
+          "description": "no sides are equal",
           "property": "scalene",
           "input": {
             "sides": [5, 4, 6]
@@ -160,7 +160,7 @@
           "expected": true
         },
         {
-          "description": "returns false if all sides are equal",
+          "description": "all sides are equal",
           "property": "scalene",
           "input": {
             "sides": [4, 4, 4]
@@ -168,7 +168,7 @@
           "expected": false
         },
         {
-          "description": "returns false if two sides are equal",
+          "description": "two sides are equal",
           "property": "scalene",
           "input": {
             "sides": [4, 4, 3]
@@ -176,7 +176,7 @@
           "expected": false
         },
         {
-          "description": "Sides that violate triangle inequality are not scalene, even if they are all different",
+          "description": "may not violate triangle inequality",
           "property": "scalene",
           "input": {
             "sides": [7, 3, 2]


### PR DESCRIPTION
Proposed fix to https://github.com/exercism/csharp/issues/1253

The current [Test] names confused me when I was doing the exercise. It was also difficult to see which tests failed, because of long method names combined with a small window with the test results.

This PR changes the "Returns_true_if_the_triangle_is_equilateral_false_if_any_side_is_unequal" style in favour of a pattern that follows "equilateral_triangle_returns_false_if_any_side_is_unequal".