### PR TITLE
paasio: Title as "PaaS I/O" instead of default "Paasio"

### DIFF
--- a/exercises/paasio/metadata.yml
+++ b/exercises/paasio/metadata.yml
@@ -1,4 +1,5 @@
 ---
+title: "PaaS I/O"
 blurb: "Report network IO statistics"
 source: "Brian Matsuo"
 source_url: "https://github.com/bmatsuo"


### PR DESCRIPTION
See how it is currently listed as Paasio:
http://exercism.io/tracks/go/exercises/paasio
http://exercism.io/tracks/rust/exercises/paasio

Given that the game is about input/output statistics for a
platform-as-a-service, "PaaS I/O" seems a better way than the default.