### PR TITLE
Circular buffer - add test case for initial clear wrapping

### DIFF
--- a/exercises/circular-buffer/canonical-data.json
+++ b/exercises/circular-buffer/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "circular-buffer",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "comments": [
     "In general, these circular buffers are expected to be stateful,",
     "and each language will operate on them differently.",
@@ -388,6 +388,51 @@
             "operation": "read",
             "should_succeed": true,
             "expected": 5
+          }
+        ]
+      },
+      "expected": {}
+    },
+    {
+      "description": "initial clear does not affect wrapping around",
+      "property": "run",
+      "input": {
+        "capacity": 2,
+        "operations": [
+          {
+            "operation": "clear"
+          },
+          {
+            "operation": "write",
+            "item": 1,
+            "should_succeed": true
+          },
+          {
+            "operation": "write",
+            "item": 2,
+            "should_succeed": true
+          },
+          {
+            "operation": "overwrite",
+            "item": 3
+          },
+          {
+            "operation": "overwrite",
+            "item": 4
+          },
+          {
+            "operation": "read",
+            "should_succeed": true,
+            "expected": 3
+          },
+          {
+            "operation": "read",
+            "should_succeed": true,
+            "expected": 4
+          },
+          {
+            "operation": "read",
+            "should_succeed": false
           }
         ]
       },


### PR DESCRIPTION
This change is intended to make the initial clear test case a little more strict - testing the overwrite and read fail capability after clearing as well.

The test case was also moved because it now uses overwrites and duplicating the test case didn't seem reasonable.

Original PR on the C++ track: exercism/cpp#296

This is an edge case that could happen when the clear alters the way the end of container is handled, as shown in the above PR. However, as also discussed, it is currently very specific and could be accidentally circumvented.