### PR TITLE
triangle: Clearly show in JSON when side lengths are invalid

### DIFF
--- a/exercises/triangle/canonical-data.json
+++ b/exercises/triangle/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "triangle",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "comments": [
     " Pursuant to discussion in #202, we have decided NOT to test triangles ",
     " where all side lengths are positive but a + b = c. e.g:               ",
@@ -12,10 +12,11 @@
     " The tests assert properties of the triangle are true or false.        ",
     " See: https://github.com/exercism/problem-specifications/issues/379 for disscussion  ",
     " of this approach                                                      ",
-    " How you handle invalid triangles is up to you. These tests suggest a  ",
-    " triangle is returned, but all of its properties are false. But you    ",
-    " could also have the creation of an invalid triangle return an error   ",
-    " or exception. Choose what is idiomatic for your language.             "
+    " How you handle invalid triangles is up to you. These tests explicitly ",
+    " mark triangles with invalid side lengths with an error object. Your   ",
+    " track should decide whether that means such inputs result in an error ",
+    " or not (instead considering such inputs valid, with an expected result",
+    " of `false`). Choose what is idiomatic for your language.              "
   ],
   "cases": [
     {
@@ -51,7 +52,7 @@
           "input": {
             "sides": [0, 0, 0]
           },
-          "expected": false
+          "expected": {"error": "side lengths must be > 0"}
         },
         {
           "comments": [
@@ -116,7 +117,7 @@
           "input": {
             "sides": [1, 1, 3]
           },
-          "expected": false
+          "expected": {"error": "triangle inequality violated"}
         },
         {
           "description": "second triangle inequality violation",
@@ -124,7 +125,7 @@
           "input": {
             "sides": [1, 3, 1]
           },
-          "expected": false
+          "expected": {"error": "triangle inequality violated"}
         },
         {
           "description": "third triangle inequality violation",
@@ -132,7 +133,7 @@
           "input": {
             "sides": [3, 1, 1]
           },
-          "expected": false
+          "expected": {"error": "triangle inequality violated"}
         },
         {
           "comments": [
@@ -181,7 +182,7 @@
           "input": {
             "sides": [7, 3, 2]
           },
-          "expected": false
+          "expected": {"error": "triangle inequality violated"}
         },
         {
           "comments": [


### PR DESCRIPTION
triangle 1.3.0

The JSON file does mention that handling invalid triangles is up to the
individual track. This is affirmed. This change's objective is **to make
it easy for tracks to make that decision for themselves**.

Before this commit, the JSON file does nothing special to distinguish
the invalid triangles, so a track wishing to declare those triangles to
be in error must re-implement the rules itself so that it can see
whether a case in the file falls in that category.

After this commit, the JSON file does distinguish the invalid triangles.
A track wishing to declare the triangles to be in error is able to do so
easily, without being forced to check the inputs of each case.
A track wishing to emulate the old behaviour (simply have all relevant
queries answer `false` for inputs which describe non-triangles) need
simply translate all `error` objects to `false` instead.

Note carefully that both possibilities have merit:

Should be an error: If the job of the tested functions is: "Make a
triangle out of these side lengths. Now tell me, is that triangle this
particular type?", then it is fair that a possible answer to that
request is "But this is not a triangle, therefore the question of
whether it is a particular type is completely meaningless".

Should not be an error: If the job of the tested functions is: "Tell me
whether these side lengths describe a triangle of this type?", then it
is perfectly logical and within specification for these functions to
accept non-triangles and correctly answer "no".

Therefore, the author of this commit thinks it is wisest to continue to
allow each track to make its own decision, while at the same time
explicitly pointing out *where* the decision needs to be made in the
first place.

---

The author of this commit does, however, acknowledge that structuring
the JSON in this way will cause tracks to tend to gravitate toward
considering these inputs as an error, since doing otherwise requires an
exercise-specific post-processing rule applied to this file.

Since the author's goal is to make it easy to tell which cases in this
file are subject to this decision, the author would appreciate any other
way of making such cases apparent using a tool that is less blunt.

---

Appendix:

Of the 40 implementing tracks, here are the 24 tracks that already
consider invalid triangles to be an error:

https://github.com/exercism/clojure/blob/master/exercises/triangle/test/triangle_test.clj
https://github.com/exercism/coffeescript/blob/master/exercises/triangle/triangle_test.spec.coffee
https://github.com/exercism/common-lisp/blob/master/exercises/triangle/triangle-test.lisp
https://github.com/exercism/cpp/blob/master/exercises/triangle/triangle_test.cpp
https://github.com/exercism/d/blob/master/exercises/triangle/source/triangle.d
https://github.com/exercism/elixir/blob/master/exercises/triangle/test/triangle_test.exs
https://github.com/exercism/elm/blob/master/exercises/triangle/tests/Tests.elm
https://github.com/exercism/erlang/blob/master/exercises/triangle/test/triangle_tests.erl
https://github.com/exercism/go/blob/master/exercises/triangle/triangle_test.go
https://github.com/exercism/haskell/blob/master/exercises/triangle/test/Tests.hs
https://github.com/exercism/java/blob/master/exercises/triangle/src/test/java/TriangleTest.java
https://github.com/exercism/javascript/blob/master/exercises/triangle/triangle.spec.js
https://github.com/exercism/kotlin/blob/master/exercises/triangle/src/test/kotlin/TriangleTest.kt
https://github.com/exercism/lua/blob/master/exercises/triangle/triangle_spec.lua
https://github.com/exercism/mips/blob/master/exercises/triangle/runner.mips
https://github.com/exercism/objective-c/blob/master/exercises/triangle/TriangleTest.m
https://github.com/exercism/perl5/blob/master/exercises/triangle/triangle.t
https://github.com/exercism/php/blob/master/exercises/triangle/triangle_test.php
https://github.com/exercism/prolog/blob/master/exercises/triangle/triangle_tests.plt
https://github.com/exercism/purescript/blob/master/exercises/triangle/test/Main.purs
https://github.com/exercism/r/blob/master/exercises/triangle/test_triangle.R
https://github.com/exercism/rust/blob/master/exercises/triangle/tests/triangle.rs
https://github.com/exercism/swift/blob/master/exercises/triangle/Tests/TriangleTests/TriangleTests.swift
https://github.com/exercism/typescript/blob/master/exercises/triangle/triangle.test.ts