### PR TITLE
perfect-numbers: 'natural number' -> 'positive integer'

### DIFF
--- a/exercises/perfect-numbers/canonical-data.json
+++ b/exercises/perfect-numbers/canonical-data.json
@@ -120,24 +120,24 @@
             "cases": [
                 {
                     "uuid": "72445cee-660c-4d75-8506-6c40089dc302",
-                    "description": "Zero is rejected (not a natural number)",
+                    "description": "Zero is rejected (as it is not a positive integer)",
                     "property": "classify",
                     "input": {
                         "number": 0
                     },
                     "expected": {
-                        "error": "Classification is only possible for natural numbers."
+                        "error": "Classification is only possible for positive integers."
                     }
                 },
                 {
                     "uuid": "2d72ce2c-6802-49ac-8ece-c790ba3dae13",
-                    "description": "Negative integer is rejected (not a natural number)",
+                    "description": "Negative integer is rejected (as it is not a positive integer)",
                     "property": "classify",
                     "input": {
                         "number": -1
                     },
                     "expected": {
-                        "error": "Classification is only possible for natural numbers."
+                        "error": "Classification is only possible for positive integers."
                     }
                 }
             ]

--- a/exercises/perfect-numbers/description.md
+++ b/exercises/perfect-numbers/description.md
@@ -1,7 +1,7 @@
 Determine if a number is perfect, abundant, or deficient based on
-Nicomachus' (60 - 120 CE) classification scheme for natural numbers.
+Nicomachus' (60 - 120 CE) classification scheme for positive integers.
 
-The Greek mathematician [Nicomachus](https://en.wikipedia.org/wiki/Nicomachus) devised a classification scheme for natural numbers, identifying each as belonging uniquely to the categories of **perfect**, **abundant**, or **deficient** based on their [aliquot sum](https://en.wikipedia.org/wiki/Aliquot_sum). The aliquot sum is defined as the sum of the factors of a number not including the number itself. For example, the aliquot sum of 15 is (1 + 3 + 5) = 9
+The Greek mathematician [Nicomachus](https://en.wikipedia.org/wiki/Nicomachus) devised a classification scheme for positive integers, identifying each as belonging uniquely to the categories of **perfect**, **abundant**, or **deficient** based on their [aliquot sum](https://en.wikipedia.org/wiki/Aliquot_sum). The aliquot sum is defined as the sum of the factors of a number not including the number itself. For example, the aliquot sum of 15 is (1 + 3 + 5) = 9
 
 - **Perfect**: aliquot sum = number
   - 6 is a perfect number because (1 + 2 + 3) = 6

--- a/exercises/perfect-numbers/metadata.yml
+++ b/exercises/perfect-numbers/metadata.yml
@@ -1,4 +1,4 @@
 ---
-blurb: "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for natural numbers."
+blurb: "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers."
 source: "Taken from Chapter 2 of Functional Thinking by Neal Ford."
 source_url: "http://shop.oreilly.com/product/0636920029687.do"


### PR DESCRIPTION
There is no convention whether zero is a natural number, so let's avoid
the issue.

For example, see:
- https://mathworld.wolfram.com/NaturalNumber.html
- https://en.wikipedia.org/wiki/Natural_number
- https://math.stackexchange.com/questions/283/is-0-a-natural-number

The previous wording of
```
  "description": "Zero is rejected (not a natural number)",
```
could be especially jarring for some tracks. For example, Nim defines
`Natural` and `Positive` types, and `Natural` includes 0. See:
- https://nim-lang.github.io/Nim/system.html#Natural

Note, the other exercises that mention "natural" are:

```
difference-of-squares/description.md
1:Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.
3:The square of the sum of the first ten natural numbers is
6:The sum of the squares of the first ten natural numbers is
10:ten natural numbers and the sum of the squares of the first ten
11:natural numbers is 3025 - 385 = 2640.

difference-of-squares/metadata.yml
2:blurb: "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers."

prime-factors/description.md
1:Compute the prime factors of a given natural number.

prime-factors/metadata.yml
2:blurb: "Compute the prime factors of a given natural number."

pythagorean-triplet/description.md
1:A Pythagorean triplet is a set of three natural numbers, {a, b, c}, for

spiral-matrix/description.md
3:The matrix should be filled with natural numbers, starting from 1

sum-of-multiples/description.md
4:If we list all the natural numbers below 20 that are multiples of 3 or 5,
```