### PR TITLE
ETL: Modified canonical description to ease test suite generation

### DIFF
--- a/exercises/etl/canonical-data.json
+++ b/exercises/etl/canonical-data.json
@@ -1,77 +1,76 @@
 {
   "exercise": "etl",
-  "version": "1.0.0",
+  "version": "1.0.1",
+  "comments": [
+    "Transforms a set of scrabble data previously indexed by the",
+    "tile score to a set of data indexed by the tile letter",
+    "Note:  The expected input data for these tests should have",
+    "integer keys (not stringified numbers as shown in the JSON below",
+    "Unless the language prohibits that, please implement these tests",
+    "such that keys are integers. e.g. in JavaScript, it might look ",
+    "like `transform( { 1: ['A'] } );`"
+  ],
   "cases": [
     {
-      "comments": [
-        "Note:  The expected input data for these tests should have",
-        "integer keys (not stringified numbers as shown in the JSON below",
-        "Unless the language prohibits that, please implement these tests",
-        "such that keys are integers. e.g. in JavaScript, it might look ",
-        "like `transform( { 1: ['A'] } );`"
-      ],
-      "description": "transforms the a set of scrabble data previously indexed by the tile score to a set of data indexed by the tile letter",
-      "cases": [
-        {
-          "description": "a single letter",
-          "property": "transform",
-          "input": {
-            "1": ["A"]
-          },
-          "expected": {
-            "a": 1
-          }
-        },
-        {
-          "description": "single score with multiple letters",
-          "property": "transform",
-          "input": {
-            "1": ["A", "E", "I", "O", "U"]
-          },
-          "expected": {
-            "a": 1,
-            "e": 1,
-            "i": 1,
-            "o": 1,
-            "u": 1
-          }
-        },
-        {
-          "description": "multiple scores with multiple letters",
-          "property": "transform",
-          "input": {
-            "1": ["A", "E"],
-            "2": ["D", "G"]
-          },
-          "expected": {
-            "a": 1,
-            "d": 2,
-            "e": 1,
-            "g": 2
-          }
-        },
-        {
-          "description": "multiple scores with differing numbers of letters",
-          "property": "transform",
-          "input": {
-             "1": ["A", "E", "I", "O", "U", "L", "N", "R", "S", "T"],
-             "2": ["D", "G"],
-             "3": ["B", "C", "M", "P"],
-             "4": ["F", "H", "V", "W", "Y"],
-             "5": ["K"],
-             "8": ["J", "X"],
-            "10": ["Q", "Z"]
-          },
-          "expected": {
-            "a":  1, "b":  3, "c": 3, "d": 2, "e": 1,
-            "f":  4, "g":  2, "h": 4, "i": 1, "j": 8,
-            "k":  5, "l":  1, "m": 3, "n": 1, "o": 1,
-            "p":  3, "q": 10, "r": 1, "s": 1, "t": 1,
-            "u":  1, "v":  4, "w": 4, "x": 8, "y": 4,
-            "z": 10
-          }
-        }
-      ]
+      "description": "transforms a single letter",
+      "property": "transform",
+      "input": {
+        "data" : {"1": ["A"]}
+      },
+      "expected": {
+        "a": 1
+      }
+    },
+    {
+      "description": "transform a single score with multiple letters",
+      "property": "transform",
+      "input": {
+        "data" : {"1": ["A", "E", "I", "O", "U"]}
+      },
+      "expected": {
+        "a": 1,
+        "e": 1,
+        "i": 1,
+        "o": 1,
+        "u": 1
+      }
+    },
+    {
+      "description": "transform multiple scores with multiple letters",
+      "property": "transform",
+      "input": {
+        "data" : {
+        "1": ["A", "E"],
+        "2": ["D", "G"]}
+      },
+      "expected": {
+        "a": 1,
+        "d": 2,
+        "e": 1,
+        "g": 2
+      }
+    },
+    {
+      "description": "transforms multiple scores with differing numbers of letters",
+      "property": "transform",
+      "input": {
+        "data" : {
+         "1": ["A", "E", "I", "O", "U", "L", "N", "R", "S", "T"],
+         "2": ["D", "G"],
+         "3": ["B", "C", "M", "P"],
+         "4": ["F", "H", "V", "W", "Y"],
+         "5": ["K"],
+         "8": ["J", "X"],
+        "10": ["Q", "Z"]}
+      },
+      "expected": {
+        "a":  1, "b":  3, "c": 3, "d": 2, "e": 1,
+        "f":  4, "g":  2, "h": 4, "i": 1, "j": 8,
+        "k":  5, "l":  1, "m": 3, "n": 1, "o": 1,
+        "p":  3, "q": 10, "r": 1, "s": 1, "t": 1,
+        "u":  1, "v":  4, "w": 4, "x": 8, "y": 4,
+        "z": 10
+      }
     }
   ]
 }


### PR DESCRIPTION
Small change to the json spec that is easier for code generation, and clearly shows that you are calling the etl function with 1 parameter (which has "1"..."x" tile arrays)