### PR TITLE
resistor-color-duo: Fix wording in description, add test case

### DIFF
--- a/exercises/resistor-color-duo/canonical-data.json
+++ b/exercises/resistor-color-duo/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "resistor-color-duo",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "cases": [
     {
       "description": "Brown and black",

--- a/exercises/resistor-color-duo/canonical-data.json
+++ b/exercises/resistor-color-duo/canonical-data.json
@@ -35,6 +35,14 @@
       "expected": 33
     },
     {
+      "description": "Black and brown",
+      "property": "value",
+      "input": {
+        "colors": ["black", "brown"]
+      },
+      "expected": 1
+    },
+    {
       "description": "Ignore additional colors",
       "property": "value",
       "input": {

--- a/exercises/resistor-color-duo/description.md
+++ b/exercises/resistor-color-duo/description.md
@@ -3,7 +3,7 @@ If you want to build something using a Raspberry Pi, you'll probably use _resist
 * Each resistor has a resistance value.
 * Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
 
-To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values. Each band has a numeric and a positional value. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the numeric value 10 + 5 = 15, as if the colors were digits.
+To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values. Each band has a numeric and a positional value. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the numeric value.
 
 In this exercise you are going to create a helpful program so that you don't have to remember the numeric values of the bands. The program will take color names as input and output a numeric value of at most two digits.
 

--- a/exercises/resistor-color-duo/description.md
+++ b/exercises/resistor-color-duo/description.md
@@ -2,10 +2,10 @@ If you want to build something using a Raspberry Pi, you'll probably use _resist
 
 * Each resistor has a resistance value.
 * Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
-To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values. Each band has a position and a numeric value. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
 
-In this exercise you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take color names as input and output a two digit number, even if the input is more than two colors!
+To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values. Each band has a numeric and a positional value. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the numeric value 10 + 5 = 15, as if the colors were digits.
 
+In this exercise you are going to create a helpful program so that you don't have to remember the numeric values of the bands. The program will take color names as input and output a numeric value of at most two digits.
 
 The band colors are encoded as follows:
 
@@ -21,6 +21,6 @@ The band colors are encoded as follows:
 - White: 9
 
 From the example above:
-brown-green should return 15
-brown-green-violet should return 15 too, ignoring the third color.
 
+- Brown and green should return 15.
+- If your language track enables more than two colors as input, such as brown, green and violet, this should return 15, too, ignoring additional colors beyond the first two.


### PR DESCRIPTION
TL;DR:
 - Add `["black", "brown"]` test case.
 - Clarify "numerical value".
 - Remove "even if the input is more than two colors!"
 - Add conditional before and clarify "ignoring the third color."
 - Change formatting of the last two bullets (there were none).

Bumping the canonical version in exercism/haskell#865, I encountered some problems that I'd like to address.

> Each band has a position and a numeric value.

Since the first bands of a resistor denote the numeric value, perhaps it should read "a numeric and a positional value" in that order. After all, the positional value serves only as thematic context when looking at this exercise in isolation, which the student does regardless of whether the track implements resistor-color-trio in succession or not: addressing the positional value either happens at a later point in time, or not at all.

> For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.

Since this interpretation of colored bands only applies to the numeric value, perhaps it should say "numeric value 15", since one brown band followed by one green band in the context of the exercise does not address the positional value or the full resistance value of the resistor.

An additional didactic point of concern: It may also say "numeric value 10 + 5 = 15, as if the colors were digits", to signify how the example is derived. (I saw a guy live code this exercise on twitch, and this part is not obvious.)

> The program will take color names as input and output *a two digit number*,

As resistor-color-duo is implemented on 12 tracks, here is how they interpret "black, brown" (0, 1):

- bash: `01` -- according to specification.
- javascript / ecmascript: `1`
- nim: `1`
- dart: `1`
- crystal: `1`
- haskell: `1`
- java: `1`
- d: `1`
- c: `1`
- python: `1`
- ruby: `1`

The only language that follows the specification is the only one where integers are represented as strings and so concatenate prefix zeroes easily. Unfortunately there is no test case that starts with "black" to demonstrate which interpretation is correct.

Given that the README speaks of the output as a numeric value, and given that canonical-tests.json has `"expected": 10` for `"colors": ["brown", "black"]` rather than `"expected": "10"`, it would make sense to regard prefix zeroes as redundant, and as such, the formulation should be changed to "a numeric value of at most two digits" to be true, and to clarify that the function does not address the positional value.

And it would make sense to add the following test:

```diff
+    {
+      "description": "Black and brown",
+      "property": "value",
+      "input": {
+        "colors": ["black", "brown"]
+      },
+      "expected": 1
+    },
```

For the last and most problematic case:

> even if the input is more than two colors!

> brown-green-violet should return 15 too, ignoring the third color.

> ```
>     {
>       description: Ignore additional colors,
>       property: value,
>       input: {
>         colors: [green, brown, orange]
>       },
>       expected: 51
>     }
> ```

The following two formulations and test case were added in exercism/problem-specifications#1569 that "aims to fix a basic implementation bug whereby any additional colors are also used in the calculation". The way many dynamic languages implement this function is with an input array capable of holding 0, 1, 2, 3 or more colors.

This third-band test case (and formulations) have made the function explicitly more ambiguous: Unlike 0 or 1 bands, which is undefined, the third band should be ignored, and >3 bands are undefined. Presumably they should be ignored as well, but following this logic, should 0 or 1 bands also be ignored, giving the result `0`?

Before exercism/problem-specifications#1569, the Haskell track originally chose in exercism/haskell#808 to go with the same dynamic and error-prone approach, whereby the following sufficed:

```haskell
value :: [Color] -> Int
value [a, b] = 10 * value1 a + value1 b

value1 :: Color -> Int
value1 = ...
```

Since this function may easily be modelled as a [pure](https://en.wikipedia.org/wiki/Pure_function), [total](https://en.wikipedia.org/wiki/Total_functional_programming) function instead, alternative implementations might have one of the following type signatures

```haskell
value :: (Color, Color) -> Int
value :: [Color] -> Maybe Int
value :: [Color] -> Either String Int
value :: [Color] -> Either ColorError Int
```

depending on the aim of the exercise. Since error handling was initially argued against in exercism/haskell#808, the only pure, total alternative is `value :: (Color, Color) -> Int`. Fortunately, track maintainers get to decide how an exercise is best implemented for a given language, but unfortunately, this choice is not compatible with the wording of the problem description on two accounts:

1. It is not true that the numeric value is two digits. Fortunately, this is not true on 11 of 12 tracks, so changing it to "of at most two digits" can safely be regarded as a bugfix at the expense of @exercism/bash maintainers, who may still choose to keep the exercise as-is if they so prefer, since "of at most two digits" correctly describes an output of `01`.

2. There can be no third color in `value :: (Color, Color) -> Int`, and indeed, should there be, it would be an error. Due to Haskell's type system, such errors are promoted to compile-time type errors, rather than run-time errors. Since most tracks that implement this exercise use a variable-length input list/array, the wording of a third color may apply here, and so removing these formulations would affect most other implementing tracks negatively.

   A compromise would be to remove the sentence "even if the input is more than two colors!" and change the last formulation to "If your language track enables more than two colors as input, such as brown, green and violet, this should return 15, too, ignoring additional colors beyond the first two."

   This preserves the (justifiable but unsafe) ambiguity of 0 and 1 color for those tracks that prefer run-time errors, and it removes the additional ambiguity of differentiating 3 colors but not >3.

   And it gives preference to the majority of tracks at the slight expense of one track.