### PR TITLE
topics: suggestion to add errors

### DIFF
--- a/TOPICS.txt
+++ b/TOPICS.txt
@@ -6,6 +6,7 @@ conditionals
 events
 equality
 exception_handling
+error_handling
 generics
 inheritance
 interfaces
@@ -26,7 +27,6 @@ classes
 dates
 discriminated_unions
 enumerations
-errors
 floating_point_numbers
 graphs
 integers

--- a/TOPICS.txt
+++ b/TOPICS.txt
@@ -5,8 +5,7 @@ callbacks
 conditionals
 events
 equality
-exception_handling
-error_handling
+errors_and_exceptions
 generics
 inheritance
 interfaces

--- a/TOPICS.txt
+++ b/TOPICS.txt
@@ -5,7 +5,8 @@ callbacks
 conditionals
 events
 equality
-errors_and_exceptions
+error_handling
+exception_handling
 generics
 inheritance
 interfaces

--- a/TOPICS.txt
+++ b/TOPICS.txt
@@ -26,6 +26,7 @@ classes
 dates
 discriminated_unions
 enumerations
+errors
 floating_point_numbers
 graphs
 integers


### PR DESCRIPTION
This is a bit of a Go thing.

First of all there are no `exceptions` in Go. So we cannot use the tag `exception_handling` as that would be wrong. In Go we have `errors` (and `panics`).
Secondly, `errors` are values in Go. So they'd be a data type.

We could also add `error_handling` in `Basic Concepts` instead.