### PR TITLE
resistor-color-duo: add test case to ignore additional colors

### DIFF
--- a/exercises/resistor-color-duo/canonical-data.json
+++ b/exercises/resistor-color-duo/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "resistor-color-duo",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "cases": [
     {
       "description": "Brown and black",
@@ -33,6 +33,14 @@
         "colors": ["orange", "orange"]
       },
       "expected": 33
+    },
+    {
+      "description": "Ignore additional colors",
+      "property": "value",
+      "input": {
+        "colors": ["green", "brown", "orange"]
+      },
+      "expected": 51
     }
   ]
 }

--- a/exercises/resistor-color-duo/description.md
+++ b/exercises/resistor-color-duo/description.md
@@ -4,7 +4,8 @@ If you want to build something using a Raspberry Pi, you'll probably use _resist
 * Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
 To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values. Each band has a position and a numeric value. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
 
-In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take color names as input, and output a two digit number. Even when the input is more than two colors!
+In this exercise you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take color names as input and output a two digit number, even if the input is more than two colors!
+
 
 The band colors are encoded as follows:
 

--- a/exercises/resistor-color-duo/description.md
+++ b/exercises/resistor-color-duo/description.md
@@ -2,9 +2,9 @@ If you want to build something using a Raspberry Pi, you'll probably use _resist
 
 * Each resistor has a resistance value.
 * Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
-To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values. Each band acts as a digit of a number. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
+To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values. Each band has a position and a numeric value. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
 
-In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take two colors as input, and output the correct number.
+In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take color names as input, and output a two digit number. Even when the input is more than two colors!
 
 The band colors are encoded as follows:
 
@@ -18,3 +18,8 @@ The band colors are encoded as follows:
 - Violet: 7
 - Grey: 8
 - White: 9
+
+From the example above:
+brown-green should return 15
+brown-green-violet should return 15 too, ignoring the third color.
+


### PR DESCRIPTION
This PR aims to fix a basic implementation bug whereby any additional colors are also used in the calculation.