### PR TITLE
leap: Grammar tweak for canonical data

### DIFF
--- a/exercises/leap/canonical-data.json
+++ b/exercises/leap/canonical-data.json
@@ -1,9 +1,9 @@
 {
   "exercise": "leap",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "cases": [
     {
-      "description": "year not divisible by 4 in common year",
+      "description": "year not divisible by 4 is common year",
       "property": "leapYear",
       "input": {
         "year": 2015
@@ -11,7 +11,7 @@
       "expected": false
     },
     {
-      "description": "year divisible by 2, not divisible by 4 in common year",
+      "description": "year divisible by 2, not divisible by 4 is common year",
       "property": "leapYear",
       "input": {
         "year": 1970
@@ -19,7 +19,7 @@
       "expected": false
     },
     {
-      "description": "year divisible by 4, not divisible by 100 in leap year",
+      "description": "year divisible by 4, not divisible by 100 is leap year",
       "property": "leapYear",
       "input": {
         "year": 1996
@@ -35,7 +35,7 @@
       "expected": true
     },
     {
-      "description": "year divisible by 100, not divisible by 400 in common year",
+      "description": "year divisible by 100, not divisible by 400 is common year",
       "property": "leapYear",
       "input": {
         "year": 2100
@@ -51,7 +51,7 @@
       "expected": false
     },
     {
-      "description": "year divisible by 400 in leap year",
+      "description": "year divisible by 400 is leap year",
       "property": "leapYear",
       "input": {
         "year": 2000
@@ -67,7 +67,7 @@
       "expected": true
     },
     {
-      "description": "year divisible by 200, not divisible by 400 in common year",
+      "description": "year divisible by 200, not divisible by 400 is common year",
       "property": "leapYear",
       "input": {
         "year": 1800


### PR DESCRIPTION
The grammar in the leap canonical data descriptions was flagged up in https://github.com/exercism/perl6/pull/347