### PR TITLE
ETL descriptions too long

### DIFF
--- a/exercises/etl/canonical-data.json
+++ b/exercises/etl/canonical-data.json
@@ -5,7 +5,7 @@
     {
       "comments": [
         "Transforms a set of legacy scrabble data stored as letters per score",
-        "to a set of data stored score per letter."
+        "to a set of data stored score per letter.",
         "Note:  The expected input data for these tests should have",
         "integer keys (not stringified numbers as shown in the JSON below",
         "Unless the language prohibits that, please implement these tests",

--- a/exercises/etl/canonical-data.json
+++ b/exercises/etl/canonical-data.json
@@ -10,9 +10,9 @@
         "such that keys are integers. e.g. in JavaScript, it might look ",
         "like `transform( { 1: ['A'] } );`"
       ],
-      "description": "Transform",
-      "comments": [ "Transforms the a set of scrabble data previously indexed by the tile score",
-                    "to a set of data indexed by the tile letter"
+      "description": "Transform legacy to new",
+      "comments": [ "Transforms a set of legacy scrabble data stored as letters per score",
+                    "to a set of data stored score per letter"
       ],
       "cases": [
         {

--- a/exercises/etl/canonical-data.json
+++ b/exercises/etl/canonical-data.json
@@ -10,7 +10,10 @@
         "such that keys are integers. e.g. in JavaScript, it might look ",
         "like `transform( { 1: ['A'] } );`"
       ],
-      "description": "transforms the a set of scrabble data previously indexed by the tile score to a set of data indexed by the tile letter",
+      "description": "Transform",
+      "comments": [ "Transforms the a set of scrabble data previously indexed by the tile score",
+                    "to a set of data indexed by the tile letter"
+      ],
       "cases": [
         {
           "description": "a single letter",

--- a/exercises/etl/canonical-data.json
+++ b/exercises/etl/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "etl",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "cases": [
     {
       "comments": [

--- a/exercises/etl/canonical-data.json
+++ b/exercises/etl/canonical-data.json
@@ -4,6 +4,8 @@
   "cases": [
     {
       "comments": [
+        "Transforms a set of legacy scrabble data stored as letters per score",
+        "to a set of data stored score per letter."
         "Note:  The expected input data for these tests should have",
         "integer keys (not stringified numbers as shown in the JSON below",
         "Unless the language prohibits that, please implement these tests",
@@ -11,12 +13,10 @@
         "like `transform( { 1: ['A'] } );`"
       ],
       "description": "Transform legacy to new",
-      "comments": [ "Transforms a set of legacy scrabble data stored as letters per score",
-                    "to a set of data stored score per letter"
       ],
       "cases": [
         {
-          "description": "a single letter",
+          "description": "single letter",
           "property": "transform",
           "input": {
             "1": ["A"]

--- a/exercises/etl/canonical-data.json
+++ b/exercises/etl/canonical-data.json
@@ -13,7 +13,6 @@
         "like `transform( { 1: ['A'] } );`"
       ],
       "description": "Transform legacy to new",
-      ],
       "cases": [
         {
           "description": "single letter",


### PR DESCRIPTION
Such a long test is really a comment, not a description to be used as a test identifier.
Make it so, per #1473