### PR TITLE
raindrops: simplify description.md

### DIFF
--- a/exercises/raindrops/description.md
+++ b/exercises/raindrops/description.md
@@ -1,4 +1,4 @@
-In this variant of the children's game [Fizz Buzz](https://en.wikipedia.org/wiki/Fizz_buzz) -- which has often been used as a screening exercise in technical job interviews -- your task is to convert an number into a string that contains raindrop sounds corresponding to certain potential factors. A factor is a number that evenly divides into another number, leaving no remainder. The simplest way to test if a one number is a factor of another is to use the [modulo operation](https://en.wikipedia.org/wiki/Modulo_operation).
+Your task is to convert a number into a string that contains raindrop sounds corresponding to certain potential factors. A factor is a number that evenly divides into another number, leaving no remainder. The simplest way to test if a one number is a factor of another is to use the [modulo operation](https://en.wikipedia.org/wiki/Modulo_operation).
 
 The rules of `raindrops` are that if a given number:
 

--- a/exercises/raindrops/description.md
+++ b/exercises/raindrops/description.md
@@ -5,7 +5,7 @@ The rules of `raindrops` are quite simple; if a given number:
 - has 3 as a factor, add 'Pling' to the result.
 - has 5 as a factor, add 'Plang' to the result.
 - has 7 as a factor, add 'Plong' to the result.
-- _does not_ have any of 3, 5, or 7 as a factor, the result should be the digits of number.
+- _does not_ have any of 3, 5, or 7 as a factor, the result should be the digits of the number.
 
 ## Examples
 

--- a/exercises/raindrops/description.md
+++ b/exercises/raindrops/description.md
@@ -1,6 +1,6 @@
 In this variant of the children's game [Fizz Buzz](https://en.wikipedia.org/wiki/Fizz_buzz) -- which has often been used as a screening exercise in technical job interviews -- your task is to convert an number into a string that contains raindrop sounds corresponding to certain potential factors. A factor is a number that evenly divides into another number, leaving no remainder. The simplest way to test if a one number is a factor of another is to use the [modulo operation](https://en.wikipedia.org/wiki/Modulo_operation).
 
-The rules of `raindrops` are quite simple; if a given number:
+The rules of `raindrops` are that if a given number:
 
 - has 3 as a factor, add 'Pling' to the result.
 - has 5 as a factor, add 'Plang' to the result.

--- a/exercises/raindrops/description.md
+++ b/exercises/raindrops/description.md
@@ -1,16 +1,14 @@
-Convert a number to a string, the contents of which depend on the number's factors.
+In this variant of the children's game [Fizz Buzz](https://en.wikipedia.org/wiki/Fizz_buzz) -- which has often been used as a screening exercise in technical job interviews -- your task is to convert an number into a string that contains raindrop sounds corresponding to certain potential factors. A factor is a number that evenly divides into another number, leaving no remainder. The simplest way to test if a one number is a factor of another is to use the [modulo operation](https://en.wikipedia.org/wiki/Modulo_operation).
 
-- If the number has 3 as a factor, output 'Pling'.
-- If the number has 5 as a factor, output 'Plang'.
-- If the number has 7 as a factor, output 'Plong'.
-- If the number does not have 3, 5, or 7 as a factor,
-  just pass the number's digits straight through.
+The rules of `raindrops` are quite simple; if a given number:
+
+- has 3 as a factor, add 'Pling' to the result.
+- has 5 as a factor, add 'Plang' to the result.
+- has 7 as a factor, add 'Plong' to the result.
+- _does not_ have any of 3, 5, or 7 as a factor, the result should be the digits of number.
 
 ## Examples
 
-- 28's factors are 1, 2, 4, **7**, 14, 28.
-  - In raindrop-speak, this would be a simple "Plong".
-- 30's factors are 1, 2, **3**, **5**, 6, 10, 15, 30.
-  - In raindrop-speak, this would be a "PlingPlang".
-- 34 has four factors: 1, 2, 17, and 34.
-  - In raindrop-speak, this would be "34".
+- 28 has 7 as a factor, but not 3 or 5, so the result would be "Plong".
+- 30 has both 3 and 5 as factors, but not 7, so the result would be "PlingPlang".
+- 34 is not factored by 3, 5, or 7, so the result would be "34".

--- a/exercises/raindrops/metadata.yml
+++ b/exercises/raindrops/metadata.yml
@@ -1,4 +1,4 @@
 ---
-blurb: "Convert a number to a string, the contents of which depend on the number's factors."
-source: "A variation on a famous interview question intended to weed out potential candidates."
-source_url: "http://jumpstartlab.com"
+blurb: "Convert a number to a string, the content of which depends on the number's factors."
+source: "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division."
+source_url: "https://en.wikipedia.org/wiki/Fizz_buzz"


### PR DESCRIPTION
Currently the description.md implies a solution where the student generates _all_ factors of a number and then tests for membership within that set; that's a frustrating and unnecessary wild good chase for a beginner, and I've had multiple students trip up on it. This updates to be a little less ambiguous and to add some informational links.