### PR TITLE
scale-generator: fix name of augmented interval

### DIFF
--- a/exercises/scale-generator/description.md
+++ b/exercises/scale-generator/description.md
@@ -41,7 +41,7 @@ a "whole step" or "major second" (written as an upper-case "M"). The
 diatonic scales are built using only these two intervals between
 adjacent notes.
 
-Non-diatonic scales can contain other intervals.  An "augmented first"
-interval, written "A", has two interceding notes (e.g., from A to C or
-Db to E). There are also smaller and larger intervals, but they will not
-figure into this exercise.
+Non-diatonic scales can contain other intervals.  An "augmented second"
+interval, written "A", has two interceding notes (e.g., from A to C or Db to E)
+or a "whole step" plus a "half step". There are also smaller and larger
+intervals, but they will not figure into this exercise.


### PR DESCRIPTION
The interval described is an augmented *second*, not an augmented first.
Added also its composition in terms of steps for completeness.

Fixes #1642

Signed-off-by: Rafael Fonseca <r4f4rfs@gmail.com>