### PR TITLE
Resistor color trio: test invalid color

### DIFF
--- a/OPTIONAL-KEYS.txt
+++ b/OPTIONAL-KEYS.txt
@@ -1,3 +1,4 @@
 floating-point
 big-integer
 unicode
+error

--- a/exercises/resistor-color-trio/canonical-data.json
+++ b/exercises/resistor-color-trio/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "resistor-color-trio",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "cases": [
     {
       "description": "Orange and orange and black",
@@ -56,6 +56,15 @@
         "value": 470,
         "unit": "kiloohms"
       }
+    },
+    {
+      "description": "Invalid color",
+      "property": "label",
+      "optional": "error",
+      "input": {
+        "colors": ["yellow", "purple", "black"]
+      },
+      "expected": { "error": "invalid color" }
     }
   ]
 }


### PR DESCRIPTION
This PR adds an additional test case for an invalid color. As not every track might want to implement this, I've added an optional key named `"error"`.

This PR is intended to be used in the track anatomy project, and as such, targets the `trackanatomy` branch.

Edit (Maud):
- [ ] Update readme with explanation.