### PR TITLE
Darts: Correct typo in metadata

### DIFF
--- a/exercises/darts/metadata.yml
+++ b/exercises/darts/metadata.yml
@@ -1,3 +1,3 @@
 ---
 blurb: "Write a function that returns the earned points in a single toss of a Darts game"
-source: "Inspired by an excersie created by a professor Della Paolera in Argentina"
+source: "Inspired by an exercise created by a professor Della Paolera in Argentina"


### PR DESCRIPTION
I think 'excersie' is meant to be 'exercise'