### PR TITLE
list-ops: change order in append test case description

### DIFF
--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "list-ops",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "comments": [
     "Though there are no specifications here for dealing with large lists,",
     "implementers may add tests for handling large lists to ensure that the",

--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -20,7 +20,7 @@
           "expected": []
         },
         {
-          "description": "empty list to list",
+          "description": "list to empty list",
           "property": "append",
           "input": {
             "list1": [],


### PR DESCRIPTION
Per #1609, this change makes the ordering of inputs implied by the description match the inputs as they are actually supplied.