### PR TITLE
[Darts] Add additional edge case

### DIFF
--- a/exercises/darts/canonical-data.json
+++ b/exercises/darts/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "darts",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "comments": [
     "Return the correct amount earned by a dart landing in a given point in the target problem"
   ],

--- a/exercises/darts/canonical-data.json
+++ b/exercises/darts/canonical-data.json
@@ -79,6 +79,15 @@
     },
     {
       "property": "score",
+      "description": "A dart lands right in the center of the dart board is scored in the inner circle",
+      "input": {
+        "x": 0,
+        "y": 0
+      },
+      "expected": 10
+    },
+    {
+      "property": "score",
       "description": "A dart whose coordinates sum to > 5 but whose radius to origin is <= 5 is scored in the middle circle",
       "input": {
         "x": 2,


### PR DESCRIPTION
Cover the edge case where a student might only think to check if `distance > 0` rather than `>= 0`, or similar.