### PR TITLE
high-scores: Add latestIsPersonalBest method

### DIFF
--- a/exercises/high-scores/canonical-data.json
+++ b/exercises/high-scores/canonical-data.json
@@ -1,12 +1,13 @@
 {
   "exercise": "high-scores",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "comments": [
     "This is meant to be an easy exercise to practise: ",
     "* arrays as simple lists",
     "* instantiating a class",
+    "* simple boolean usage",
     "Consider adding a track specific recommendation in the track's hint.md.",
-    "Consider linking to a explanatory blogpost or beginner level tutorials for both topics.",
+    "Consider linking to a explanatory blogpost or beginner level tutorials for the listed topics.",
     "See Ruby Track hint.md for an example."
   ],
   "cases": [
@@ -76,6 +77,27 @@
             "scores": [40]
           },
           "expected": [40]
+        }
+      ]
+    },
+    {
+      "description": "Is latest score the personal best?",
+      "cases": [
+        {
+          "description": "Latest score is not the personal best",
+          "property": "latestIsPersonalBest",
+          "input": {
+            "scores": [100, 40, 10, 70]
+          },
+          "expected": false
+        },
+        {
+          "description": "Latest score is the personal best",
+          "property": "latestIsPersonalBest",
+          "input": {
+            "scores": [70, 40, 10, 100]
+          },
+          "expected": true
         }
       ]
     }


### PR DESCRIPTION
This PR adds a new property to HighScores that returns a boolean indicating whether the latest score is the personal best.

This was suggested by @F3PiX ~who will update this description with more details soon.~
Update:
A previous version of the exercise had a 'report' method, that contained a boolean check. The `report` was removed when it proved to be a burden to mentor without adding enough learning value. 
This explicit boolean method brings back the boolean. :yay:
  
I chose to name the property `latestIsPersonalBest` in part because we will name the method `latest_is_personal_best?` in Ruby, but I can change it to something like `isLatestPersonalBest` if people think it's better for the other tracks.

@SleeplessByte @ErikSchierboom 