### PR TITLE
WIP: Test that bin/check_optional works. (Do not merge)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ cache: yarn
 script:
   - bin/check_required_files_present
   - sh bin/check_versions
+  - bin/check_optional
   - yarn test

--- a/OPTIONAL-KEYS.txt
+++ b/OPTIONAL-KEYS.txt
@@ -1,0 +1,3 @@
+floating-point
+big-integer
+unicode

--- a/bin/check_optional
+++ b/bin/check_optional
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# This script checks that 'optional' fields in canonical-data.json are listed.
+
+optional_keys_file=OPTIONAL-KEYS.txt
+allowed_optional=$(jq -nR '[inputs]' $optional_keys_file)
+
+failed=0
+
+check_optional_for_file() {
+    json_file=$1
+    echo "Checking 'optional' fields in $json_file"
+
+    present_optional=$(jq '[ .cases[] | recurse(.cases[]?) | .optional | select(. != null) ]' $json_file)
+    invalid_optional=$(jq --null-input \
+                          --argjson allowed "$allowed_optional" \
+                          --argjson present "$present_optional" \
+                          --raw-output '$present - $allowed | join("\n")')
+
+    if [ ! -z "$invalid_optional" ]; then
+        echo "Invalid optional fields:"
+        echo "$invalid_optional" | perl -pe 's/^/ - /'
+        echo
+
+        failed=1
+    fi
+}
+
+for json_file in $(git diff --name-only master HEAD | grep '^exercises/.*/canonical-data\.json$'); do
+    check_optional_for_file $json_file
+done
+
+if [ $failed -gt 0 ]; then
+    echo "Allowed optional fields (see $optional_keys_file) are:"
+    cat $optional_keys_file | perl -pe 's/^/ - /'
+    exit 1
+fi
+
+exit 0

--- a/exercises/leap/canonical-data.json
+++ b/exercises/leap/canonical-data.json
@@ -13,6 +13,7 @@
     {
       "description": "year divisible by 2, not divisible by 4 in common year",
       "property": "leapYear",
+      "optional": "unicode",
       "input": {
         "year": 1970
       },
@@ -24,7 +25,8 @@
       "input": {
         "year": 1996
       },
-      "expected": true
+      "expected": true,
+      "optional": "medium-sized-int"
     },
     {
       "description": "year divisible by 100, not divisible by 400 in common year",
@@ -48,7 +50,8 @@
       "input": {
         "year": 1800
       },
-      "expected": false
+      "expected": false,
+      "optional": "dont-mention-the-war"
     }
   ]
 }

--- a/exercises/robot-simulator/canonical-data.json
+++ b/exercises/robot-simulator/canonical-data.json
@@ -28,7 +28,8 @@
               "y": 0
             },
             "direction": "north"
-          }
+          },
+          "optional": "floating-point"
         },
         {
           "description": "at negative position facing south",
@@ -46,7 +47,8 @@
               "y": -1
             },
             "direction": "south"
-          }
+          },
+          "optional": "unicode"
         }
       ]
     },
@@ -83,6 +85,7 @@
             "direction": "east",
             "instructions": "R"
           },
+          "optional": "wat",
           "expected": {
             "position": {
               "x": 0,
@@ -189,7 +192,8 @@
               "y": 0
             },
             "direction": "east"
-          }
+          },
+          "optional": "wat"
         },
         {
           "description": "changes east to north",
@@ -208,7 +212,8 @@
               "y": 0
             },
             "direction": "north"
-          }
+          },
+          "optional": "sugar"
         }
       ]
     },


### PR DESCRIPTION
This PR demonstrates how `bin/check_optional` checks 'optional' fields
in canonical-data.json. This works recursively such that 'optional'
fields in cases and in nested cases are addressed.