### PR TITLE
leap: Add years that refute some unusual factors

### DIFF
--- a/exercises/leap/canonical-data.json
+++ b/exercises/leap/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "leap",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "cases": [
     {
       "description": "year not divisible by 4 in common year",
@@ -27,6 +27,14 @@
       "expected": true
     },
     {
+      "description": "year divisible by 4 and 5 is still a leap year",
+      "property": "leapYear",
+      "input": {
+        "year": 1960
+      },
+      "expected": true
+    },
+    {
       "description": "year divisible by 100, not divisible by 400 in common year",
       "property": "leapYear",
       "input": {
@@ -35,10 +43,26 @@
       "expected": false
     },
     {
+      "description": "year divisible by 100 but not by 3 is still not a leap year",
+      "property": "leapYear",
+      "input": {
+        "year": 1900
+      },
+      "expected": false
+    },
+    {
       "description": "year divisible by 400 in leap year",
       "property": "leapYear",
       "input": {
         "year": 2000
+      },
+      "expected": true
+    },
+    {
+      "description": "year divisible by 400 but not by 125 is still a leap year",
+      "property": "leapYear",
+      "input": {
+        "year": 2400
       },
       "expected": true
     },


### PR DESCRIPTION
leap 1.6.0

Some implementations unexpectedly pass the entire test suite:

* Replacing 4 with 499, 998, or 1996
* Replacing 100 with 5, 10, or 20
* Replacing 100 with 3, 6, 12, 15, 30, 60, 75, 150, 300 
* Replacing 400 with 125, 250, 500, 1000, or 2000

Adding these test cases would correctly point out that these solutions
are incorrect.

I think it's a bit unusual since no student is going to write such an
implementation except a student deliberately trying to slip past the 
tests.
Or maybe a student trying to micro-optimise? Maybe they are trying to
test whether division by small numbers is faster than division by large
numbers?

But discussion participants have deemed that the cost of three tests is
worth the benefit of reducing mental overhead of mentors, since such
solutions have in fact been seen in the wild.