### PR TITLE
pangram: Slim down descriptions to generate better test identifiers 

### DIFF
--- a/exercises/pangram/canonical-data.json
+++ b/exercises/pangram/canonical-data.json
@@ -7,7 +7,7 @@
   "version": "1.5.0",
   "cases": [
     {
-      "description": "sentence empty",
+      "description": "empty sentence",
       "property": "isPangram",
       "input": {
         "sentence": ""
@@ -15,7 +15,7 @@
       "expected": false
     },
     {
-      "description": "recognizes a perfect lower case pangram",
+      "description": "perfect lower case",
       "property": "isPangram",
       "input": {
         "sentence": "abcdefghijklmnopqrstuvwxyz"
@@ -23,7 +23,7 @@
       "expected": true
     },
     {
-      "description": "pangram with only lower case",
+      "description": "only lower case",
       "property": "isPangram",
       "input": {
         "sentence": "the quick brown fox jumps over the lazy dog"
@@ -39,7 +39,7 @@
       "expected": false
     },
     {
-      "description": "another missing character, e.g. 'h'",
+      "description": "missing character 'h'",
       "property": "isPangram",
       "input": {
         "sentence": "five boxing wizards jump quickly at it"
@@ -47,7 +47,7 @@
       "expected": false
     },
     {
-      "description": "pangram with underscores",
+      "description": "with underscores",
       "property": "isPangram",
       "input": {
         "sentence": "the_quick_brown_fox_jumps_over_the_lazy_dog"
@@ -55,7 +55,7 @@
       "expected": true
     },
     {
-      "description": "pangram with numbers",
+      "description": "with numbers",
       "property": "isPangram",
       "input": {
         "sentence": "the 1 quick brown fox jumps over the 2 lazy dogs"
@@ -71,7 +71,7 @@
       "expected": false
     },
     {
-      "description": "pangram with mixed case and punctuation",
+      "description": "mixed case and punctuation",
       "property": "isPangram",
       "input": {
         "sentence": "\"Five quacking Zephyrs jolt my wax bed.\""
@@ -79,7 +79,7 @@
       "expected": true
     },
     {
-      "description": "upper and lower case versions of the same character should not be counted separately",
+      "description": "case insensitive",
       "property": "isPangram",
       "input": {
         "sentence": "the quick brown fox jumps over with lazy FX"

--- a/exercises/pangram/canonical-data.json
+++ b/exercises/pangram/canonical-data.json
@@ -31,7 +31,7 @@
       "expected": true
     },
     {
-      "description": "missing character 'x'",
+      "description": "missing an 'x'",
       "property": "isPangram",
       "input": {
         "sentence": "a quick movement of the enemy will jeopardize five gunboats"

--- a/exercises/pangram/canonical-data.json
+++ b/exercises/pangram/canonical-data.json
@@ -1,97 +1,90 @@
 {
   "exercise": "pangram",
   "comments": [
-    "A pangram is a sentence using every letter of the alphabet at least once."
+    "A pangram is a sentence using every letter of the alphabet at least once.",
+    "Output should be a boolean denoting if the string is a pangram or not."
   ],
-  "version": "1.4.1",
+  "version": "1.5.0",
   "cases": [
     {
-      "description": "Check if the given string is a pangram",
-      "comments": [
-        "Output should be a boolean denoting if the string is a pangram or not."
-      ],
-      "cases": [
-        {
-          "description": "sentence empty",
-          "property": "isPangram",
-          "input": {
-            "sentence": ""
-          },
-          "expected": false
-        },
-        {
-          "description": "recognizes a perfect lower case pangram",
-          "property": "isPangram",
-          "input": {
-            "sentence": "abcdefghijklmnopqrstuvwxyz"
-          },
-          "expected": true
-        },
-        {
-          "description": "pangram with only lower case",
-          "property": "isPangram",
-          "input": {
-            "sentence": "the quick brown fox jumps over the lazy dog"
-          },
-          "expected": true
-        },
-        {
-          "description": "missing character 'x'",
-          "property": "isPangram",
-          "input": {
-            "sentence": "a quick movement of the enemy will jeopardize five gunboats"
-          },
-          "expected": false
-        },
-        {
-          "description": "another missing character, e.g. 'h'",
-          "property": "isPangram",
-          "input": {
-            "sentence": "five boxing wizards jump quickly at it"
-          },
-          "expected": false
-        },
-        {
-          "description": "pangram with underscores",
-          "property": "isPangram",
-          "input": {
-            "sentence": "the_quick_brown_fox_jumps_over_the_lazy_dog"
-          },
-          "expected": true
-        },
-        {
-          "description": "pangram with numbers",
-          "property": "isPangram",
-          "input": {
-            "sentence": "the 1 quick brown fox jumps over the 2 lazy dogs"
-          },
-          "expected": true
-        },
-        {
-          "description": "missing letters replaced by numbers",
-          "property": "isPangram",
-          "input": {
-            "sentence": "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog"
-          },
-          "expected": false
-        },
-        {
-          "description": "pangram with mixed case and punctuation",
-          "property": "isPangram",
-          "input": {
-            "sentence": "\"Five quacking Zephyrs jolt my wax bed.\""
-          },
-          "expected": true
-        },
-        {
-          "description": "upper and lower case versions of the same character should not be counted separately",
-          "property": "isPangram",
-          "input": {
-            "sentence": "the quick brown fox jumps over with lazy FX"
-          },
-          "expected": false
-        }
-      ]
+      "description": "sentence empty",
+      "property": "isPangram",
+      "input": {
+        "sentence": ""
+      },
+      "expected": false
+    },
+    {
+      "description": "recognizes a perfect lower case pangram",
+      "property": "isPangram",
+      "input": {
+        "sentence": "abcdefghijklmnopqrstuvwxyz"
+      },
+      "expected": true
+    },
+    {
+      "description": "pangram with only lower case",
+      "property": "isPangram",
+      "input": {
+        "sentence": "the quick brown fox jumps over the lazy dog"
+      },
+      "expected": true
+    },
+    {
+      "description": "missing character 'x'",
+      "property": "isPangram",
+      "input": {
+        "sentence": "a quick movement of the enemy will jeopardize five gunboats"
+      },
+      "expected": false
+    },
+    {
+      "description": "another missing character, e.g. 'h'",
+      "property": "isPangram",
+      "input": {
+        "sentence": "five boxing wizards jump quickly at it"
+      },
+      "expected": false
+    },
+    {
+      "description": "pangram with underscores",
+      "property": "isPangram",
+      "input": {
+        "sentence": "the_quick_brown_fox_jumps_over_the_lazy_dog"
+      },
+      "expected": true
+    },
+    {
+      "description": "pangram with numbers",
+      "property": "isPangram",
+      "input": {
+        "sentence": "the 1 quick brown fox jumps over the 2 lazy dogs"
+      },
+      "expected": true
+    },
+    {
+      "description": "missing letters replaced by numbers",
+      "property": "isPangram",
+      "input": {
+        "sentence": "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog"
+      },
+      "expected": false
+    },
+    {
+      "description": "pangram with mixed case and punctuation",
+      "property": "isPangram",
+      "input": {
+        "sentence": "\"Five quacking Zephyrs jolt my wax bed.\""
+      },
+      "expected": true
+    },
+    {
+      "description": "upper and lower case versions of the same character should not be counted separately",
+      "property": "isPangram",
+      "input": {
+        "sentence": "the quick brown fox jumps over with lazy FX"
+      },
+      "expected": false
     }
   ]
 }

--- a/exercises/pangram/canonical-data.json
+++ b/exercises/pangram/canonical-data.json
@@ -31,7 +31,7 @@
       "expected": true
     },
     {
-      "description": "missing an 'x'",
+      "description": "missing character 'x'",
       "property": "isPangram",
       "input": {
         "sentence": "a quick movement of the enemy will jeopardize five gunboats"

--- a/exercises/pangram/canonical-data.json
+++ b/exercises/pangram/canonical-data.json
@@ -4,7 +4,7 @@
     "A pangram is a sentence using every letter of the alphabet at least once.",
     "Output should be a boolean denoting if the string is a pangram or not."
   ],
-  "version": "1.5.0",
+  "version": "2.0.0",
   "cases": [
     {
       "description": "empty sentence",

--- a/exercises/pangram/canonical-data.json
+++ b/exercises/pangram/canonical-data.json
@@ -31,7 +31,7 @@
       "expected": true
     },
     {
-      "description": "missing character 'x'",
+      "description": "missing the letter 'x'",
       "property": "isPangram",
       "input": {
         "sentence": "a quick movement of the enemy will jeopardize five gunboats"
@@ -39,7 +39,7 @@
       "expected": false
     },
     {
-      "description": "missing character 'h'",
+      "description": "missing the letter 'h'",
       "property": "isPangram",
       "input": {
         "sentence": "five boxing wizards jump quickly at it"


### PR DESCRIPTION
The purpose of the "description" field is to derive identifiers for naming generated test methods, but some descriptions have tended to verbosity ending up with long identifiers (up to 150 characters). Such long method names are harder for students to work with and also are awkward for some IDE GUIs.

Issue #1473 proposed adding a separate "identifier" field, but I was required to first try improving "descriptions" to better suit "identifier" generation. This PR aims to slim down the generated identifiers without losing substantive information about the test.

To start with,  "Check if the given string is a pangram" is a rather banal redundant description unworthy of nesting.