### PR TITLE
word-search: ensure every letter of the word is checked

### DIFF
--- a/exercises/word-search/canonical-data.json
+++ b/exercises/word-search/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "word-search",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "comments": [
     "Grid rows and columns are 1-indexed."
   ],
@@ -983,6 +983,21 @@
           }
         },
         "haskell": null
+      }
+    },
+    {
+      "description": "checks every letter of the word, rejecting a near-match",
+      "property": "search",
+      "input": {
+        "grid": [
+          "ecmascrips"
+        ],
+        "wordsToSearchFor": [
+          "ecmascript"
+        ]
+      },
+      "expected": {
+        "ecmascript": null
       }
     }
   ]


### PR DESCRIPTION
I thought of adding this case, but I think it's highly unlikely that any
submitted solution will make this mistake.

The most likely form of this mistake is an off-by-one mistake, where
only the first N-1 letters of the word are checked. But we already have
coverage for this in the existing tests, even if it isn't explicit.
The word "lua", if suject to this mistake, has at least one location
where it might become "lur" instead.

Since this test case has not in fact added any new coverage, I have
decided to withdraw it. This pull request will be closed immediately upon submitting.