### PR TITLE
[two-bucket] Make valid moves clearer

### DIFF
--- a/exercises/two-bucket/description.md
+++ b/exercises/two-bucket/description.md
@@ -21,8 +21,8 @@ Example:
 Bucket one can hold up to 7 liters, and bucket two can hold up to 11 liters. Let's say bucket one, at a given step, is holding 7 liters, and bucket two is holding 8 liters (7,8). If you empty bucket one and make no change to bucket two, leaving you with 0 liters and 8 liters respectively (0,8), that counts as one "move". Instead, if you had poured from bucket one into bucket two until bucket two was full, leaving you with 4 liters in bucket one and 11 liters in bucket two (4,11), that would count as only one "move" as well.
 
 To conclude, the only valid moves are:
-- pouring from one bucket to another
-- emptying one bucket and doing nothing to the other
-- filling one bucket and doing nothing to the other
+- pouring from either bucket to another
+- emptying either bucket and doing nothing to the other
+- filling either bucket and doing nothing to the other
 
 Written with <3 at [Fullstack Academy](http://www.fullstackacademy.com/) by Lindsay Levine.


### PR DESCRIPTION
There has been confusion over the reuse of the word "one" in both the descriptions of the bucket ("Bucket one") and the moves ("Move from one bucket"). This removes that confusion, which will help reduce misunderstanding, especially amongst non-native English speakers.

With reference to https://github.com/exercism/exercism/issues/5205#event-3090216965