### PR TITLE
grains: add total test

### DIFF
--- a/exercises/grains/canonical-data.json
+++ b/exercises/grains/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "grains",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "comments": [
     "The final tests of square test error conditions",
     "In these cases you should expect an error as is idiomatic for your language"
@@ -94,7 +94,9 @@
     {
       "description": "returns the total number of grains on the board",
       "property": "total",
-      "input": {},
+      "input": {
+        "square": 64
+      },
       "expected": 18446744073709551615
     }
   ]


### PR DESCRIPTION
Update problem specification to provide a value for the "total" function. Current test case passes empty value to total() and expects the answer for total(64)