### PR TITLE
two-bucket: test inability to reach the goal

### DIFF
--- a/exercises/two-bucket/canonical-data.json
+++ b/exercises/two-bucket/canonical-data.json
@@ -96,6 +96,50 @@
         "goalBucket": "two",
         "otherBucket": 2
       }
+    },
+    {
+      "uuid": "449be72d-b10a-4f4b-a959-ca741e333b72",
+      "description": "Not possible to reach the goal",
+      "property": "measure",
+      "input": {
+        "bucketOne": 6,
+        "bucketTwo": 15,
+        "goal": 5,
+        "startBucket": "one"
+      },
+      "expected": {
+        "error": "impossible"
+      }
+    },
+    {
+      "uuid": "aac38b7a-77f4-4d62-9b91-8846d533b054",
+      "description": "With the same buckets but a different goal, then it is possible",
+      "property": "measure",
+      "input": {
+        "bucketOne": 6,
+        "bucketTwo": 15,
+        "goal": 9,
+        "startBucket": "one"
+      },
+      "expected": {
+        "moves": 10,
+        "goalBucket": "two",
+        "otherBucket": 0
+      }
+    },
+    {
+      "uuid": "74633132-0ccf-49de-8450-af4ab2e3b299",
+      "description": "Goal larger than both buckets is impossible",
+      "property": "measure",
+      "input": {
+        "bucketOne": 5,
+        "bucketTwo": 7,
+        "goal": 8,
+        "startBucket": "one"
+      },
+      "expected": {
+        "error": "impossible"
+      }
     }
   ]
 }


### PR DESCRIPTION
~~**This is a non-bugfix change to an exercise; accordingly, it is currently under embargo.** Please keep this in mind when taking actions on this pull request.~~ Embargo has been lifted.


1. A test where the goal is too large.

The student solution would need to either:

* (If searching the state space) Notice that there are no further states
  to be visited, and yet the solution has not been reached.
* Notice that the goal is larger than the larger bucket, therefore can 
  be rejected immediately.

2. A test where the goal is not too large yet still can't be reached

The student solution would need to either:

* (If searching the state space) Notice that there are no further states
  to be visited, and yet the solution has not been reached.
* Notice that the goal is not divisible by the GCD of the bucket sizes,
  therefore can be rejected immediately.

There are ten implementing tracks:
bash csharp fsharp go java javascript python ruby rust typescript

Of these tracks, only two of them (Bash, Go) currently test the
condition where it is not possible to reach the goal.

Having this test serves as a reminder that it remains wise to handle the
situation where a search has not found its goal.

It doesn't seem like this was discussed in the original submission:
https://github.com/exercism/DEPRECATED.javascript/pull/68
So it seems like it would be good to have a discussion of it on record.