### PR TITLE
robot-name: remove dead link

### DIFF
--- a/exercises/robot-name/metadata.yml
+++ b/exercises/robot-name/metadata.yml
@@ -1,4 +1,3 @@
 ---
 blurb: "Manage robot factory settings."
 source: "A debugging session with Paul Blackwell at gSchool."
-source_url: "http://gschool.it"


### PR DESCRIPTION
gSchool.it is now a domain parking spot