### PR TITLE
Connect: remove obsolete sentence from description

### DIFF
--- a/exercises/connect/description.md
+++ b/exercises/connect/description.md
@@ -13,8 +13,7 @@ Your goal is to build a program that given a simple representation of a board
 computes the winner (or lack thereof). Note that all games need not be "fair".
 (For example, players may have mismatched piece counts.)
 
-The boards look like this (with spaces added for readability, which won't be in
-the representation passed to your code):
+The boards look like this:
 
 ```text
 . O . X .


### PR DESCRIPTION
The canonical test input is now similar to what is shown in the description, but the description says it isn't. Fixes #1435.