### PR TITLE
Pangram: check case insensitive behavior

### DIFF
--- a/exercises/pangram/canonical-data.json
+++ b/exercises/pangram/canonical-data.json
@@ -4,7 +4,7 @@
     "A pangram is a sentence using every letter of the alphabet at least once.",
     "Output should be a boolean denoting if the string is a pangram or not."
   ],
-  "version": "2.0.0",
+  "version": "2.1.0",
   "cases": [
     {
       "description": "empty sentence",
@@ -85,6 +85,22 @@
         "sentence": "the quick brown fox jumps over with lazy FX"
       },
       "expected": false
+    },
+    {
+      "description": "a-m and A-M are 26 different letters but not a pangram",
+      "property": "isPangram",
+      "input": {
+        "sentence": "abcdefghijklm ABCDEFGHIJKLM"
+      },
+      "expected": false
+    },
+    {
+      "description": "pangram with more than 26 letters (if case sensitive)",
+      "property": "isPangram",
+      "input": {
+        "sentence": "the 1 quick brown fox jumps Over the 2 lazy dogs"
+      },
+      "expected": true
     }
   ]
 }


### PR DESCRIPTION
I received one solution where it was only checked whether there are exactly 26 letters (case sensitive)
This would result in that `a...m A...M` is a pangram for example.
Also fails if there are more than 26 letters when counting i.e o and O as two different ones.