### PR TITLE
rational-numbers: Make formulas more readable

### DIFF
--- a/exercises/rational-numbers/description.md
+++ b/exercises/rational-numbers/description.md
@@ -10,11 +10,11 @@ The product (multiplication) of two rational numbers `r₁ = a₁/b₁` and `r�
 
 Dividing a rational number `r₁ = a₁/b₁` by another `r₂ = a₂/b₂` is `r₁ / r₂ = (a₁ * b₂) / (a₂ * b₁)` if `a₂ * b₁` is not zero.
 
-Exponentiation of a rational number `r = a/b` to a non-negative integer power `n` is `r^n = a^n/b^n`.
+Exponentiation of a rational number `r = a/b` to a non-negative integer power `n` is `r^n = (a^n)/(b^n)`.
 
-Exponentiation of a rational number `r = a/b` to a negative integer power `n` is `r^n = b^m/a^m`, where `m = |n|`.
+Exponentiation of a rational number `r = a/b` to a negative integer power `n` is `r^n = (b^m)/(a^m)`, where `m = |n|`.
 
-Exponentiation of a rational number `r = a/b` to a real (floating-point) number `x` is the quotient `a^x/b^x`, which is a real number.
+Exponentiation of a rational number `r = a/b` to a real (floating-point) number `x` is the quotient `(a^x)/(b^x)`, which is a real number.
 
 Exponentiation of a real number `x` to a rational number `r = a/b` is `x^(a/b) = root(x^a, b)`, where `root(p, q)` is the `q`th root of `p`.
 

--- a/exercises/rational-numbers/description.md
+++ b/exercises/rational-numbers/description.md
@@ -2,21 +2,21 @@ A rational number is defined as the quotient of two integers `a` and `b`, called
 
 The absolute value `|r|` of the rational number `r = a/b` is equal to `|a|/|b|`.
 
-The sum of two rational numbers `r1 = a1/b1` and `r2 = a2/b2` is `r1 + r2 = a1/b1 + a2/b2 = (a1 * b2 + a2 * b1) / (b1 * b2)`.
+The sum of two rational numbers `r₁ = a₁/b₁` and `r₂ = a₂/b₂` is `r₁ + r₂ = a₁/b₁ + a₂/b₂ = (a₁ * b₂ + a₂ * b₁) / (b₁ * b₂)`.
 
-The difference of two rational numbers `r1 = a1/b1` and `r2 = a2/b2` is `r1 - r2 = a1/b1 - a2/b2 = (a1 * b2 - a2 * b1) / (b1 * b2)`.
+The difference of two rational numbers `r₁ = a₁/b₁` and `r₂ = a₂/b₂` is `r₁ - r₂ = a₁/b₁ - a₂/b₂ = (a₁ * b₂ - a₂ * b₁) / (b₁ * b₂)`.
 
-The product (multiplication) of two rational numbers `r1 = a1/b1` and `r2 = a2/b2` is `r1 * r2 = (a1 * a2) / (b1 * b2)`.
+The product (multiplication) of two rational numbers `r₁ = a₁/b₁` and `r₂ = a₂/b₂` is `r₁ * r₂ = (a₁ * a₂) / (b₁ * b₂)`.
 
-Dividing a rational number `r1 = a1/b1` by another `r2 = a2/b2` is `r1 / r2 = (a1 * b2) / (a2 * b1)` if `a2 * b1` is not zero.
+Dividing a rational number `r₁ = a₁/b₁` by another `r₂ = a₂/b₂` is `r₁ / r₂ = (a₁ * b₂) / (a₂ * b₁)` if `a₂ * b₁` is not zero.
 
-Exponentiation of a rational number `r = a/b` to a non-negative integer power `n` is `r^n = (a^n)/(b^n)`.
+Exponentiation of a rational number `r = a/b` to a non-negative integer power `n` is `rⁿ = aⁿ/bⁿ`.
 
-Exponentiation of a rational number `r = a/b` to a negative integer power `n` is `r^n = (b^m)/(a^m)`, where `m = |n|`.
+Exponentiation of a rational number `r = a/b` to a negative integer power `n` is `rⁿ = bᵐ/aᵐ`, where `m = |n|`.
 
-Exponentiation of a rational number `r = a/b` to a real (floating-point) number `x` is the quotient `(a^x)/(b^x)`, which is a real number.
+Exponentiation of a rational number `r = a/b` to a real (floating-point) number `x` is the quotient `aˣ/bˣ`, which is a real number.
 
-Exponentiation of a real number `x` to a rational number `r = a/b` is `x^(a/b) = root(x^a, b)`, where `root(p, q)` is the `q`th root of `p`.
+Exponentiation of a real number `x` to a rational number `r = a/b` is `x^(a/b) = root(xᵃ, b)`, where `root(p, q)` is the `q`th root of `p`.
 
 Implement the following operations:
  - addition, subtraction, multiplication and division of two rational numbers,

--- a/exercises/rational-numbers/description.md
+++ b/exercises/rational-numbers/description.md
@@ -10,13 +10,13 @@ The product (multiplication) of two rational numbers `r₁ = a₁/b₁` and `r�
 
 Dividing a rational number `r₁ = a₁/b₁` by another `r₂ = a₂/b₂` is `r₁ / r₂ = (a₁ * b₂) / (a₂ * b₁)` if `a₂ * b₁` is not zero.
 
-Exponentiation of a rational number `r = a/b` to a non-negative integer power `n` is `rⁿ = aⁿ/bⁿ`.
+Exponentiation of a rational number `r = a/b` to a non-negative integer power `n` is `r^n = a^n/b^n`.
 
-Exponentiation of a rational number `r = a/b` to a negative integer power `n` is `rⁿ = bᵐ/aᵐ`, where `m = |n|`.
+Exponentiation of a rational number `r = a/b` to a negative integer power `n` is `r^n = b^m/a^m`, where `m = |n|`.
 
-Exponentiation of a rational number `r = a/b` to a real (floating-point) number `x` is the quotient `aˣ/bˣ`, which is a real number.
+Exponentiation of a rational number `r = a/b` to a real (floating-point) number `x` is the quotient `a^x/b^x`, which is a real number.
 
-Exponentiation of a real number `x` to a rational number `r = a/b` is `x^(a/b) = root(xᵃ, b)`, where `root(p, q)` is the `q`th root of `p`.
+Exponentiation of a real number `x` to a rational number `r = a/b` is `x^(a/b) = root(x^a, b)`, where `root(p, q)` is the `q`th root of `p`.
 
 Implement the following operations:
  - addition, subtraction, multiplication and division of two rational numbers,


### PR DESCRIPTION
This makes the given formulas easier to read, by using `a₁` instead of `a1` etc.

I don't know if this is covered by #1560, please turn it into a draft if it is.