### PR TITLE
[Darts] Slim down generated method names

### DIFF
--- a/exercises/darts/canonical-data.json
+++ b/exercises/darts/canonical-data.json
@@ -16,7 +16,7 @@
     },
     {
       "property": "score",
-      "description": "On outer border",
+      "description": "On outer circle",
       "input": {
         "x": 0,
         "y": 10
@@ -25,7 +25,7 @@
     },
     {
       "property": "score",
-      "description": "On middle-outer border",
+      "description": "On middle circle",
       "input": {
         "x": -5,
         "y": 0
@@ -34,7 +34,7 @@
     },
     {
       "property": "score",
-      "description": "On inner-middle border",
+      "description": "On inner circle",
       "input": {
         "x": 0,
         "y": -1
@@ -52,16 +52,16 @@
     },
     {
       "property": "score",
-      "description": "Just within inner-middle border",
+      "description": "Just within inner circle",
       "input": {
         "x": 0.7,
         "y": 0.7
       },
-      "expected": 1
+      "expected": 10
     },
     {
       "property": "score",
-      "description": "Just beyond inner-middle border",
+      "description": "Just beyond inner circle",
       "input": {
         "x": 0.8,
         "y": -0.8
@@ -70,7 +70,7 @@
     },
     {
       "property": "score",
-      "description": "Just within middle-outer border",
+      "description": "Just within middle circle",
       "input": {
         "x": -3.5,
         "y": 3.5
@@ -79,7 +79,7 @@
     },   
     {
       "property": "score",
-      "description": "Just beyond middle-outer border",
+      "description": "Just beyond middle circle",
       "input": {
         "x": -3.6,
         "y": -3.6
@@ -88,7 +88,7 @@
     },     
     {
       "property": "score",
-      "description": "Just within outer border",
+      "description": "Just within outer circle",
       "input": {
         "x": -7.0,
         "y": 7.0
@@ -97,7 +97,7 @@
     },     
     {
       "property": "score",
-      "description": "Just beyond outer border",
+      "description": "Just beyond outer circle",
       "input": {
         "x": 7.1,
         "y": -7.1
@@ -106,7 +106,7 @@
     },    
     {
       "property": "score",
-      "description": "Asymetric position within inner region",
+      "description": "Asymetric position within inner circle",
       "input": {
         "x": 0.4,
         "y": 0.8
@@ -115,7 +115,7 @@
     },
     {
       "property": "score",
-      "description": "Asymetric position within middle region",
+      "description": "Asymetric position between inner and middle circles",
       "input": {
         "x": -2,
         "y": 4
@@ -124,7 +124,7 @@
     },
     {
       "property": "score",
-      "description": "Asymmetric position within outer region",
+      "description": "Asymmetric position between middle and outer circles",
       "input": {
         "x": 4,
         "y": -8

--- a/exercises/darts/canonical-data.json
+++ b/exercises/darts/canonical-data.json
@@ -70,7 +70,7 @@
     },
     {
       "property": "score",
-      "description": "Middle-Outer border, dart just inside",
+      "description": "Middle-outer border, dart just inside",
       "input": {
         "x": -3.5,
         "y": 3.5

--- a/exercises/darts/canonical-data.json
+++ b/exercises/darts/canonical-data.json
@@ -2,12 +2,12 @@
   "exercise": "darts",
   "version": "2.0.0",
   "comments": [
-    "Return the correct amount earned by a dart landing in a given point in the target problem"
+    "Return the correct amount earned by a dart landing in a given point in the target."
   ],
   "cases": [
     {
       "property": "score",
-      "description": "A dart lands outside the target",
+      "description": "Dart missed target",
       "input": {
         "x": -9,
         "y": 9
@@ -16,7 +16,7 @@
     },
     {
       "property": "score",
-      "description": "A dart lands just in the border of the target",
+      "description": "Outer region, dart on border",
       "input": {
         "x": 0,
         "y": 10
@@ -25,34 +25,16 @@
     },
     {
       "property": "score",
-      "description": "A dart lands in the outer circle",
+      "description": "Middle region, dart on border",
       "input": {
-        "x": 4,
-        "y": 4
-      },
-      "expected": 1
-    },
-    {
-      "property": "score",
-      "description": "A dart lands right in the border between outer and middle circles",
-      "input": {
-        "x": 5,
+        "x": -5,
         "y": 0
       },
       "expected": 5
     },
     {
       "property": "score",
-      "description": "A dart lands in the middle circle",
-      "input": {
-        "x": 0.8,
-        "y": -0.8
-      },
-      "expected": 5
-    },
-    {
-      "property": "score",
-      "description": "A dart lands right in the border between middle and inner circles",
+      "description": "Inner region, dart on border",
       "input": {
         "x": 0,
         "y": -1
@@ -61,7 +43,7 @@
     },
     {
       "property": "score",
-      "description": "A dart lands in the inner circle",
+      "description": "Inner region, dart far inside",
       "input": {
         "x": -0.1,
         "y": -0.1
@@ -70,7 +52,61 @@
     },
     {
       "property": "score",
-      "description": "A dart whose coordinates sum to > 1 but whose radius to origin is <= 1 is scored in the inner circle",
+      "description": "Inner-Middle border, dart just inside",
+      "input": {
+        "x": 0.7,
+        "y": 0.7
+      },
+      "expected": 1
+    },
+    {
+      "property": "score",
+      "description": "Inner-Middle border, dart just outside",
+      "input": {
+        "x": 0.8,
+        "y": -0.8
+      },
+      "expected": 5
+    },
+    {
+      "property": "score",
+      "description": "Middle-Outer border, dart just inside",
+      "input": {
+        "x": -3.5,
+        "y": 3.5
+      },
+      "expected": 5
+    },   
+    {
+      "property": "score",
+      "description": "Middle-Outer border, dart just outside",
+      "input": {
+        "x": -3.6,
+        "y": -3.6
+      },
+      "expected": 1
+    },     
+    {
+      "property": "score",
+      "description": "Outer border, dart just inside",
+      "input": {
+        "x": -7.0,
+        "y": 7.0
+      },
+      "expected": 1
+    },     
+    {
+      "property": "score",
+      "description": "Outer border, dart just outside",
+      "input": {
+        "x": 7.1,
+        "y": -7.1
+      },
+      "expected": 0
+    },    
+    {
+      "property": "score",
+      "description": "Inner region dart, asymmetric position",
       "input": {
         "x": 0.4,
         "y": 0.8
@@ -79,19 +115,19 @@
     },
     {
       "property": "score",
-      "description": "A dart whose coordinates sum to > 5 but whose radius to origin is <= 5 is scored in the middle circle",
+      "description": "Middle region dart, asymmetric position",
       "input": {
-        "x": 2,
+        "x": -2,
         "y": 4
       },
       "expected": 5
     },
     {
       "property": "score",
-      "description": "A dart whose coordinates sum to > 10 but whose radius to origin is <= 10 is scored in the outer circle",
+      "description": "Outer region dart, asymmetric position",
       "input": {
         "x": 4,
-        "y": 8
+        "y": -8
       },
       "expected": 1
     }

--- a/exercises/darts/canonical-data.json
+++ b/exercises/darts/canonical-data.json
@@ -79,7 +79,7 @@
     },   
     {
       "property": "score",
-      "description": "Middle-Outer border, dart just outside",
+      "description": "Middle-outer border, dart just outside",
       "input": {
         "x": -3.6,
         "y": -3.6

--- a/exercises/darts/canonical-data.json
+++ b/exercises/darts/canonical-data.json
@@ -16,7 +16,7 @@
     },
     {
       "property": "score",
-      "description": "Outer region, dart on border",
+      "description": "On outer border",
       "input": {
         "x": 0,
         "y": 10
@@ -25,7 +25,7 @@
     },
     {
       "property": "score",
-      "description": "Middle region, dart on border",
+      "description": "On middle-outer border",
       "input": {
         "x": -5,
         "y": 0
@@ -34,7 +34,7 @@
     },
     {
       "property": "score",
-      "description": "Inner region, dart on border",
+      "description": "On inner-middle border",
       "input": {
         "x": 0,
         "y": -1
@@ -43,7 +43,7 @@
     },
     {
       "property": "score",
-      "description": "Inner region, dart far inside",
+      "description": "Far inside inner region",
       "input": {
         "x": -0.1,
         "y": -0.1
@@ -52,7 +52,7 @@
     },
     {
       "property": "score",
-      "description": "Inner-middle border, dart just inside",
+      "description": "Just within inner-middle border",
       "input": {
         "x": 0.7,
         "y": 0.7
@@ -61,7 +61,7 @@
     },
     {
       "property": "score",
-      "description": "Inner-middle border, dart just outside",
+      "description": "Just beyond inner-middle border",
       "input": {
         "x": 0.8,
         "y": -0.8
@@ -70,7 +70,7 @@
     },
     {
       "property": "score",
-      "description": "Middle-outer border, dart just inside",
+      "description": "Just within middle-outer border",
       "input": {
         "x": -3.5,
         "y": 3.5
@@ -79,7 +79,7 @@
     },   
     {
       "property": "score",
-      "description": "Middle-outer border, dart just outside",
+      "description": "Just beyond middle-outer border",
       "input": {
         "x": -3.6,
         "y": -3.6
@@ -88,7 +88,7 @@
     },     
     {
       "property": "score",
-      "description": "Outer border, dart just inside",
+      "description": "Just within outer border",
       "input": {
         "x": -7.0,
         "y": 7.0
@@ -97,7 +97,7 @@
     },     
     {
       "property": "score",
-      "description": "Outer border, dart just outside",
+      "description": "Just beyond outer border",
       "input": {
         "x": 7.1,
         "y": -7.1
@@ -106,7 +106,7 @@
     },    
     {
       "property": "score",
-      "description": "Inner region dart, asymmetric position",
+      "description": "Asymetric position within inner region",
       "input": {
         "x": 0.4,
         "y": 0.8
@@ -115,7 +115,7 @@
     },
     {
       "property": "score",
-      "description": "Middle region dart, asymmetric position",
+      "description": "Asymetric position within middle region",
       "input": {
         "x": -2,
         "y": 4
@@ -124,7 +124,7 @@
     },
     {
       "property": "score",
-      "description": "Outer region dart, asymmetric position",
+      "description": "Asymmetric position within outer region",
       "input": {
         "x": 4,
         "y": -8

--- a/exercises/darts/canonical-data.json
+++ b/exercises/darts/canonical-data.json
@@ -61,7 +61,7 @@
     },
     {
       "property": "score",
-      "description": "Inner-Middle border, dart just outside",
+      "description": "Inner-middle border, dart just outside",
       "input": {
         "x": 0.8,
         "y": -0.8

--- a/exercises/darts/canonical-data.json
+++ b/exercises/darts/canonical-data.json
@@ -106,30 +106,12 @@
     },    
     {
       "property": "score",
-      "description": "Asymmetric position within inner circle",
-      "input": {
-        "x": 0.4,
-        "y": 0.8
-      },
-      "expected": 10
-    },
-    {
-      "property": "score",
       "description": "Asymmetric position between inner and middle circles",
       "input": {
-        "x": -2,
-        "y": 4
+        "x": 0.5,
+        "y": -4
       },
       "expected": 5
-    },
-    {
-      "property": "score",
-      "description": "Asymmetric position between middle and outer circles",
-      "input": {
-        "x": 4,
-        "y": -8
-      },
-      "expected": 1
     }
   ]
 }

--- a/exercises/darts/canonical-data.json
+++ b/exercises/darts/canonical-data.json
@@ -52,7 +52,7 @@
     },
     {
       "property": "score",
-      "description": "Inner-Middle border, dart just inside",
+      "description": "Inner-middle border, dart just inside",
       "input": {
         "x": 0.7,
         "y": 0.7

--- a/exercises/darts/canonical-data.json
+++ b/exercises/darts/canonical-data.json
@@ -42,6 +42,7 @@
       "expected": 10
     },
     {
+      "property": "score",
       "description": "Exactly on centre",
       "input": {
         "x": 0,

--- a/exercises/darts/canonical-data.json
+++ b/exercises/darts/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "darts",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "comments": [
     "Return the correct amount earned by a dart landing in a given point in the target."
   ],

--- a/exercises/darts/canonical-data.json
+++ b/exercises/darts/canonical-data.json
@@ -7,7 +7,7 @@
   "cases": [
     {
       "property": "score",
-      "description": "Dart missed target",
+      "description": "Missed target",
       "input": {
         "x": -9,
         "y": 9
@@ -106,7 +106,7 @@
     },    
     {
       "property": "score",
-      "description": "Asymetric position within inner circle",
+      "description": "Asymmetric position within inner circle",
       "input": {
         "x": 0.4,
         "y": 0.8
@@ -115,7 +115,7 @@
     },
     {
       "property": "score",
-      "description": "Asymetric position between inner and middle circles",
+      "description": "Asymmetric position between inner and middle circles",
       "input": {
         "x": -2,
         "y": 4

--- a/exercises/darts/canonical-data.json
+++ b/exercises/darts/canonical-data.json
@@ -2,7 +2,7 @@
   "exercise": "darts",
   "version": "2.1.0",
   "comments": [
-    "Return the correct amount earned by a dart landing in a given point in the target."
+    "Return the correct amount earned by a dart's landing position."
   ],
   "cases": [
     {
@@ -16,7 +16,7 @@
     },
     {
       "property": "score",
-      "description": "On outer circle",
+      "description": "On the outer circle",
       "input": {
         "x": 0,
         "y": 10
@@ -25,7 +25,7 @@
     },
     {
       "property": "score",
-      "description": "On middle circle",
+      "description": "On the middle circle",
       "input": {
         "x": -5,
         "y": 0
@@ -34,7 +34,7 @@
     },
     {
       "property": "score",
-      "description": "On inner circle",
+      "description": "On the inner circle",
       "input": {
         "x": 0,
         "y": -1
@@ -43,7 +43,7 @@
     },
     {
       "property": "score",
-      "description": "Near centre",
+      "description": "Near the centre",
       "input": {
         "x": -0.1,
         "y": -0.1
@@ -52,7 +52,7 @@
     },
     {
       "property": "score",
-      "description": "Just within inner circle",
+      "description": "Just within the inner circle",
       "input": {
         "x": 0.7,
         "y": 0.7
@@ -61,7 +61,7 @@
     },
     {
       "property": "score",
-      "description": "Just beyond inner circle",
+      "description": "Just outside the inner circle",
       "input": {
         "x": 0.8,
         "y": -0.8
@@ -70,7 +70,7 @@
     },
     {
       "property": "score",
-      "description": "Just within middle circle",
+      "description": "Just within the middle circle",
       "input": {
         "x": -3.5,
         "y": 3.5
@@ -79,7 +79,7 @@
     },   
     {
       "property": "score",
-      "description": "Just beyond middle circle",
+      "description": "Just outside the middle circle",
       "input": {
         "x": -3.6,
         "y": -3.6
@@ -88,7 +88,7 @@
     },     
     {
       "property": "score",
-      "description": "Just within outer circle",
+      "description": "Just within the outer circle",
       "input": {
         "x": -7.0,
         "y": 7.0
@@ -97,7 +97,7 @@
     },     
     {
       "property": "score",
-      "description": "Just beyond outer circle",
+      "description": "Just outside the outer circle",
       "input": {
         "x": 7.1,
         "y": -7.1
@@ -106,7 +106,7 @@
     },    
     {
       "property": "score",
-      "description": "Asymmetric position between inner and middle circles",
+      "description": "Asymmetric position between the inner and middle circles",
       "input": {
         "x": 0.5,
         "y": -4

--- a/exercises/darts/canonical-data.json
+++ b/exercises/darts/canonical-data.json
@@ -43,7 +43,7 @@
     },
     {
       "property": "score",
-      "description": "Far inside inner region",
+      "description": "Near centre",
       "input": {
         "x": -0.1,
         "y": -0.1

--- a/exercises/darts/canonical-data.json
+++ b/exercises/darts/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "darts",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "comments": [
     "Return the correct amount earned by a dart's landing position."
   ],


### PR DESCRIPTION
The purpose of the "description" field is to derive identifiers for naming generated test methods, but some descriptions have tended to verbosity ending up with long identifiers (up to 150 characters).  Such long method names are harder for students to work with and also are awkward for some IDE GUIs.

Issue #1473 proposed adding a separate "identifier" field, but the consensus there was to first try improving "descriptions" to better suit "identifier" generation.    This PR attempts to slim down the generated identifiers without losing substantive information about the test.

For the longest descriptions here, I couldn't recognize the significance of...
```
dart whose coordinates sum to > 1 but whose radius to origin is <= 1
```
While considering a shorter alternative, it helped consistency to also rearranged the shorter descriptions to be more explicit about each test condition, and add a couple of tests each side of boundary conditions.