### PR TITLE
reverse-string: Add a test with an even-sized word

### DIFF
--- a/exercises/reverse-string/canonical-data.json
+++ b/exercises/reverse-string/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "reverse-string",
-  "version": "1.1.0",      
+  "version": "1.2.0",
   "comments": [
         "If property based testing tools are available, a good property to test is reversing a string twice: reverse(reverse(string)) == string"
       ],
@@ -44,6 +44,14 @@
         "value": "racecar"
       },
       "expected": "racecar"
+    },
+    {
+      "description": "an even-sized word",
+      "property": "reverse",
+      "input": {
+        "value": "drawer"
+      },
+      "expected": "reward"
     }
   ]
 }


### PR DESCRIPTION
Currently the tests have only odd sized strings. That allows an approach
to pass that does not work on even sized strings:

```cpp
std::string reverse_string::reverse_string(std::string str)
{
    if (str.size())
        for (auto a = str.begin(), b = str.end() - 1; a != b; ++a, --b)
            std::swap(*a, *b);
    return str;
}
```

The problem is `!=` instead of `<`.

Adding a test with an even sized string catches that invalid approach.