### PR TITLE
Luhn: Add a test with an odd number of spaces

### DIFF
--- a/exercises/luhn/canonical-data.json
+++ b/exercises/luhn/canonical-data.json
@@ -67,6 +67,14 @@
       "expected": true
     },
     {
+      "description": "valid number with an odd number of spaces",
+      "property": "valid",
+      "input": {
+        "value": "234 567 891 234"
+      },
+      "expected": true
+    },
+    {
       "description": "valid strings with a non-digit added at the end become invalid",
       "property": "valid",
       "input": {


### PR DESCRIPTION
Currently the test have only valid numbers (a) without spaces, (b) with
an even number of spaces, or (c) where all digits are 0.
That allows an approach where you iterate from left to right, starting
with a factor of `2 - length(number) % 2`

In Python:
```python
class Luhn(object):
    def __init__(self, card_num):
        self.card_num = card_num

    def is_valid(self):
        sum = 0
        digit_count = 0
        factor = 2 - len(self.card_num) % 2
        for c in self.card_num:
            if c == ' ': continue
            if not ('0' <= c <= '9'): return False
            digit_count += 1
            digit = int(c) * factor
            if digit > 9: digit -= 9
            sum += digit
            factor = 3 - factor
        return digit_count > 1 and sum % 10 == 0
```

Adding a test case where a valid number has an odd number of spaces can
catch that invalid approach.