### PR TITLE
luhn: check a number with an even remainder

### DIFF
--- a/exercises/luhn/canonical-data.json
+++ b/exercises/luhn/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "luhn",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "cases": [
     {
       "description": "single digit strings can not be valid",

--- a/exercises/luhn/canonical-data.json
+++ b/exercises/luhn/canonical-data.json
@@ -1,6 +1,6 @@
 {
   "exercise": "luhn",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "cases": [
     {
       "description": "single digit strings can not be valid",
@@ -55,6 +55,14 @@
       "property": "valid",
       "input": {
         "value": "8273 1232 7352 0569"
+      },
+      "expected": false
+    },
+    {
+      "description": "invalid long number with an even remainder",
+      "property": "valid",
+      "input": {
+        "value": "1 2345 6789 1234 5678 9012"
       },
       "expected": false
     },


### PR DESCRIPTION
I saw a student accidentally pass the test suite just by checking the parity (divisibility by 2) of the final sum instead of the divisibility by 10. A lot of algorithms involve checking of parity so I can see such mistakes slipping in from time to time.

The only two proper numbers that are not valid in the test suite sum to 41 and 57.
Initially, I thought about testing all the possible remainders using the simplest inputs of `01` through to `09` but maybe that's beyond the purpose to provide a sane yet fairly straightforward test coverage.

Anyway, I think it's a good idea to test at least one proper number that is not valid and has an even remainder.