### PR TITLE
book-store: Add test that requires use of both groups of 4 and groups of 5

### DIFF
--- a/exercises/book-store/canonical-data.json
+++ b/exercises/book-store/canonical-data.json
@@ -156,6 +156,15 @@
            "basket": [1,1,1,2,2,2,3,3,3,4,4,5,5]
          },
          "expected": 8120
+        },
+        {
+         "property": "total",
+         "description": "shuffled book order",
+         "comments": ["Suggested grouping, [[1,2,3,4],[1,2,3,5],[1,2,3,4,5]]. All the other tests give the books in sorted order.  Robust solutions should be able to handle any order"],
+         "input": {
+           "basket": [1,2,3,4,5,1,2,3,4,5,1,2,3]
+         },
+         "expected": 8120
         }
      ]
     }

--- a/exercises/book-store/canonical-data.json
+++ b/exercises/book-store/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "book-store",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "cases": [
     {
       "description": "Return the total basket price after applying the best discount.",
@@ -147,6 +147,15 @@
            "basket": [1,1,2,2,3,3,4,5,1,1,2,2,3,3,4,5]
          },
          "expected": 10240
+        },
+        {
+         "property": "total",
+         "description": "Two groups of four and a group of five",
+         "comments": ["Suggested grouping, [[1,2,3,4],[1,2,3,5],[1,2,3,4,5]]. Solutions can pass all the other tests if they just try to group without using any groups of 5. This test case breaks that since it requires both 4-groups and 5-groups."],
+         "input": {
+           "basket": [1,1,1,2,2,2,3,3,3,4,4,5,5]
+         },
+         "expected": 8120
         }
      ]
     }


### PR DESCRIPTION
Many of the "brute force" solutions I see do something like run a greedy solver multiple times with different maximum group sizes. This allows them to solve test cases that check for finding 2 groups of 4 instead of a group of 5 and a group of 3.

However, this wouldn't solve cases where you need to use both groups of 5 and groups of 4. For example, consider books = [1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3]. The cheapest price possible is achieved by splitting it into 1 group of 5 and 2 groups of 4, with cost = 800*(1*5*0.75 + 2*4*0.8) = 8120. Solutions like those described above will typically split it into 2 groups of 5 and 1 group of 3, with a cost of 800*(2*5*0.75 + 1*3*0.9) = 8160.

For further motivation and discussion see: https://github.com/exercism/python/pull/2141

