### PR TITLE
Add testcases to matching-brackets

### DIFF
--- a/exercises/matching-brackets/canonical-data.json
+++ b/exercises/matching-brackets/canonical-data.json
@@ -137,6 +137,24 @@
       "expected": false
     },
     {
+      "uuid": "a345a753-d889-4b7e-99ae-34ac85910d1a",
+      "description": "early unexpected brackets",
+      "property": "isPaired",
+      "input": {
+        "value": ")()"
+      },
+      "expected": false
+    },
+    {
+      "uuid": "21f81d61-1608-465a-b850-baa44c5def83",
+      "description": "early mismatched brackets",
+      "property": "isPaired",
+      "input": {
+        "value": "{)()"
+      },
+      "expected": false
+    },
+    {
       "uuid": "99255f93-261b-4435-a352-02bdecc9bdf2",
       "description": "math expression",
       "property": "isPaired",


### PR DESCRIPTION
These are up-streamed test cases from exercism/rust#946 to catch bugs discovered in this https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=1661c960aaf13f061dbeb747a587cece matching-brackets rust implementation that where not caught with the preexisting testcases.

As explained in the [other pull request](https://github.com/exercism/rust/pull/946) these test cases handle bugs related to implementations not quitting when there is a error in situations such as isolated mismatched brackets or closing brackets when the stack is empty.