### PR TITLE
robot-simulator: "Rotating (counter)clockwise" -> turning left/right

### DIFF
--- a/exercises/robot-simulator/canonical-data.json
+++ b/exercises/robot-simulator/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "robot-simulator",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "comments": [
     "Some tests have two expectations: one for the position, one for the direction",
     "Optionally, you can also test",
@@ -51,7 +51,7 @@
       ]
     },
     {
-      "description": "Rotating clockwise",
+      "description": "Turning right",
       "cases": [
         {
           "description": "changes north to east",
@@ -132,7 +132,7 @@
       ]
     },
     {
-      "description": "Rotating counter-clockwise",
+      "description": "Turning left",
       "cases": [
         {
           "description": "changes north to west",


### PR DESCRIPTION
Was curious about the clockwise/counterclockwise concept. The README
only ever makes reference to "turn right" and "turn left", never
referring to clockwise/counterclockwise.
https://github.com/exercism/problem-specifications/blob/master/exercises/robot-simulator/description.md

While it may seem obvious to some that clockwise corresponds to turning
right (true if looking at robot from above), it does require
establishing the assumption that the point of view is from above.

It seems to make more sense to speak of turning right and left,
especially since the corresponding instructions are R and L.

Historical:
The first time these terms were introduced was with this canonical data
being added in c72f06a21d0233711f143bc5f72df51cfce4a393.