### PR TITLE
Correct Queen Attack test values

### DIFF
--- a/exercises/queen-attack/canonical-data.json
+++ b/exercises/queen-attack/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "queen-attack",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "comments": [
     "Testing invalid positions will vary by language. The expected",
     "value of 'error' is there to indicate some sort of failure should",
@@ -204,14 +204,14 @@
           "input": {
             "white_queen": {
               "position": {
-                "row": 2,
-                "column": 2
+                "row": 0,
+                "column": 6
               }
             },
             "black_queen": {
               "position": {
-                "row": 5,
-                "column": 5
+                "row": 1,
+                "column": 7
               }
             }
           },

--- a/exercises/queen-attack/canonical-data.json
+++ b/exercises/queen-attack/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "queen-attack",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "comments": [
     "Testing invalid positions will vary by language. The expected",
     "value of 'error' is there to indicate some sort of failure should",

--- a/exercises/queen-attack/canonical-data.json
+++ b/exercises/queen-attack/canonical-data.json
@@ -204,14 +204,14 @@
           "input": {
             "white_queen": {
               "position": {
-                "row": 0,
-                "column": 6
+                "row": 1,
+                "column": 7
               }
             },
             "black_queen": {
               "position": {
-                "row": 1,
-                "column": 7
+                "row": 0,
+                "column": 6
               }
             }
           },


### PR DESCRIPTION
There is a flaw in the Queen Attack test suite that causes the most naive implementation that makes the tests green to actually be incomplete.

The tests for "third diagonal" (2, 2 and 1, 1) and "fourth diagonal" (2, 2 and 5, 5) actually test for the same diagonal (A1 to H8) and are fulfilled by the condition `row1 = column1 && row2 = column2`. This does not cover the parallels of that diagonal, however, so if there was an additional test for (0, 6) and (1, 7) that would still be red.

This is fixed by replacing the redundant "fourth diagonal" test values with said (0, 6) and (1, 7), which will require the condition to be changed to `row1 - column1 = row2 - column2`, thus covering all diagonals from "top left" to "bottom right".

That said, the tests for "first diagonal" and "second diagonal" are actually also covering the same diagonal (the one from "bottom left" to "top right" that includes 2, 2), but this PR is not addressing that.