### PR TITLE
Matrix: Add test case

### DIFF
--- a/exercises/matrix/canonical-data.json
+++ b/exercises/matrix/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "matrix",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "cases": [
     {
       "description": "extract row from one number matrix",
@@ -64,6 +64,15 @@
         "index": 3
       },
       "expected": [3, 6, 9, 6]
+    },
+    {
+      "description": "can extract column from non-square matrix with more columns than rows",
+      "property": "column",
+      "input": {
+        "string": "1 2 3\n4 5 6",
+        "index": 3
+      },
+      "expected": [3, 6]
     },
     {
       "description": "extract column where numbers have different widths",

--- a/exercises/matrix/canonical-data.json
+++ b/exercises/matrix/canonical-data.json
@@ -30,13 +30,13 @@
       "expected": [10, 20]
     },
     {
-      "description": "can extract row from non-square matrix",
+      "description": "can extract row from non-square matrix with no corresponding column",
       "property": "row",
       "input": {
         "string": "1 2 3\n4 5 6\n7 8 9\n8 7 6",
-        "index": 3
+        "index": 4
       },
-      "expected": [7, 8, 9]
+      "expected": [8, 7, 6]
     },
     {
       "description": "extract column from one number matrix",
@@ -57,22 +57,13 @@
       "expected": [3, 6, 9]
     },
     {
-      "description": "can extract column from non-square matrix",
+      "description": "can extract column from non-square matrix with no corresponding row",
       "property": "column",
       "input": {
-        "string": "1 2 3\n4 5 6\n7 8 9\n8 7 6",
-        "index": 3
+        "string": "1 2 3 4\n 5 6 7 8\n 9 8 7 6",
+        "index": 4
       },
-      "expected": [3, 6, 9, 6]
-    },
-    {
-      "description": "can extract column from non-square matrix with more columns than rows",
-      "property": "column",
-      "input": {
-        "string": "1 2 3\n4 5 6",
-        "index": 3
-      },
-      "expected": [3, 6]
+      "expected": [4, 8, 6]
     },
     {
       "description": "extract column where numbers have different widths",


### PR DESCRIPTION
In javascript the following wrong implementation passes all previous test cases but not the new one
```
export class Matrix {
  constructor(string) {
    this._rows = string
      .split('\n')
      .map(row => row.split(' ').map(Number))
    this._columns = this._rows
      .map((_, i) => this._rows.map(row => row[i]))
  }

  get rows() {
    return this._rows
  }

  get columns() {
    return this._columns
  }
}
```