### PR TITLE
darts: add tests to disallow absolute addition

### DIFF
--- a/exercises/darts/canonical-data.json
+++ b/exercises/darts/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "darts",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "cases": [
     {
       "description": "Return the correct amount earned by a dart landing in a given point in the target problem.",

--- a/exercises/darts/canonical-data.json
+++ b/exercises/darts/canonical-data.json
@@ -67,6 +67,33 @@
            "y": -0.1
          },
          "expected": 10
+        },
+        {
+         "property": "score",
+         "description": "A dart whose coordinates sum to > 1 but whose radius to origin is <= 1 is scored in the inner circle",
+         "input": {
+           "x": 0.4,
+           "y": 0.8
+         },
+         "expected": 10
+        },
+        {
+         "property": "score",
+         "description": "A dart whose coordinates sum to > 5 but whose radius to origin is <= 5 is scored in the middle circle",
+         "input": {
+           "x": 2,
+           "y": 4
+         },
+         "expected": 5
+        },
+        {
+         "property": "score",
+         "description": "A dart whose coordinates sum to > 10 but whose radius to origin is <= 10 is scored in the outer circle",
+         "input": {
+           "x": 4,
+           "y": 8
+         },
+         "expected": 1
         }
      ]
     }


### PR DESCRIPTION
The current tests allow an erroneous-but-passing solution where the sum of the absolute values of the coordinates of the dart are compared to the radius thresholds (ie return 5 if `abs(x) + abs(y)` is greater than 1 but less than or equal to 5), rather than the calculated distance of the dart from the origin. Thanks to [grwkremilek](https://exercism.io/tracks/python/exercises/darts/solutions/fd550c5405d64d84be3312566b300e1b) for the find.