### PR TITLE
Fix rational numbers config

### DIFF
--- a/exercises/rational-numbers/canonical-data.json
+++ b/exercises/rational-numbers/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "rational-numbers",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "comments": [
     " The canonical data assumes mathematically correct real   ",
     " numbers. The testsuites should consider rounding errors  ",

--- a/exercises/rational-numbers/canonical-data.json
+++ b/exercises/rational-numbers/canonical-data.json
@@ -247,7 +247,7 @@
       "cases": [
         {
           "description": "Raise a positive rational number to a positive integer power",
-          "property": "exprational",
+          "property": "expRational",
           "input": {
             "r": [1, 2],
             "n": 3
@@ -256,7 +256,7 @@
         },
         {
           "description": "Raise a negative rational number to a positive integer power",
-          "property": "exprational",
+          "property": "expRational",
           "input": {
             "r": [-1, 2],
             "n": 3
@@ -265,7 +265,7 @@
         },
         {
           "description": "Raise zero to an integer power",
-          "property": "exprational",
+          "property": "expRational",
           "input": {
             "r": [0, 1],
             "n": 5
@@ -274,7 +274,7 @@
         },
         {
           "description": "Raise one to an integer power",
-          "property": "exprational",
+          "property": "expRational",
           "input": {
             "r": [1, 1],
             "n": 4
@@ -283,7 +283,7 @@
         },
         {
           "description": "Raise a positive rational number to the power of zero",
-          "property": "exprational",
+          "property": "expRational",
           "input": {
             "r": [1, 2],
             "n": 0
@@ -292,7 +292,7 @@
         },
         {
           "description": "Raise a negative rational number to the power of zero",
-          "property": "exprational",
+          "property": "expRational",
           "input": {
             "r": [-1, 2],
             "n": 0
@@ -306,7 +306,7 @@
       "cases": [
         {
           "description": "Raise a real number to a positive rational number",
-          "property": "expreal",
+          "property": "expReal",
           "input": {
             "x": 8,
             "r": [4, 3]
@@ -315,7 +315,7 @@
         },
         {
           "description": "Raise a real number to a negative rational number",
-          "property": "expreal",
+          "property": "expReal",
           "input": {
             "x": 9,
             "r": [-1, 2]
@@ -324,7 +324,7 @@
         },
         {
           "description": "Raise a real number to a zero rational number",
-          "property": "expreal",
+          "property": "expReal",
           "input": {
             "x": 2,
             "r": [0, 1]

--- a/exercises/rational-numbers/canonical-data.json
+++ b/exercises/rational-numbers/canonical-data.json
@@ -59,7 +59,7 @@
           "cases": [
             {
               "description": "Subtract two positive rational numbers",
-              "property": "sub",
+              "property": "subtract",
               "input": {
                 "r1": [1, 2],
                 "r2": [2, 3]
@@ -68,7 +68,7 @@
             },
             {
               "description": "Subtract a positive rational number and a negative rational number",
-              "property": "sub",
+              "property": "subtract",
               "input": {
                 "r1": [1, 2],
                 "r2": [-2, 3]
@@ -77,7 +77,7 @@
             },
             {
               "description": "Subtract two negative rational numbers",
-              "property": "sub",
+              "property": "subtract",
               "input": {
                 "r1": [-1, 2],
                 "r2": [-2, 3]
@@ -86,7 +86,7 @@
             },
             {
               "description": "Subtract a rational number from itself",
-              "property": "sub",
+              "property": "subtract",
               "input": {
                 "r1": [1, 2],
                 "r2": [1, 2]
@@ -100,7 +100,7 @@
           "cases": [
             {
               "description": "Multiply two positive rational numbers",
-              "property": "mul",
+              "property": "multiply",
               "input": {
                 "r1": [1, 2],
                 "r2": [2, 3]
@@ -109,7 +109,7 @@
             },
             {
               "description": "Multiply a negative rational number by a positive rational number",
-              "property": "mul",
+              "property": "multiply",
               "input": {
                 "r1": [-1, 2],
                 "r2": [2, 3]
@@ -118,7 +118,7 @@
             },
             {
               "description": "Multiply two negative rational numbers",
-              "property": "mul",
+              "property": "multiply",
               "input": {
                 "r1": [-1, 2],
                 "r2": [-2, 3]
@@ -127,7 +127,7 @@
             },
             {
               "description": "Multiply a rational number by its reciprocal",
-              "property": "mul",
+              "property": "multiply",
               "input": {
                 "r1": [1, 2],
                 "r2": [2, 1]
@@ -136,7 +136,7 @@
             },
             {
               "description": "Multiply a rational number by 1",
-              "property": "mul",
+              "property": "multiply",
               "input": {
                 "r1": [1, 2],
                 "r2": [1, 1]
@@ -145,7 +145,7 @@
             },
             {
               "description": "Multiply a rational number by 0",
-              "property": "mul",
+              "property": "multiply",
               "input": {
                 "r1": [1, 2],
                 "r2": [0, 1]
@@ -159,7 +159,7 @@
           "cases": [
             {
               "description": "Divide two positive rational numbers",
-              "property": "div",
+              "property": "divide",
               "input": {
                 "r1": [1, 2],
                 "r2": [2, 3]
@@ -168,7 +168,7 @@
             },
             {
               "description": "Divide a positive rational number by a negative rational number",
-              "property": "div",
+              "property": "divide",
               "input": {
                 "r1": [1, 2],
                 "r2": [-2, 3]
@@ -177,7 +177,7 @@
             },
             {
               "description": "Divide two negative rational numbers",
-              "property": "div",
+              "property": "divide",
               "input": {
                 "r1": [-1, 2],
                 "r2": [-2, 3]
@@ -186,7 +186,7 @@
             },
             {
               "description": "Divide a rational number by 1",
-              "property": "div",
+              "property": "divide",
               "input": {
                 "r1": [1, 2],
                 "r2": [1, 1]
@@ -202,7 +202,7 @@
       "cases": [
         {
           "description": "Absolute value of a positive rational number",
-          "property": "abs",
+          "property": "absolute",
           "input": {
             "r": [1, 2]
           },
@@ -210,7 +210,7 @@
         },
         {
           "description": "Absolute value of a positive rational number with negative numerator and denominator",
-          "property": "abs",
+          "property": "absolute",
           "input": {
             "r": [-1, -2]
           },
@@ -218,7 +218,7 @@
         },
         {
           "description": "Absolute value of a negative rational number",
-          "property": "abs",
+          "property": "absolute",
           "input": {
             "r": [-1, 2]
           },
@@ -226,7 +226,7 @@
         },
         {
           "description": "Absolute value of a negative rational number with negative denominator",
-          "property": "abs",
+          "property": "absolute",
           "input": {
             "r": [1, -2]
           },
@@ -234,7 +234,7 @@
         },
         {
           "description": "Absolute value of zero",
-          "property": "abs",
+          "property": "absolute",
           "input": {
             "r": [0, 1]
           },

--- a/exercises/rational-numbers/canonical-data.json
+++ b/exercises/rational-numbers/canonical-data.json
@@ -26,7 +26,7 @@
               "expected": [7, 6]
             },
             {
-              "description": "Add a positive rational number and a negative rational number",
+              "description": "Add a positive and a negative rational number",
               "property": "add",
               "input": {
                 "r1": [1, 2],
@@ -67,7 +67,7 @@
               "expected": [-1, 6]
             },
             {
-              "description": "Subtract a positive rational number and a negative rational number",
+              "description": "Subtract a positive and a negative rational number",
               "property": "subtract",
               "input": {
                 "r1": [1, 2],
@@ -108,7 +108,7 @@
               "expected": [1, 3]
             },
             {
-              "description": "Multiply a negative rational number by a positive rational number",
+              "description": "Multiply a negative by a positive rational number",
               "property": "multiply",
               "input": {
                 "r1": [-1, 2],
@@ -167,7 +167,7 @@
               "expected": [3, 4]
             },
             {
-              "description": "Divide a positive rational number by a negative rational number",
+              "description": "Divide a positive by a negative rational number",
               "property": "divide",
               "input": {
                 "r1": [1, 2],


### PR DESCRIPTION
Per #1603 this updates some properties to full words instead of abbreviations.

I have also updated the casing on multi-word properties from alllowercase to camelCase.

Additionally have reduced the verbosity of some test case names where possible as these can fall a foul of style linters that restrict line length where the test case description is usually used as such in the test case name in the code.