### PR TITLE
affine cipher: remove reference to an exit code

### DIFF
--- a/exercises/affine-cipher/canonical-data.json
+++ b/exercises/affine-cipher/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "affine-cipher",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "comments": [
     "The test are divided into two groups: ",
     "* Encoding from English to affine cipher",

--- a/exercises/affine-cipher/description.md
+++ b/exercises/affine-cipher/description.md
@@ -33,7 +33,7 @@ More information regarding how to find a Modular Multiplicative Inverse
 and what it means can be found [here.](https://en.wikipedia.org/wiki/Modular_multiplicative_inverse) 
 
 Because automatic decryption fails if `a` is not coprime to `m` your
-program should return status 1 and `"Error: a and m must be coprime."`
+program should error
 if they are not.  Otherwise it should encode or decode with the
 provided key.
  


### PR DESCRIPTION
While it is idiomatic for shell scripts to indicate an error status
via exit code, doing so is uncommon in other languages. For generality,
the problem specifications should not instruct the test suites to
return an exit code.

This includes a bump to the patch version as the test suite has
not changed at all.