### PR TITLE
Robot simulator descriptions too long

### DIFF
--- a/exercises/robot-simulator/canonical-data.json
+++ b/exercises/robot-simulator/canonical-data.json
@@ -315,7 +315,7 @@
       "description": "Series of instructions",
       "comments": [ "The robot can follow a series of instructions and end up with the correct position and direction.",
                     "Where R = Turn Right, L = Turn Left and A = Advance"
-      ]
+      ],
       "cases": [
         {
           "description": "moving east and north",

--- a/exercises/robot-simulator/canonical-data.json
+++ b/exercises/robot-simulator/canonical-data.json
@@ -10,11 +10,11 @@
   ],
   "cases": [
     {
-      "description": "Create",
+      "description": "Creation",
       "comments": [ "A robot is created with a position and a direction" ],
       "cases": [
         {
-          "description": "at origin facing north",
+          "description": "At origin",
           "comments": [ "Robots are created with a position and direction" ],
           "property": "create",
           "input": {
@@ -33,7 +33,7 @@
           }
         },
         {
-          "description": "at negative position facing South",
+          "description": "Allows negative positions",
           "comments": [ "Negative positions allowed" ],
           "property": "create",
           "input": {

--- a/exercises/robot-simulator/canonical-data.json
+++ b/exercises/robot-simulator/canonical-data.json
@@ -10,10 +10,12 @@
   ],
   "cases": [
     {
-      "description": "A robot is created with a position and a direction",
+      "description": "Create",
+      "comments": [ "A robot is created with a position and a direction" ],
       "cases": [
         {
-          "description": "Robots are created with a position and direction",
+          "description": "at origin facing north",
+          "comments": [ "Robots are created with a position and direction" ],
           "property": "create",
           "input": {
             "position": {
@@ -31,7 +33,8 @@
           }
         },
         {
-          "description": "Negative positions are allowed",
+          "description": "at negative position facing South",
+          "comments": [ "Negative positions allowed" ],
           "property": "create",
           "input": {
             "position": {
@@ -51,10 +54,12 @@
       ]
     },
     {
-      "description": "rotates the robot's direction 90 degrees clockwise",
+      "description": "Rotate clockwise",
+      "comments": [ "rotates the robot's direction 90 degrees clockwise" ],
       "cases": [
         {
-          "description": "changes the direction from north to east",
+          "description": "north to east",
+          "comments": [ "changes the direction from north to east" ],
           "property": "move",
           "input": {
             "position": {
@@ -73,7 +78,8 @@
           }
         },
         {
-          "description": "changes the direction from east to south",
+          "description": "east to south",
+          "comments": [ "changes the direction from east to south" ],
           "property": "move",
           "input": {
             "position": {
@@ -92,7 +98,8 @@
           }
         },
         {
-          "description": "changes the direction from south to west",
+          "description": "south to west",
+          "comments": [ "changes the direction from south to west" ],
           "property": "move",
           "input": {
             "position": {
@@ -111,7 +118,8 @@
           }
         },
         {
-          "description": "changes the direction from west to north",
+          "description": "west to north",
+          "comments": [ "changes the direction from west to north" ],
           "property": "move",
           "input": {
             "position": {
@@ -132,10 +140,12 @@
       ]
     },
     {
-      "description": "rotates the robot's direction 90 degrees counter-clockwise",
+      "description": "Rotates counter-clockwise",
+      "comments": [ "rotates the robot's direction 90 degrees counter-clockwise" ],
       "cases": [
         {
-          "description": "changes the direction from north to west",
+          "description": "north to west",
+          "comments": [ "changes the direction from north to west" ],
           "property": "move",
           "input": {
             "position": {
@@ -154,7 +164,8 @@
           }
         },
         {
-          "description": "changes the direction from west to south",
+          "description": "west to south",
+          "comments": [ "changes the direction from west to south" ],
           "property": "move",
           "input": {
             "position": {
@@ -173,7 +184,8 @@
           }
         },
         {
-          "description": "changes the direction from south to east",
+          "description": "south to east",
+          "comments": [ "changes the direction from south to east" ],
           "property": "move",
           "input": {
             "position": {
@@ -192,7 +204,8 @@
           }
         },
         {
-          "description": "changes the direction from east to north",
+          "description": "east to north",
+          "comments": [ "changes the direction from east to north" ],
           "property": "move",
           "input": {
             "position": {
@@ -213,10 +226,12 @@
       ]
     },
     {
-      "description": "moves the robot forward 1 space in the direction it is pointing",
+      "description": "Forward One",
+      "comments": [ "moves the robot forward 1 space in the direction it is pointing" ],
       "cases": [
         {
-          "description": "increases the y coordinate one when facing north",
+          "description": "facing north",
+          "comments": [ "increases the y coordinate one when facing north" ],
           "property": "move",
           "input": {
             "position": {
@@ -235,7 +250,8 @@
           }
         },
         {
-          "description": "decreases the y coordinate by one when facing south",
+          "description": "facing south",
+          "comments": [ "decreases the y coordinate by one when facing south" ],
           "property": "move",
           "input": {
             "position": {
@@ -254,7 +270,8 @@
           }
         },
         {
-          "description": "increases the x coordinate by one when facing east",
+          "description": "facing east",
+          "comments": [ "increases the x coordinate by one when facing east" ],
           "property": "move",
           "input": {
             "position": {
@@ -273,7 +290,8 @@
           }
         },
         {
-          "description": "decreases the x coordinate by one when facing west",
+          "description": "facing west",
+          "comments": [ "decreases the x coordinate by one when facing west" ],
           "property": "move",
           "input": {
             "position": {
@@ -294,10 +312,14 @@
       ]
     },
     {
-      "description": "Where R = Turn Right, L = Turn Left and A = Advance, the robot can follow a series of instructions and end up with the correct position and direction",
+      "description": "Series of instructions",
+      "comments": [ "The robot can follow a series of instructions and end up with the correct position and direction.",
+                    "Where R = Turn Right, L = Turn Left and A = Advance"
+      ]
       "cases": [
         {
-          "description": "instructions to move east and north from README",
+          "description": "moving east and north",
+          "comments": [ "instructions to move east and north from README" ],
           "property": "move",
           "input": {
             "position": {
@@ -316,7 +338,8 @@
           }
         },
         {
-          "description": "instructions to move west and north",
+          "description": "moving west and north",
+          "comments": [ "instructions to move west and north" ],
           "property": "move",
           "input": {
             "position": {
@@ -335,7 +358,8 @@
           }
         },
         {
-          "description": "instructions to move west and south",
+          "description": "moving west and south",
+          "comments": [ "instructions to move west and south" ],
           "property": "move",
           "input": {
             "position": {
@@ -354,7 +378,8 @@
           }
         },
         {
-          "description": "instructions to move east and north",
+          "description": "moving east and north",
+          "comments": [ "instructions to move east and north" ],
           "property": "move",
           "input": {
             "position": {

--- a/exercises/robot-simulator/canonical-data.json
+++ b/exercises/robot-simulator/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "robot-simulator",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "comments": [
     "Some tests have two expectations: one for the position, one for the direction",
     "Optionally, you can also test",
@@ -10,12 +10,10 @@
   ],
   "cases": [
     {
-      "description": "Creation",
-      "comments": [ "A robot is created with a position and a direction" ],
+      "description": "Create robot",
       "cases": [
         {
-          "description": "At origin",
-          "comments": [ "Robots are created with a position and direction" ],
+          "description": "at origin facing north",
           "property": "create",
           "input": {
             "position": {
@@ -33,8 +31,7 @@
           }
         },
         {
-          "description": "Allows negative positions",
-          "comments": [ "Negative positions allowed" ],
+          "description": "at negative position facing south",
           "property": "create",
           "input": {
             "position": {
@@ -54,12 +51,10 @@
       ]
     },
     {
-      "description": "Rotate clockwise",
-      "comments": [ "rotates the robot's direction 90 degrees clockwise" ],
+      "description": "Rotating clockwise",
       "cases": [
         {
-          "description": "north to east",
-          "comments": [ "changes the direction from north to east" ],
+          "description": "changes north to east",
           "property": "move",
           "input": {
             "position": {
@@ -78,8 +73,7 @@
           }
         },
         {
-          "description": "east to south",
-          "comments": [ "changes the direction from east to south" ],
+          "description": "changes east to south",
           "property": "move",
           "input": {
             "position": {
@@ -98,8 +92,7 @@
           }
         },
         {
-          "description": "south to west",
-          "comments": [ "changes the direction from south to west" ],
+          "description": "changes south to west",
           "property": "move",
           "input": {
             "position": {
@@ -118,8 +111,7 @@
           }
         },
         {
-          "description": "west to north",
-          "comments": [ "changes the direction from west to north" ],
+          "description": "changes west to north",
           "property": "move",
           "input": {
             "position": {
@@ -140,12 +132,10 @@
       ]
     },
     {
-      "description": "Rotates counter-clockwise",
-      "comments": [ "rotates the robot's direction 90 degrees counter-clockwise" ],
+      "description": "Rotating counter-clockwise",
       "cases": [
         {
-          "description": "north to west",
-          "comments": [ "changes the direction from north to west" ],
+          "description": "changes north to west",
           "property": "move",
           "input": {
             "position": {
@@ -164,8 +154,7 @@
           }
         },
         {
-          "description": "west to south",
-          "comments": [ "changes the direction from west to south" ],
+          "description": "changes west to south",
           "property": "move",
           "input": {
             "position": {
@@ -184,8 +173,7 @@
           }
         },
         {
-          "description": "south to east",
-          "comments": [ "changes the direction from south to east" ],
+          "description": "changes south to east",
           "property": "move",
           "input": {
             "position": {
@@ -204,8 +192,7 @@
           }
         },
         {
-          "description": "east to north",
-          "comments": [ "changes the direction from east to north" ],
+          "description": "changes east to north",
           "property": "move",
           "input": {
             "position": {
@@ -226,12 +213,10 @@
       ]
     },
     {
-      "description": "Forward One",
-      "comments": [ "moves the robot forward 1 space in the direction it is pointing" ],
+      "description": "Moving forward one",
       "cases": [
         {
-          "description": "facing north",
-          "comments": [ "increases the y coordinate one when facing north" ],
+          "description": "facing north increments Y",
           "property": "move",
           "input": {
             "position": {
@@ -250,8 +235,7 @@
           }
         },
         {
-          "description": "facing south",
-          "comments": [ "decreases the y coordinate by one when facing south" ],
+          "description": "facing south decrements Y",
           "property": "move",
           "input": {
             "position": {
@@ -270,8 +254,7 @@
           }
         },
         {
-          "description": "facing east",
-          "comments": [ "increases the x coordinate by one when facing east" ],
+          "description": "facing east increments X",
           "property": "move",
           "input": {
             "position": {
@@ -290,8 +273,7 @@
           }
         },
         {
-          "description": "facing west",
-          "comments": [ "decreases the x coordinate by one when facing west" ],
+          "description": "facing west decrements X",
           "property": "move",
           "input": {
             "position": {
@@ -312,14 +294,13 @@
       ]
     },
     {
-      "description": "Series of instructions",
+      "description": "Follow series of instructions",
       "comments": [ "The robot can follow a series of instructions and end up with the correct position and direction.",
                     "Where R = Turn Right, L = Turn Left and A = Advance"
       ],
       "cases": [
         {
-          "description": "moving east and north",
-          "comments": [ "instructions to move east and north from README" ],
+          "description": "moving east and north from README",
           "property": "move",
           "input": {
             "position": {
@@ -339,7 +320,6 @@
         },
         {
           "description": "moving west and north",
-          "comments": [ "instructions to move west and north" ],
           "property": "move",
           "input": {
             "position": {
@@ -359,7 +339,6 @@
         },
         {
           "description": "moving west and south",
-          "comments": [ "instructions to move west and south" ],
           "property": "move",
           "input": {
             "position": {
@@ -379,7 +358,6 @@
         },
         {
           "description": "moving east and north",
-          "comments": [ "instructions to move east and north" ],
           "property": "move",
           "input": {
             "position": {


### PR DESCRIPTION
[Edit] Some language tracks (e.g. Pharo) individually identify tests.  To auto-create these identifiers during code generation, the only data currently available is the canonical data "description" field.  Some tracks insert this field directly into their generated code as a comment, and the "descriptions" are suitably verbose for that purpose.  However such verbosity generates some very long identifiers (e.g. >150 characters).  

Issue #1473 proposed to adding a distinct "identifier" field.  Back-pressure there directed me to first try compressing "descriptions" to suit "identifier" generation.  This PR is a trial at doing that - minimizing description length without losing information.  However even if no substantive information is lost, I such compression may compromise the readability of comments generated from the "descriptions", so I'm interested in feedback on that here and in #1473.

P.S. When originally creating this PR I misunderstood the canonical data "comments" field was for maintainers only and unrelated to generated comments for students. Original text of this post...
> Convert long descriptions into comments per #1473



