### PR TITLE
robot-name description: singular "robot"

### DIFF
--- a/exercises/robot-name/description.md
+++ b/exercises/robot-name/description.md
@@ -1,14 +1,14 @@
 Manage robot factory settings.
 
-When robots come off the factory floor, they have no name.
+When a robot comes off the factory floor, it has no name.
 
-The first time you boot them up, a random name is generated in the format
+The first time you turn on a robot, a random name is generated in the format
 of two uppercase letters followed by three digits, such as RX837 or BC811.
 
 Every once in a while we need to reset a robot to its factory settings,
-which means that their name gets wiped. The next time you ask, it will
+which means that its name gets wiped. The next time you ask, that robot will
 respond with a new random name.
 
 The names must be random: they should not follow a predictable sequence.
-Random names means a risk of collisions. Your solution must ensure that
+Using random names means a risk of collisions. Your solution must ensure that
 every existing robot has a unique name.


### PR DESCRIPTION
While working on exercism/perl5#328, I noticed that the description of robot-name mixed singular and plural.  This PR changes robot-name/description.md to use singular forms consistently throughout.  I also changed "boot up" to "turn on" in hopes of making it easier for non-native English speakers to understand the text.

This is my first contribution to this project - thank you for considering this PR!