### PR TITLE
Allergies: Modified canonical description to make it generatable

### DIFF
--- a/exercises/allergies/canonical-data.json
+++ b/exercises/allergies/canonical-data.json
@@ -3,14 +3,11 @@
   "version": "1.2.1",
   "comments": [
     "Given a number and a substance, indicate whether Tom is allergic ",
-    "to that substance.",
-    "Test cases for this method involve more than one assertion.",
-    "Each case in 'expected' specifies what the method should return for",
-    "the given substance."
+    "to that substance."
   ],
   "cases": [
     {
-      "description": "no allergies means not allergic with:",
+      "description": "no allergies means not allergic to:",
       "cases": [
         {
           "description": "peanuts",
@@ -52,10 +49,9 @@
     },
     {
       "description": "allergic to eggs in addition to other stuff like:",
-      "property": "allergicTo",
       "cases": [
         {
-          "description": "eggs",
+          "description": "eggs repeated",
           "property": "allergicTo",
           "input": {
             "item": "eggs",

--- a/exercises/allergies/canonical-data.json
+++ b/exercises/allergies/canonical-data.json
@@ -1,16 +1,66 @@
 {
   "exercise": "allergies",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "comments": [
     "Given a number and a substance, indicate whether Tom is allergic ",
     "to that substance."
   ],
   "cases": [
     {
-      "description": "no allergies means not allergic to:",
+      "description": "testing for eggs allergy",
       "cases": [
         {
-          "description": "peanuts",
+          "description": "not allergic to anything",
+          "property": "allergicTo",
+          "input": {
+            "item": "eggs",
+            "score": 0
+          },
+          "expected": false
+        },
+        {
+          "description": "allergic only to eggs",
+          "property": "allergicTo",
+          "input": {
+            "item": "eggs",
+            "score": 1
+          },
+          "expected": true
+        },
+        {
+          "description": "allergic to eggs and something else",
+          "property": "allergicTo",
+          "input": {
+            "item": "eggs",
+            "score": 3
+          },
+          "expected": false
+        },
+        {
+          "description": "allergic to something, but not eggs",
+          "property": "allergicTo",
+          "input": {
+            "item": "eggs",
+            "score": 2
+          },
+          "expected": false
+        },
+        {
+          "description": "allergic to everything",
+          "property": "allergicTo",
+          "input": {
+            "item": "eggs",
+            "score": 255
+          },
+          "expected": true
+        }
+      ]
+    },
+    {
+      "description": "testing for peanuts allergy",
+      "cases": [
+        {
+          "description": "not allergic to anything",
           "property": "allergicTo",
           "input": {
             "item": "peanuts",
@@ -19,7 +69,298 @@
           "expected": false
         },
         {
-          "description": "cats",
+          "description": "allergic only to peanuts",
+          "property": "allergicTo",
+          "input": {
+            "item": "peanuts",
+            "score": 2
+          },
+          "expected": true
+        },
+        {
+          "description": "allergic to peanuts and something else",
+          "property": "allergicTo",
+          "input": {
+            "item": "peanuts",
+            "score": 7
+          },
+          "expected": false
+        },
+        {
+          "description": "allergic to something, but not peanuts",
+          "property": "allergicTo",
+          "input": {
+            "item": "peanuts",
+            "score": 5
+          },
+          "expected": false
+        },
+        {
+          "description": "allergic to everything",
+          "property": "allergicTo",
+          "input": {
+            "item": "peanuts",
+            "score": 255
+          },
+          "expected": true
+        }
+      ]
+    },
+    {
+      "description": "testing for shellfish allergy",
+      "cases": [
+        {
+          "description": "not allergic to anything",
+          "property": "allergicTo",
+          "input": {
+            "item": "shellfish",
+            "score": 0
+          },
+          "expected": false
+        },
+        {
+          "description": "allergic only to shellfish",
+          "property": "allergicTo",
+          "input": {
+            "item": "shellfish",
+            "score": 4
+          },
+          "expected": true
+        },
+        {
+          "description": "allergic to shellfish and something else",
+          "property": "allergicTo",
+          "input": {
+            "item": "shellfish",
+            "score": 14
+          },
+          "expected": false
+        },
+        {
+          "description": "allergic to something, but not shellfish",
+          "property": "allergicTo",
+          "input": {
+            "item": "shellfish",
+            "score": 10
+          },
+          "expected": false
+        },
+        {
+          "description": "allergic to everything",
+          "property": "allergicTo",
+          "input": {
+            "item": "shellfish",
+            "score": 255
+          },
+          "expected": true
+        }
+      ]
+    },
+    {
+      "description": "testing for strawberries allergy",
+      "cases": [
+        {
+          "description": "not allergic to anything",
+          "property": "allergicTo",
+          "input": {
+            "item": "strawberries",
+            "score": 0
+          },
+          "expected": false
+        },
+        {
+          "description": "allergic only to strawberries",
+          "property": "allergicTo",
+          "input": {
+            "item": "strawberries",
+            "score": 8
+          },
+          "expected": true
+        },
+        {
+          "description": "allergic to strawberries and something else",
+          "property": "allergicTo",
+          "input": {
+            "item": "strawberries",
+            "score": 28
+          },
+          "expected": false
+        },
+        {
+          "description": "allergic to something, but not strawberries",
+          "property": "allergicTo",
+          "input": {
+            "item": "strawberries",
+            "score": 20
+          },
+          "expected": false
+        },
+        {
+          "description": "allergic to everything",
+          "property": "allergicTo",
+          "input": {
+            "item": "strawberries",
+            "score": 255
+          },
+          "expected": true
+        }
+      ]
+    },
+    {
+      "description": "testing for tomatoes allergy",
+      "cases": [
+        {
+          "description": "not allergic to anything",
+          "property": "allergicTo",
+          "input": {
+            "item": "tomatoes",
+            "score": 0
+          },
+          "expected": false
+        },
+        {
+          "description": "allergic only to tomatoes",
+          "property": "allergicTo",
+          "input": {
+            "item": "tomatoes",
+            "score": 16
+          },
+          "expected": true
+        },
+        {
+          "description": "allergic to tomatoes and something else",
+          "property": "allergicTo",
+          "input": {
+            "item": "tomatoes",
+            "score": 56
+          },
+          "expected": false
+        },
+        {
+          "description": "allergic to something, but not tomatoes",
+          "property": "allergicTo",
+          "input": {
+            "item": "tomatoes",
+            "score": 40
+          },
+          "expected": false
+        },
+        {
+          "description": "allergic to everything",
+          "property": "allergicTo",
+          "input": {
+            "item": "tomatoes",
+            "score": 255
+          },
+          "expected": true
+        }
+      ]
+    },
+    {
+      "description": "testing for chocolate allergy",
+      "cases": [
+        {
+          "description": "not allergic to anything",
+          "property": "allergicTo",
+          "input": {
+            "item": "chocolate",
+            "score": 0
+          },
+          "expected": false
+        },
+        {
+          "description": "allergic only to chocolate",
+          "property": "allergicTo",
+          "input": {
+            "item": "chocolate",
+            "score": 32
+          },
+          "expected": true
+        },
+        {
+          "description": "allergic to chocolate and something else",
+          "property": "allergicTo",
+          "input": {
+            "item": "chocolate",
+            "score": 112
+          },
+          "expected": false
+        },
+        {
+          "description": "allergic to something, but not chocolate",
+          "property": "allergicTo",
+          "input": {
+            "item": "chocolate",
+            "score": 80
+          },
+          "expected": false
+        },
+        {
+          "description": "allergic to everything",
+          "property": "allergicTo",
+          "input": {
+            "item": "chocolate",
+            "score": 255
+          },
+          "expected": true
+        }
+      ]
+    },
+    {
+      "description": "testing for pollen allergy",
+      "cases": [
+        {
+          "description": "not allergic to anything",
+          "property": "allergicTo",
+          "input": {
+            "item": "pollen",
+            "score": 0
+          },
+          "expected": false
+        },
+        {
+          "description": "allergic only to pollen",
+          "property": "allergicTo",
+          "input": {
+            "item": "pollen",
+            "score": 64
+          },
+          "expected": true
+        },
+        {
+          "description": "allergic to pollen and something else",
+          "property": "allergicTo",
+          "input": {
+            "item": "pollen",
+            "score": 224
+          },
+          "expected": false
+        },
+        {
+          "description": "allergic to something, but not pollen",
+          "property": "allergicTo",
+          "input": {
+            "item": "pollen",
+            "score": 160
+          },
+          "expected": false
+        },
+        {
+          "description": "allergic to everything",
+          "property": "allergicTo",
+          "input": {
+            "item": "pollen",
+            "score": 255
+          },
+          "expected": true
+        }
+      ]
+    },
+    {
+      "description": "testing for cats allergy",
+      "cases": [
+        {
+          "description": "not allergic to anything",
           "property": "allergicTo",
           "input": {
             "item": "cats",
@@ -28,98 +369,38 @@
           "expected": false
         },
         {
-          "description": "strawberries",
+          "description": "allergic only to cats",
           "property": "allergicTo",
           "input": {
-            "item": "strawberries",
-            "score": 0
-          },
-          "expected": false
-        }
-      ]
-    },
-    {
-      "description": "allergic to only eggs",
-      "property": "allergicTo",
-      "input": {
-        "item": "eggs",
-        "score": 1
-      },
-      "expected": true
-    },
-    {
-      "description": "allergic to eggs in addition to other stuff like:",
-      "cases": [
-        {
-          "description": "eggs repeated",
-          "property": "allergicTo",
-          "input": {
-            "item": "eggs",
-            "score": 5
+            "item": "cats",
+            "score": 128
           },
           "expected": true
         },
         {
-          "description": "shellfish",
+          "description": "allergic to cats and something else",
           "property": "allergicTo",
           "input": {
-            "item": "shellfish",
-            "score": 5
-          },
-          "expected": true
-        },
-        {
-          "description": "strawberries",
-          "property": "allergicTo",
-          "input": {
-            "item": "strawberries",
-            "score": 5
-          },
-          "expected": false
-        }
-      ]
-    },
-    {
-      "description": "allergic to strawberries but not:",
-      "cases": [
-        {
-          "description": "peanuts",
-          "property": "allergicTo",
-          "input": {
-            "item": "peanuts",
-            "score": 9
+            "item": "cats",
+            "score": 192
           },
           "expected": false
         },
         {
-          "description": "shellfish",
+          "description": "allergic to something, but not cats",
           "property": "allergicTo",
           "input": {
-            "item": "shellfish",
-            "score": 9
+            "item": "cats",
+            "score": 64
           },
           "expected": false
-        }
-      ]
-    },
-    {
-      "description": "allergic to strawberries and also:",
-      "cases": [
-        {
-          "description": "eggs",
-          "property": "allergicTo",
-          "input": {
-            "item": "eggs",
-            "score": 9
-          },
-          "expected": true
         },
         {
-          "description": "strawberries repeated",
+          "description": "allergic to everything",
           "property": "allergicTo",
           "input": {
-            "item": "strawberries",
-            "score": 9
+            "item": "cats",
+            "score": 255
           },
           "expected": true
         }

--- a/exercises/allergies/canonical-data.json
+++ b/exercises/allergies/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "allergies",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "cases": [
     {
       "description": "allergicTo",
@@ -13,95 +13,134 @@
       ],
       "cases": [
         {
-          "description": "no allergies means not allergic",
-          "property": "allergicTo",
-          "input": {
-            "score": 0
-          },
-          "expected": [
+          "description": "no allergies means not allergic with:",
+          "cases": [
             {
-              "substance": "peanuts",
-              "result": false
+              "description": "peanuts",
+              "property": "allergicTo",
+              "input": {
+                "item": "peanuts",
+                "score": 0
+              },
+              "expected": false
             },
             {
-              "substance": "cats",
-              "result": false
+              "description": "cats",
+              "property": "allergicTo",
+              "input": {
+                "item": "cats",
+                "score": 0
+              },
+              "expected": false
             },
             {
-              "substance": "strawberries",
-              "result": false
-            }
-          ]
-        },
-        {
-          "description": "is allergic to eggs",
-          "property": "allergicTo",
-          "input": {
-            "score": 1
-          },
-          "expected": [
-            {
-              "substance": "eggs",
-              "result": true
-            }
-          ]
-        },
-        {
-          "description": "allergic to eggs in addition to other stuff",
-          "property": "allergicTo",
-          "input": {
-            "score": 5
-          },
-          "expected": [
-            {
-              "substance": "eggs",
-              "result": true
-            },
-            {
-              "substance": "shellfish",
-              "result": true
-            },
-            {
-              "substance": "strawberries",
-              "result": false
-            }
-          ]
-        },
-        {
-          "description": "allergic to strawberries but not peanuts",
-          "property": "allergicTo",
-          "input": {
-            "score": 9
-          },
-          "expected": [
-            {
-              "substance": "eggs",
-              "result": true
-            },
-            {
-              "substance": "peanuts",
-              "result": false
-            },  
-            {
-              "substance": "shellfish",
-              "result": false
-            },
-            {
-              "substance": "strawberries",
-              "result": true
+              "description": "strawberries",
+              "property": "allergicTo",
+              "input": {
+                "item": "strawberries",
+                "score": 0
+              },
+              "expected": false
             }
           ]
         }
       ]
     },
     {
-      "description": "list",
+      "description": "allergic to only eggs",
+      "property": "allergicTo",
+      "input": {
+        "item": "eggs",
+        "score": 1
+      },
+      "expected": true
+    },
+    {
+      "description": "allergic to eggs in addition to other stuff like:",
+      "property": "allergicTo",
+      "cases": [
+        {
+          "description": "strawberries",
+          "property": "allergicTo",
+          "input": {
+            "item": "eggs",
+            "score": 5
+          },
+          "expected": true
+        },
+        {
+          "description": "shellfish",
+          "property": "allergicTo",
+          "input": {
+            "item": "shellfish",
+            "score": 5
+          },
+          "expected": true
+        },
+        {
+          "description": "strawberries",
+          "property": "allergicTo",
+          "input": {
+            "item": "eggs",
+            "score": 5
+          },
+          "expected": true
+        }
+      ]
+    },
+    {
+      "description": "allergic to strawberries but not peanuts with:",
+      "property": "allergicTo",
+      "input": {
+        "score": 9
+      },
+      "cases": [
+        {
+          "description": "eggs",
+          "property": "allergicTo",
+          "input": {
+            "item": "eggs",
+            "score": 9
+          },
+          "expected": true
+        },
+        {
+          "description": "peanuts",
+          "property": "allergicTo",
+          "input": {
+            "item": "peanuts",
+            "score": 9
+          },
+          "expected": false
+        },
+        {
+          "description": "shellfish",
+          "property": "allergicTo",
+          "input": {
+            "item": "shellfish",
+            "score": 9
+          },
+          "expected": false
+        },
+        {
+          "description": "strawberries",
+          "property": "allergicTo",
+          "input": {
+            "item": "strawberries",
+            "score": 9
+          },
+          "expected": true
+        }
+      ]
+    },
+    {
+      "description": "list when:",
       "comments": [
         "Given a number, list all things Tom is allergic to"
       ],
       "cases": [
         {
-          "description": "no allergies at all",
+          "description": "no allergies",
           "property": "list",
           "input": {
             "score": 0
@@ -109,88 +148,103 @@
           "expected": []
         },
         {
-          "description": "allergic to just eggs",
+          "description": "just eggs",
           "property": "list",
           "input": {
             "score": 1
           },
-          "expected": ["eggs"]
+          "expected": [
+            "eggs"
+          ]
         },
         {
-          "description": "allergic to just peanuts",
+          "description": "just peanuts",
           "property": "list",
           "input": {
             "score": 2
           },
-          "expected": ["peanuts"]
+          "expected": [
+            "peanuts"
+          ]
         },
         {
-          "description": "allergic to just strawberries",
+          "description": "just strawberries",
           "property": "list",
           "input": {
             "score": 8
           },
-          "expected": ["strawberries"]
+          "expected": [
+            "strawberries"
+          ]
         },
         {
-          "description": "allergic to eggs and peanuts",
+          "description": "eggs and peanuts",
           "property": "list",
           "input": {
             "score": 3
           },
-          "expected": ["eggs", "peanuts"]
+          "expected": [
+            "eggs",
+            "peanuts"
+          ]
         },
         {
-          "description": "allergic to more than eggs but not peanuts",
+          "description": "more than eggs but not peanuts",
           "property": "list",
           "input": {
             "score": 5
           },
-          "expected": ["eggs", "shellfish"]
+          "expected": [
+            "eggs",
+            "shellfish"
+          ]
         },
         {
-          "description": "allergic to lots of stuff",
+          "description": "lots of stuff",
           "property": "list",
           "input": {
             "score": 248
           },
-          "expected": [ "strawberries",
-                        "tomatoes",
-                        "chocolate",
-                        "pollen",
-                        "cats"
-                      ]
+          "expected": [
+            "strawberries",
+            "tomatoes",
+            "chocolate",
+            "pollen",
+            "cats"
+          ]
         },
         {
-          "description": "allergic to everything",
+          "description": "everything",
           "property": "list",
           "input": {
             "score": 255
           },
-          "expected": [ "eggs",
-                        "peanuts",
-                        "shellfish",
-                        "strawberries",
-                        "tomatoes",
-                        "chocolate",
-                        "pollen",
-                        "cats"
-                      ]
+          "expected": [
+            "eggs",
+            "peanuts",
+            "shellfish",
+            "strawberries",
+            "tomatoes",
+            "chocolate",
+            "pollen",
+            "cats"
+          ]
         },
         {
-          "description": "ignore non allergen score parts",
+          "description": "no allergen score parts",
           "property": "list",
           "input": {
             "score": 509
           },
-          "expected": [ "eggs",
-                        "shellfish",
-                        "strawberries",
-                        "tomatoes",
-                        "chocolate",
-                        "pollen",
-                        "cats"
-                      ]
+          "expected": [
+            "eggs",
+            "shellfish",
+            "strawberries",
+            "tomatoes",
+            "chocolate",
+            "pollen",
+            "cats"
+          ]
         }
       ]
     }

--- a/exercises/allergies/canonical-data.json
+++ b/exercises/allergies/canonical-data.json
@@ -1,48 +1,43 @@
 {
   "exercise": "allergies",
   "version": "1.2.1",
+  "comments": [
+    "Given a number and a substance, indicate whether Tom is allergic ",
+    "to that substance.",
+    "Test cases for this method involve more than one assertion.",
+    "Each case in 'expected' specifies what the method should return for",
+    "the given substance."
+  ],
   "cases": [
     {
-      "description": "allergicTo",
-      "comments": [
-        "Given a number and a substance, indicate whether Tom is allergic ",
-        "to that substance.",
-        "Test cases for this method involve more than one assertion.",
-        "Each case in 'expected' specifies what the method should return for",
-        "the given substance."
-      ],
+      "description": "no allergies means not allergic with:",
       "cases": [
         {
-          "description": "no allergies means not allergic with:",
-          "cases": [
-            {
-              "description": "peanuts",
-              "property": "allergicTo",
-              "input": {
-                "item": "peanuts",
-                "score": 0
-              },
-              "expected": false
-            },
-            {
-              "description": "cats",
-              "property": "allergicTo",
-              "input": {
-                "item": "cats",
-                "score": 0
-              },
-              "expected": false
-            },
-            {
-              "description": "strawberries",
-              "property": "allergicTo",
-              "input": {
-                "item": "strawberries",
-                "score": 0
-              },
-              "expected": false
-            }
-          ]
+          "description": "peanuts",
+          "property": "allergicTo",
+          "input": {
+            "item": "peanuts",
+            "score": 0
+          },
+          "expected": false
+        },
+        {
+          "description": "cats",
+          "property": "allergicTo",
+          "input": {
+            "item": "cats",
+            "score": 0
+          },
+          "expected": false
+        },
+        {
+          "description": "strawberries",
+          "property": "allergicTo",
+          "input": {
+            "item": "strawberries",
+            "score": 0
+          },
+          "expected": false
         }
       ]
     },
@@ -60,7 +55,7 @@
       "property": "allergicTo",
       "cases": [
         {
-          "description": "strawberries",
+          "description": "eggs",
           "property": "allergicTo",
           "input": {
             "item": "eggs",
@@ -81,10 +76,10 @@
           "description": "strawberries",
           "property": "allergicTo",
           "input": {
-            "item": "eggs",
+            "item": "strawberries",
             "score": 5
           },
-          "expected": true
+          "expected": false
         }
       ]
     },

--- a/exercises/allergies/canonical-data.json
+++ b/exercises/allergies/canonical-data.json
@@ -80,21 +80,8 @@
       ]
     },
     {
-      "description": "allergic to strawberries but not peanuts with:",
-      "property": "allergicTo",
-      "input": {
-        "score": 9
-      },
+      "description": "allergic to strawberries but not:",
       "cases": [
-        {
-          "description": "eggs",
-          "property": "allergicTo",
-          "input": {
-            "item": "eggs",
-            "score": 9
-          },
-          "expected": true
-        },
         {
           "description": "peanuts",
           "property": "allergicTo",
@@ -112,9 +99,23 @@
             "score": 9
           },
           "expected": false
+        }
+      ]
+    },
+    {
+      "description": "allergic to strawberries and also:",
+      "cases": [
+        {
+          "description": "eggs",
+          "property": "allergicTo",
+          "input": {
+            "item": "eggs",
+            "score": 9
+          },
+          "expected": true
         },
         {
-          "description": "strawberries",
+          "description": "strawberries repeated",
           "property": "allergicTo",
           "input": {
             "item": "strawberries",

--- a/exercises/allergies/canonical-data.json
+++ b/exercises/allergies/canonical-data.json
@@ -34,7 +34,7 @@
             "item": "eggs",
             "score": 3
           },
-          "expected": false
+          "expected": true
         },
         {
           "description": "allergic to something, but not eggs",
@@ -84,7 +84,7 @@
             "item": "peanuts",
             "score": 7
           },
-          "expected": false
+          "expected": true
         },
         {
           "description": "allergic to something, but not peanuts",
@@ -134,7 +134,7 @@
             "item": "shellfish",
             "score": 14
           },
-          "expected": false
+          "expected": true
         },
         {
           "description": "allergic to something, but not shellfish",
@@ -184,7 +184,7 @@
             "item": "strawberries",
             "score": 28
           },
-          "expected": false
+          "expected": true
         },
         {
           "description": "allergic to something, but not strawberries",
@@ -234,7 +234,7 @@
             "item": "tomatoes",
             "score": 56
           },
-          "expected": false
+          "expected": true
         },
         {
           "description": "allergic to something, but not tomatoes",
@@ -284,7 +284,7 @@
             "item": "chocolate",
             "score": 112
           },
-          "expected": false
+          "expected": true
         },
         {
           "description": "allergic to something, but not chocolate",
@@ -334,7 +334,7 @@
             "item": "pollen",
             "score": 224
           },
-          "expected": false
+          "expected": true
         },
         {
           "description": "allergic to something, but not pollen",
@@ -384,7 +384,7 @@
             "item": "cats",
             "score": 192
           },
-          "expected": false
+          "expected": true
         },
         {
           "description": "allergic to something, but not cats",


### PR DESCRIPTION
The canonical-data for allergies wasn't in a format consistent with other exercises, and relied on a comment that explained that some of the expected results were actually an array of answers with the expectation that each one was a separate test. This is not possible to detect automatically and differentiate it from tests that expect array results. (I can only assume that other tracks which generate have hand edited their results).

Looking at how all the current tracks have interpreted the spec,  they have all specified an  "allergicToItem: 'eggs' forScore: 1"  type of approach... so I propose modifying the json use sub cases to specify each one individually (this is done for lots of other exercises already).

I think this is the simplest approach - otherwise we need to adjust the schema to specify that a result can be multi-valued, and probably should have a different name like:

"manyExpected" : [ {...}, {...} ]