### PR TITLE
Armstrong-numbers: add test case for 21897142587612075

### DIFF
--- a/exercises/armstrong-numbers/canonical-data.json
+++ b/exercises/armstrong-numbers/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "armstrong-numbers",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "cases": [
     {
       "description": "Single digit numbers are Armstrong numbers",
@@ -65,6 +65,14 @@
         "number": 9926314
       },
       "expected": false
+    },
+    {
+      "description": "Seventeen digit number that is an Armstrong number",
+      "property": "isArmstrongNumber",
+      "input": {
+        "number": 21897142587612075
+      },
+      "expected": true
     }
   ]
 }


### PR DESCRIPTION
Most of solutions are using some sort of built-in "power" function, which can (ex.: Clojure, Erlang/Elixir, JS) rely on floating-point arithmetics under the hood (even though the interface functions can accept integers). The number 21897142587612075 is known to be armstrong one ([http://mathworld.wolfram.com/NarcissisticNumber.html](http://mathworld.wolfram.com/NarcissisticNumber.html)), but depending on the floating point arithmetic implementation used might cause false negatives on solutions that convert between numeric types, because `9^17` returns `16677181699666570` or `16677181699666568`, but not `16677181699666569` which is expected.