### PR TITLE
Fix metadata source_url for simple-linked-list exercise

### DIFF
--- a/exercises/simple-linked-list/metadata.yml
+++ b/exercises/simple-linked-list/metadata.yml
@@ -1,4 +1,4 @@
 ---
 blurb: "Write a simple linked list implementation that uses Elements and a List"
 source: "Inspired by 'Data Structures and Algorithms with Object-Oriented Design Patterns in Ruby', singly linked-lists."
-source_url: "https://web.archive.org/web/20160414064110/http://www.brpreiss.com/books/opus8/"
+source_url: "https://web.archive.org/web/20160731005714/http://brpreiss.com/books/opus8/html/page96.html"


### PR DESCRIPTION
Previous web.archive.org link pointed to the book homepage.
Change it to point to simple-linked-list page.

Previous: https://github.com/exercism/problem-specifications/pull/1648