### PR TITLE
word-count: improve description

### DIFF
--- a/exercises/word-count/description.md
+++ b/exercises/word-count/description.md
@@ -6,12 +6,12 @@ For the purposes of this exercise you can expect that a _word_ will always be on
 2. A _simple word_ composed of one or more ASCII letters (ie "a" or "they") OR
 3. A _contraction_ of two _simple words_ joined by a single apostrophe (ie "it's" or "they're")
 
-When creating your count you can assume the following rules:
+When counting words you can assume the following rules:
 
 1. The count is _case insensitive_ (ie "You", "you", and "YOU" are 3 uses of the same word)
 2. The count is _unordered_; the tests will ignore how words and counts are ordered
-3. Other than the apostraphe in a _contraction_ all forms of _punctuation_ are ignored
-4. The words can be seperated by _any_ form of whitespace (ie "\t", "\n", " ")
+3. Other than the apostrophe in a _contraction_ all forms of _punctuation_ are ignored
+4. The words can be separated by _any_ form of whitespace (ie "\t", "\n", " ")
 
 For example, for the phrase `"That's the password: 'PASSWORD 123'!", cried the Special Agent.\nSo I fled.` the count would be:
 

--- a/exercises/word-count/description.md
+++ b/exercises/word-count/description.md
@@ -1,10 +1,29 @@
-Given a phrase, count the occurrences of each word in that phrase.
+Given a phrase, count the occurrences of each _word_ in that phrase.
 
-For example for the input `"olly olly in come free"`
+For the purposes of this exercise you can expect that a _word_ will always be one of:
+
+1. A _number_ composed of one or more ASCII digits (ie "0" or "1234") OR
+2. A _simple word_ composed of one or more ASCII letters (ie "a" or "they") OR
+3. A _contraction_ of two _simple words_ joined by a single apostrophe (ie "it's" or "they're")
+
+When creating your count you can assume the following rules:
+
+1. The count is _case insensitive_ (ie "You", "you", and "YOU" are 3 uses of the same word)
+2. The count is _unordered_; the tests will ignore how words and counts are ordered
+3. Other than the apostraphe in a _contraction_ all forms of _punctuation_ are ignored
+4. The words can be seperated by _any_ form of whitespace (ie "\t", "\n", " ")
+
+For example, for the phrase `"That's the password: 'PASSWORD 123'!", cried the Special Agent.\nSo I fled.` the count would be:
 
 ```text
-olly: 2
-in: 1
-come: 1
-free: 1
+that's: 1
+the: 2
+password: 2
+123: 1
+cried: 1
+special: 1
+agent: 1
+so: 1
+I: 1
+fled 1
 ```

--- a/exercises/word-count/description.md
+++ b/exercises/word-count/description.md
@@ -24,6 +24,6 @@ cried: 1
 special: 1
 agent: 1
 so: 1
-I: 1
-fled 1
+i: 1
+fled: 1
 ```


### PR DESCRIPTION
Improves the description of `word-count` to address issues described in #1539, #1461 and #869.

Removing ambiguity from the meaning of a "word" should reduce the amount of churn for students, and also clarify that tests are _not_ required for English anachronisms and vernacular _not_ covered by the explicit definition.

Please chime in if anything about my wording could be improved.