### PR TITLE
[WIP] Add schema key indicating multiline strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ script:
   - bin/check_required_files_present
   - sh bin/check_versions
   - bin/check_optional
+  - bin/check_multi-line-string-array_contents
   - yarn test

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ is easier to understand with an example:
 
 ```json
 { "exercise": "foobar"
-, "version" : "1.1.0"
+, "version" : "1.2.0"
 , "comments":
     [ " Comments are always optional and can be used almost anywhere.      "
     , "                                                                    "
@@ -78,6 +78,18 @@ is easier to understand with an example:
           "lastName"   : "Smithee"
         }  
       , "expected"   : "ASlmainthee"
+      }
+    , { "description": "Baz'ing a name returns its parts combined to a multi-line string"
+      , "property"   : "baz"
+      , "multi-line-string-array": [ "expected" ]
+      , "input"      : {
+          "firstName"  : "Alan",
+          "lastName"   : "Smithee"
+        }  
+      , "expected"   : [ "Their name is: "
+                       , "Alan"
+                       , "Smithee."
+                       ]
       }
     , { "comments":
           [ " Test cases can be arbitrarily grouped with a description "

--- a/bin/check_multi-line-string-array_contents
+++ b/bin/check_multi-line-string-array_contents
@@ -10,7 +10,7 @@ check_keys() {
 
     present_keys=$(jq '[ .cases[] | ."multi-line-string-array" | select(. != null)[] ] | unique' $json_file)
 
-    allowed_keys=$(jq '[ .cases[] | recurse(.cases[]?) | .input | keys[] ] | unique + ["expected"]' $json_file)
+    allowed_keys=$(jq '[ .cases[] | recurse(.cases[]?) | .input | select(. != null) | keys[] ] + ["expected"] | unique' $json_file)
 
     invalid_keys=$(jq --null-input \
                       --argjson allowed "$allowed_keys" \

--- a/bin/check_multi-line-string-array_contents
+++ b/bin/check_multi-line-string-array_contents
@@ -18,7 +18,7 @@ check_keys() {
                       --raw-output '$present - $allowed | join("\n")')
 
     if [ ! -z "$invalid_keys" ]; then
-        echo "Invalid multi-line-string-array entries:"
+        echo "The following multi-line-string-array input parameters did not occur in any tests:"
         echo "$invalid_keys" | perl -pe 's/^/ - /'
         echo
 

--- a/bin/check_multi-line-string-array_contents
+++ b/bin/check_multi-line-string-array_contents
@@ -8,7 +8,7 @@ check_keys() {
     json_file=$1
     echo "Checking 'multi-line-string-array' contents in $json_file"
 
-    present_keys=$(jq '[ .cases[] | recurse(.cases[]?) | ."multi-line-string-array" | select(. != null)[] ] | unique ' $json_file)
+    present_keys=$(jq '[ .cases[] | ."multi-line-string-array" | select(. != null)[] ] | unique' $json_file)
 
     allowed_keys=$(jq '[ .cases[] | recurse(.cases[]?) | .input | keys[] ] | unique + ["expected"]' $json_file)
 

--- a/bin/check_multi-line-string-array_contents
+++ b/bin/check_multi-line-string-array_contents
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# This script checks that multi-line-string-array only contains valid keys.
+
+failed=0
+
+check_keys() {
+    json_file=$1
+    echo "Checking 'multi-line-string-array' contents in $json_file"
+
+    present_keys=$(jq '[ .cases[] | recurse(.cases[]?) | ."multi-line-string-array" | select(. != null)[] ] | unique ' $json_file)
+
+    allowed_keys=$(jq '[ .cases[] | recurse(.cases[]?) | .input | keys[] ] | unique + ["expected"]' $json_file)
+
+    invalid_keys=$(jq --null-input \
+                      --argjson allowed "$allowed_keys" \
+                      --argjson present "$present_keys" \
+                      --raw-output '$present - $allowed | join("\n")')
+
+    if [ ! -z "$invalid_keys" ]; then
+        echo "Invalid multi-line-string-array entries:"
+        echo "$invalid_keys" | perl -pe 's/^/ - /'
+        echo
+
+        failed=1
+    fi
+}
+
+for json_file in $(git diff --name-only master HEAD | grep '^exercises/.*/canonical-data\.json$'); do
+    check_keys $json_file
+done
+
+if [ $failed -gt 0 ]; then
+    echo "Only input keys are valid entries of multi-line-string-array"
+    exit 1
+fi
+
+exit 0

--- a/canonical-schema.json
+++ b/canonical-schema.json
@@ -27,7 +27,7 @@
    "self": { "vendor" : "io.exercism"
            , "name"   : "canonical-data"
            , "format" : "jsonschema"
-           , "version": "1-1-0"
+           , "version": "1-2-0"
            },
 
    "$ref": "#/definitions/canonicalData",
@@ -85,12 +85,13 @@
           , "type"       : "object"
           , "required"   : ["description", "property", "input", "expected"]
           , "properties" :
-                { "description": { "$ref": "#/definitions/description" }
-                , "optional"   : { "$ref": "#/definitions/optional"    }
-                , "comments"   : { "$ref": "#/definitions/comments"    }
-                , "property"   : { "$ref": "#/definitions/property"    }
-                , "input"      : { "$ref": "#/definitions/input"       }
-                , "expected"   : { "$ref": "#/definitions/expected"    }
+                { "description"             : { "$ref": "#/definitions/description"             }
+                , "optional"                : { "$ref": "#/definitions/optional"                }
+                , "multi-line-string-array" : { "$ref": "#/definitions/multi-line-string-array" }
+                , "comments"                : { "$ref": "#/definitions/comments"                }
+                , "property"                : { "$ref": "#/definitions/property"                }
+                , "input"                   : { "$ref": "#/definitions/input"                   }
+                , "expected"                : { "$ref": "#/definitions/expected"                }
                 }
           , "additionalProperties": false
           },
@@ -117,6 +118,11 @@
           { "description": "An identifier for similar optional test cases (kebab-case)"
           , "type"       : "string"
           , "pattern"    : "^[a-z]+(-[a-z]+)*$"
+          },
+    
+      "multi-line-string-array":
+          { "description": "Arrays of strings in the specified properties represent a multiline string"
+          , "type"       : "array"
           },
 
       "property":

--- a/canonical-schema.json
+++ b/canonical-schema.json
@@ -123,6 +123,9 @@
       "multi-line-string-array":
           { "description": "Arrays of strings in the specified properties represent a multiline string"
           , "type"       : "array"
+          , "items"      : {
+              "type": "string"
+            }
           },
 
       "property":


### PR DESCRIPTION
This adds a key `multi-line-string-array: boolean` to the schema. If its value is `true`, arrays of strings in the test case should be joined together to a multiline string.

Previous discussion of this happened in #1496: 

Motivation:

> Original issue about multiline.
> 
> There is canonical data such as food-chain and twelve-days that correctly comment:
> 
>     JSON doesn't allow for multi-line strings, so all verses are presented
>     here as arrays of strings. It's up to the test generator to join the
>     lines together with line breaks.
> 
> Okay, that's great! But in this case I think it would be great if we'd add a meta property (and keep a list of those, as there are more like these (such as a property preferably being a constant or at least immutable) so that we can automate generation of these exercises.
> 
> _Originally posted by @SleeplessByte in https://github.com/exercism/problem-specifications/issues/1496#issue-428234215_

> I currently search `comments` in order to determine if something is a multiline string; because I then need to concatenate the values in the array using `\n` -- the same exercise also tests for single line strings. So there are not array + multiline string in one exercise, but I do need special handling.
> 
> If we don't want to add a property, that's fine :)
> 
> _Originally posted by @SleeplessByte in https://github.com/exercism/problem-specifications/issues/1496#issuecomment-492993261_

It affects the following exercises:

> 1. [`transpose`](https://github.com/exercism/problem-specifications/blob/5326cf2b32fd5df77cda3ade20d088d9a928b8b3/exercises/transpose/canonical-data.json#L4)
> 1. [`proverb`](https://github.com/exercism/problem-specifications/blob/5326cf2b32fd5df77cda3ade20d088d9a928b8b3/exercises/proverb/canonical-data.json#L4)
> 1. [`food-chain`](https://github.com/exercism/problem-specifications/blob/5326cf2b32fd5df77cda3ade20d088d9a928b8b3/exercises/food-chain/canonical-data.json#L4)
> 1. [`twelve-days`](https://github.com/exercism/problem-specifications/blob/84aa47979df7f526bdcb777cacc2c2cc9647dcaa/exercises/twelve-days/canonical-data.json#L4)
> 1. [`house`](https://github.com/exercism/problem-specifications/blob/5326cf2b32fd5df77cda3ade20d088d9a928b8b3/exercises/house/canonical-data.json#L4)
> 1. [`grep`](https://github.com/exercism/problem-specifications/blob/4f2efaa7a18fce99e91b01b3b11f13cac795735c/exercises/grep/canonical-data.json#L4)
> 
> And then there is [`beer-song`](https://github.com/exercism/problem-specifications/blob/df9c28dbeb2d0957fb7a32c4d588a697c47196e5/exercises/beer-song/canonical-data.json), which doesn't actually have the comment, but should...
> 
> _Originally posted by @SleeplessByte in https://github.com/exercism/problem-specifications/issues/1496#issuecomment-493167011_

> [`tournament`](https://github.com/exercism/problem-specifications/blob/ee01fe0c110b3c92fc3a52955a86427f18d3c219/exercises/tournament/canonical-data.json) should also be on that list.
> 
> _Originally posted by @cmccandless in https://github.com/exercism/problem-specifications/issues/1496#issuecomment-493478976_

---

Hiding whitespace changes when looking at the diff is helpful, because I had to adjust the indentation of various lines that are otherwise unchanged.