### PR TITLE
Zero is an Armstrong number and requires specific testing

### DIFF
--- a/exercises/armstrong-numbers/canonical-data.json
+++ b/exercises/armstrong-numbers/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "armstrong-numbers",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "cases": [
     {
       "description": "Zero is an Armstrong number",

--- a/exercises/armstrong-numbers/canonical-data.json
+++ b/exercises/armstrong-numbers/canonical-data.json
@@ -1,7 +1,15 @@
 {
   "exercise": "armstrong-numbers",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "cases": [
+    {
+      "description": "Zero is an Armstrong number",
+      "property": "isArmstrongNumber",
+      "input": {
+        "number": 0
+      },
+      "expected": true
+    },
     {
       "description": "Single digit numbers are Armstrong numbers",
       "property": "isArmstrongNumber",


### PR DESCRIPTION
[`0` is also an Armstrong number](https://en.wikipedia.org/wiki/Narcissistic_number) and needs to be tested for explicitly if students are using a base 10 logarithm to calculate the number of digits for which `0` is a case that needs special handling.