### PR TITLE
Change test case order to be TDD orientated.

### DIFF
--- a/exercises/change/canonical-data.json
+++ b/exercises/change/canonical-data.json
@@ -8,6 +8,33 @@
   ],
   "cases": [
     {
+      "description": "no coins make 0 change",
+      "property": "findFewestCoins",
+      "input": {
+        "coins": [1, 5, 10, 21, 25],
+        "target": 0
+      },
+      "expected": []
+    },
+    {
+      "description": "cannot find negative change values",
+      "property": "findFewestCoins",
+      "input": {
+        "coins": [1, 2, 5],
+        "target": -5
+      },
+      "expected": {"error": "target can't be negative"}
+    },
+    {
+      "description": "error testing for change smaller than the smallest of coins",
+      "property": "findFewestCoins",
+      "input": {
+        "coins": [5, 10],
+        "target": 3
+      },
+      "expected": {"error": "can't make target with given coins"}
+    },
+    {
       "description": "single coin change",
       "property": "findFewestCoins",
       "input": {
@@ -24,24 +51,6 @@
         "target": 15
       },
       "expected": [5, 10]
-    },
-    {
-      "description": "change with Lilliputian Coins",
-      "property": "findFewestCoins",
-      "input": {
-        "coins": [1, 4, 15, 20, 50],
-        "target": 23
-      },
-      "expected": [4, 4, 15]
-    },
-    {
-      "description": "change with Lower Elbonia Coins",
-      "property": "findFewestCoins",
-      "input": {
-        "coins": [1, 5, 10, 21, 25],
-        "target": 63
-      },
-      "expected": [21, 21, 21]
     },
     {
       "description": "large target values",
@@ -73,24 +82,6 @@
       "expected": [4, 4, 4, 5, 5, 5]
     },
     {
-      "description": "no coins make 0 change",
-      "property": "findFewestCoins",
-      "input": {
-        "coins": [1, 5, 10, 21, 25],
-        "target": 0
-      },
-      "expected": []
-    },
-    {
-      "description": "error testing for change smaller than the smallest of coins",
-      "property": "findFewestCoins",
-      "input": {
-        "coins": [5, 10],
-        "target": 3
-      },
-      "expected": {"error": "can't make target with given coins"}
-    },
-    {
       "description": "error if no combination can add up to target",
       "property": "findFewestCoins",
       "input": {
@@ -100,13 +91,22 @@
       "expected": {"error": "can't make target with given coins"}
     },
     {
-      "description": "cannot find negative change values",
+      "description": "change with Lilliputian Coins",
       "property": "findFewestCoins",
       "input": {
-        "coins": [1, 2, 5],
-        "target": -5
+        "coins": [1, 4, 15, 20, 50],
+        "target": 23
       },
-      "expected": {"error": "target can't be negative"}
+      "expected": [4, 4, 15]
+    },
+    {
+      "description": "change with Lower Elbonia Coins",
+      "property": "findFewestCoins",
+      "input": {
+        "coins": [1, 5, 10, 21, 25],
+        "target": 63
+      },
+      "expected": [21, 21, 21]
     }
   ]
 }


### PR DESCRIPTION
I have rearranged the tests for this exercise to be more test driven development orientated as we would potentially want the easier test cases to come first so the user doing the exercise can write code to fail fast (eg. negative coins, 0 coins, etc) then build up to the difficult scenarios of using Lilliputian and Lower Elbonia Coins.

This is just a suggestion as I found the exercises as a great way of doing TDD - albeit the tests having already been wrote!