### PR TITLE
resistor-color-duo: no tests for green or red

### DIFF
--- a/exercises/resistor-color-duo/canonical-data.json
+++ b/exercises/resistor-color-duo/canonical-data.json
@@ -27,6 +27,14 @@
       "expected": 47
     },
     {
+      "description": "Green and red",
+      "property": "value",
+      "input": {
+        "colors": ["green", "red"]
+      },
+      "expected": 52
+    },
+    {
       "description": "Orange and orange",
       "property": "value",
       "input": {


### PR DESCRIPTION
I had a student submit a solution where red was missing. For completeness, adding a test for green and red.

Parenthetically, us red-green colourblind folks will appreciate the automated assistance: I had significant difficulties with my first-year electronics course.