### PR TITLE
diffie-hellman: Reword 'in range 1 .. p'

### DIFF
--- a/exercises/diffie-hellman/canonical-data.json
+++ b/exercises/diffie-hellman/canonical-data.json
@@ -17,7 +17,7 @@
   "cases": [
     {
       "uuid": "1b97bf38-4307-418e-bfd2-446ffc77588d",
-      "description": "private key is in range 1 .. p",
+      "description": "private key is greater than 1 and less than p",
       "property": "privateKeyIsInRange",
       "input": {},
       "expected": {


### PR DESCRIPTION
There are some languages where the syntax `1 .. p` includes the endpoints.

For example, the Nim code:
```Nim
for i in 1 .. 3:
  echo i
```

shows the output:
```
1
2
3
```

Therefore "in range 1 .. p" would have been especially confusing, given that it was intended to **exclude** the endpoints.

So let's use the wording from the `description.md`:
https://github.com/exercism/problem-specifications/blob/126568d7bddcb0696a3a4202030b240866a41889/exercises/diffie-hellman/description.md#L13-L14