### PR TITLE
yacht: Add "No pairs but not a big straight" test case

### DIFF
--- a/exercises/yacht/canonical-data.json
+++ b/exercises/yacht/canonical-data.json
@@ -1,6 +1,6 @@
 {
     "exercise":"yacht",
-    "version":"1.1.0",
+    "version":"1.2.0",
     "comments":[
         "The dice are represented always as a list of exactly five integers",
         "with values between 1 and 6 inclusive. The category is an string.",
@@ -235,6 +235,15 @@
             "input":{
                 "dice":[6, 5, 4, 3, 2],
                 "category":"little straight"
+            },
+            "expected":0
+        },
+        {
+            "description":"Only consecutive numbers form a straight",
+            "property":"score",
+            "input":{
+                "dice":[6, 5, 4, 3, 1],
+                "category":"big straight"
             },
             "expected":0
         },

--- a/exercises/yacht/canonical-data.json
+++ b/exercises/yacht/canonical-data.json
@@ -239,7 +239,7 @@
             "expected":0
         },
         {
-            "description":"Only consecutive numbers form a straight",
+            "description":"No pairs but not a big straight",
             "property":"score",
             "input":{
                 "dice":[6, 5, 4, 3, 1],


### PR DESCRIPTION
simple implementations checking only uniques will otherwise pass the test suite.

I submitted a solution with

```
case YachtCategory.BigStraight:
    return dice.OrderBy(x => x).Distinct().Count() == 5 && dice.Max() == 6 ? 30 : 0;
```

which incorrectly identifies 6, 5, 4, 3, 1 as a big straight.