### PR TITLE
Fix story Resistor Color Duo

### DIFF
--- a/exercises/resistor-color-duo/description.md
+++ b/exercises/resistor-color-duo/description.md
@@ -2,19 +2,9 @@ If you want to build something using a Raspberry Pi, you'll probably use _resist
 
 * Each resistor has a resistance value.
 * Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
-To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values. Each band acts as a digit of a number. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
+To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values. Each band has a position and a numeric value. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
 
 In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take two colors as input, and output the correct number.
 
-The band colors are encoded as follows:
-
-- Black: 0
-- Brown: 1
-- Red: 2
-- Orange: 3
-- Yellow: 4
-- Green: 5
-- Blue: 6
-- Violet: 7
-- Grey: 8
-- White: 9
+The colors are mapped to the numbers from 0 to 9 in the sequence:
+Black - Brown - Red - Orange - Yellow - Green - Blue - Violet - Grey - White


### PR DESCRIPTION
See https://github.com/exercism/problem-specifications/issues/1471

The current stories for Resistor Color and Resistor Color Duo raised some questions, as collected in the issue mentioned above.
Recap of the wishlist:
- Avoid the word 'encoding' 
- Don't make the listing of the color and its value look like a dictionary.
- Make it more explicit that a color band has a numeric value _and_ a position.
 
This commit is addressing these, and will be adapted for the other exercises in the series. 
 
The original story has been written by the product team, to make it an exemplar for future descriptions, so let's keep that as is. 