### PR TITLE
grade-school: Fix typo in test description

### DIFF
--- a/exercises/grade-school/canonical-data.json
+++ b/exercises/grade-school/canonical-data.json
@@ -16,7 +16,7 @@
         },
         {
             "uuid": "233be705-dd58-4968-889d-fb3c7954c9cc",
-            "description": "Adding more student adds them to the sorted roster",
+            "description": "Adding more students adds them to the sorted roster",
             "property": "roster",
             "input": {
               "students": [["Blair", 2], ["James", 2], ["Paul", 2]]


### PR DESCRIPTION
Diff:
```diff
- "description": "Adding more student adds them to the sorted roster",
+ "description": "Adding more students adds them to the sorted roster",
```