### PR TITLE
isbn-verifier: 'isbn number' -> 'isbn'

### DIFF
--- a/exercises/isbn-verifier/canonical-data.json
+++ b/exercises/isbn-verifier/canonical-data.json
@@ -7,7 +7,7 @@
     "cases": [
         {
             "uuid": "0caa3eac-d2e3-4c29-8df8-b188bc8c9292",
-            "description": "valid isbn number",
+            "description": "valid isbn",
             "property": "isValid",
             "input": {
               "isbn": "3-598-21508-8"
@@ -25,7 +25,7 @@
         },
         {
             "uuid": "4164bfee-fb0a-4a1c-9f70-64c6a1903dcd",
-            "description": "valid isbn number with a check digit of 10",
+            "description": "valid isbn with a check digit of 10",
             "property": "isValid",
             "input": {
               "isbn": "3-598-21507-X"


### PR DESCRIPTION
Most of the test descriptions just used 'isbn', so let's be consistent and avoid "International Standard Book Number number" (https://en.wikipedia.org/wiki/RAS_syndrome)