### PR TITLE
Revert "ETL descriptions too long"

### DIFF
--- a/exercises/etl/canonical-data.json
+++ b/exercises/etl/canonical-data.json
@@ -10,10 +10,7 @@
         "such that keys are integers. e.g. in JavaScript, it might look ",
         "like `transform( { 1: ['A'] } );`"
       ],
-      "description": "Transform",
-      "comments": [ "Transforms the a set of scrabble data previously indexed by the tile score",
-                    "to a set of data indexed by the tile letter"
-      ],
+      "description": "transforms the a set of scrabble data previously indexed by the tile score to a set of data indexed by the tile letter",
       "cases": [
         {
           "description": "a single letter",


### PR DESCRIPTION
This reverts commit 0df9a334ac622c63ed47be1ccb30c751265ad4ae.
I have confirmed that no JSON version change is needed