### PR TITLE
Word count - add test case for substrings from the beginning of words

### DIFF
--- a/exercises/word-count/canonical-data.json
+++ b/exercises/word-count/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "word-count",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "comments": [
     "For each word in the input, count the number of times it appears in the",
     "entire sentence."
@@ -130,6 +130,23 @@
         "between": 1,
         "large": 2,
         "and": 1
+      }
+    },
+    {
+      "description": "substrings from the beginning",
+      "property": "countWords",
+      "input": {
+        "sentence": "Joe can't tell between app, apple and a."
+      },
+      "expected": {
+        "joe": 1,
+        "can't": 1,
+        "tell": 1,
+        "between": 1,
+        "app": 1,
+        "apple": 1,
+        "and": 1,
+        "a": 1
       }
     },
     {


### PR DESCRIPTION
This should catch cases when only up to either the first word's or second word's length of characters are compared, counting substrings from the beginning under the same word.

[Original thread in the track-c channel on Slack](https://exercism-team.slack.com/archives/CATCU7LSJ/p1563419221002800)