### PR TITLE
list-ops: add append case

### DIFF
--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -30,6 +30,7 @@
           "expected": [1, 2, 3, 4]
         },
         {
+          "uuid": "e842efed-3bf6-4295-b371-4d67a4fdf19c",
           "description": "empty list to list",
           "property": "append",
           "input": {

--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -30,6 +30,15 @@
           "expected": [1, 2, 3, 4]
         },
         {
+          "description": "empty list to list",
+          "property": "append",
+          "input": {
+            "list1": [1, 2, 3, 4],
+            "list2": []
+          },
+          "expected": [1, 2, 3, 4]
+        },
+        {
           "uuid": "71dcf5eb-73ae-4a0e-b744-a52ee387922f",
           "description": "non-empty lists",
           "property": "append",


### PR DESCRIPTION
Subsequent to #1611 (which is itself pursuant to #1609), this will complete the permutation of the possible use cases for appending lists.
This is addition is from the suggestion of @petertseng in https://github.com/exercism/problem-specifications/issues/1609#issuecomment-542440691

Probably should be held until #1560 is resolved however, so adding the hold label already myself 😃 