### PR TITLE
ETL: input elements define function parameter count

### DIFF
--- a/exercises/etl/canonical-data.json
+++ b/exercises/etl/canonical-data.json
@@ -18,7 +18,9 @@
           "description": "single letter",
           "property": "transform",
           "input": {
-            "1": ["A"]
+            "legacy": { 
+              "1": ["A"] 
+            }
           },
           "expected": {
             "a": 1
@@ -28,7 +30,9 @@
           "description": "single score with multiple letters",
           "property": "transform",
           "input": {
-            "1": ["A", "E", "I", "O", "U"]
+            "legacy": { 
+              "1": ["A", "E", "I", "O", "U"]
+            }
           },
           "expected": {
             "a": 1,
@@ -42,8 +46,10 @@
           "description": "multiple scores with multiple letters",
           "property": "transform",
           "input": {
-            "1": ["A", "E"],
-            "2": ["D", "G"]
+            "legacy": { 
+              "1": ["A", "E"],
+              "2": ["D", "G"]
+            }
           },
           "expected": {
             "a": 1,
@@ -56,13 +62,15 @@
           "description": "multiple scores with differing numbers of letters",
           "property": "transform",
           "input": {
-             "1": ["A", "E", "I", "O", "U", "L", "N", "R", "S", "T"],
-             "2": ["D", "G"],
-             "3": ["B", "C", "M", "P"],
-             "4": ["F", "H", "V", "W", "Y"],
-             "5": ["K"],
-             "8": ["J", "X"],
-            "10": ["Q", "Z"]
+            "legacy": { 
+               "1": ["A", "E", "I", "O", "U", "L", "N", "R", "S", "T"],
+               "2": ["D", "G"],
+               "3": ["B", "C", "M", "P"],
+               "4": ["F", "H", "V", "W", "Y"],
+               "5": ["K"],
+               "8": ["J", "X"],
+              "10": ["Q", "Z"]
+            }
           },
           "expected": {
             "a":  1, "b":  3, "c": 3, "d": 2, "e": 1,

--- a/exercises/etl/canonical-data.json
+++ b/exercises/etl/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "etl",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "cases": [
     {
       "comments": [


### PR DESCRIPTION
This supersedes stale PR #1485. (It was easier to redo off HEAD than resolve conflict there)

Background - In practical terms for test generation, the the number of "input" elements is the number of parameters of the function-under-test.  Considering the following as an example which specifies a function with three parameters as input...
[all-your-base Canonical-data](https://github.com/exercism/problem-specifications/blob/master/exercises/all-your-base/canonical-data.json#L19-L23)
```
   {
      "description": "single bit one to decimal",
      "property": "rebase",
      "input": {
          "inputBase": 2,
          "digits": [1],
          "outputBase": 10
       },
```

This is reflected by several language implementations:


[all-your-base CSharp](https://github.com/exercism/csharp/blob/master/exercises/all-your-base/AllYourBaseTest.cs#L25)
```
Assert.Equal(expected, AllYourBase.Rebase(inputBase, digits, outputBase));    
```
[all-your-base Ruby](https://github.com/exercism/ruby/blob/master/exercises/all-your-base/all_your_base_test.rb#L13)
```
converted = BaseConverter.convert(input_base, digits, output_base)
```
[all-your-base ObjectiveC](https://github.com/exercism/objective-c/blob/master/exercises/all-your-base/AllYourBaseTest.m#L16)
```
NSArray<NSNumber *> *result = [ AllYourBase outputDigitsForInputBase:2 inputDigits:@[@1] outputBase:10 ];
```
-----------------
By that pattern, the following...
[etl canonical-data](https://github.com/exercism/problem-specifications/blob/master/exercises/etl/canonical-data.json#L41-L54)  
``` 
        {
          "description": "multiple scores with multiple letters",
          "property": "transform",
          "input": {
            "1": ["A", "E"],
            "2": ["D", "G"]
          },

```
```
        {
          "description": "multiple scores with differing numbers of letters",
          "property": "transform",
          "input": {
             "1": ["A", "E", "I", "O", "U", "L", "N", "R", "S", "T"],
             "2": ["D", "G"],
             "3": ["B", "C", "M", "P"],
             "4": ["F", "H", "V", "W", "Y"],
             "5": ["K"],
             "8": ["J", "X"],
            "10": ["Q", "Z"]
          },
```
...would imply two separate functions, one with two parameters and another with seven parameters.
But actually "1","2","3","4","8","10" are part of the data, not part of the function definition.
The example language implementations correctly inferred the intent was to call a single-parameter function... 
        
[etl CSharp](https://github.com/exercism/csharp/blob/master/exercises/etl/EtlTest.cs#L100)
```
    Assert.Equal(expected, Etl.Transform(input));
```
[etl Ruby](https://github.com/exercism/ruby/blob/master/exercises/etl/etl_test.rb#L49-L86)       
```
    assert_equal expected, ETL.transform(old)
```    
[etl ObjectiveC](https://github.com/exercism/objective-c/blob/master/exercises/etl/EtlTest.m#L48-L63)
```
    NSDictionary<NSString *, NSNumber * > *results = [Etl transform: old];
```
It is better to be explicit that the **transform** function takes a single parameter of a legacy data map.
Thus the following **canonical-data** is proposed... 
```
        {
          "description": "multiple scores with multiple letters",
          "property": "transform",
          "input": {
              "legacy": { 
                  "1": ["A", "E"],
                  "2": ["D", "G"] 
              }
          },
```