### PR TITLE
Isogram: Add missing test case that distinguishes from continue and break for loops.

### DIFF
--- a/exercises/isogram/canonical-data.json
+++ b/exercises/isogram/canonical-data.json
@@ -3,7 +3,7 @@
   "comments": [
     "An isogram is a word or phrase without a repeating letter."
   ],
-  "version": "1.7.0",
+  "version": "1.8.0",
   "cases": [
     {
       "description": "Check if the given string is an isogram",
@@ -112,6 +112,14 @@
           "property": "isIsogram",
           "input": {
             "phrase": "angola"
+          },
+          "expected": false
+        },
+        {
+          "description": "a non letter before a repeating pattern",
+          "property": "isIsogram",
+          "input": {
+            "phrase": "red bat cat"
           },
           "expected": false
         }


### PR DESCRIPTION
1. Why is this change neccesary?
Because the current test suite allows you to use a `break` a statement inside a
for loop and having all the test pass, this can lead to some confusion between
`break` and `continue` statements that are inside a for loop.

With the current test suite one could do something like this:

```
for i, letter := range word {
		letter = unicode.ToLower(letter)
		if !unicode.IsLetter(letter) {
			break
		}
		if strings.ContainsRune(word[i+1:], letter) {
			return false
		}
	}
```

And have all the test pass.

This could be problematic as the `break` statement gives a better benchmark but it's because of a coincidence with the test cases.

![Screenshot_2019-05-05_13-36-18](https://user-images.githubusercontent.com/10160626/57200937-4ca17b80-6f57-11e9-9413-f0d5a100f26f.png)

2. How does it address the issue?
A test case was added where it won't pass if you use a `break` statement, you
need to use a `continue` statement for it to work.

![Screenshot_2019-05-05_17-02-17](https://user-images.githubusercontent.com/10160626/57200955-95593480-6f57-11e9-9cf3-d06082b0eea8.png)

3. What side effects does this change have?
It clears out the confusion between `break` and `continue`.