### PR TITLE
Anagram - add test cases for differently-cased words

### DIFF
--- a/exercises/anagram/canonical-data.json
+++ b/exercises/anagram/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "anagram",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "cases": [
     {
       "description": "no matches",
@@ -53,6 +53,15 @@
         ]
       },
       "expected": ["gallery", "regally", "largely"]
+    },
+    {
+      "description": "detects multiple anagrams with different case",
+      "property": "findAnagrams",
+      "input": {
+        "subject": "nose",
+        "candidates": ["Eons", "ONES"]
+      },
+      "expected": ["Eons", "ONES"]
     },
     {
       "description": "does not detect non-anagrams with identical checksum",
@@ -116,6 +125,15 @@
         "candidates": ["BANANA", "Banana", "banana"]
       },
       "expected": []
+    },
+    {
+      "description": "words other than themselves can be anagrams",
+      "property": "findAnagrams",
+      "input": {
+        "subject": "LISTEN",
+        "candidates": ["Listen", "Silent", "LISTEN"]
+      },
+      "expected": ["Silent"]
     }
   ]
 }


### PR DESCRIPTION
Add two test cases to catch some weird solutions where all words are rejected if the matched words have different case.

Original PR on the cpp track: exercism/cpp#297