### PR TITLE
Word Count - Adds multiple apostrophe test case

### DIFF
--- a/exercises/word-count/canonical-data.json
+++ b/exercises/word-count/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "word-count",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "comments": [
     "For each word in the input, count the number of times it appears in the",
     "entire sentence."
@@ -170,6 +170,16 @@
         "one": 1,
         "two": 1,
         "three": 1
+      }
+    },
+    {
+      "description": "multiple apostrophes are ignored",
+      "property": "countWords",
+      "input": {
+        "sentence": "''hey''"
+      },
+      "expected": {
+        "hey": 1
       }
     }
   ]


### PR DESCRIPTION
I noticed when working through the word-count problem on the Python track, I was able to pass the test suite with an incorrect solution. Effectively, the test suite does not check that users ignore non-contracting apostrophes. As such, I've added a simple test checking that the word "\'\'hey\'\'"  (the middle quotes are apostrophes) successfully comes out to "hey". I could see this being potentially out-of-scope though.