### PR TITLE
CI: Clean up workflow and clarify what "JS tests" are

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,15 @@ on:
       - master
 
 jobs:
-  test:
+  required-files:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: All required files are present
+        run: bin/check_required_files_present
+
+  schema-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -32,9 +40,6 @@ jobs:
 
       - name: Install dependencies
         run: yarn install
-
-      - name: Check all required files are present
-        run: bin/check_required_files_present
 
       - name: Run JS tests
         run: yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   required-files:
+    name: All required files are present
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -16,6 +17,7 @@ jobs:
         run: bin/check_required_files_present
 
   schema-tests:
+    name: Schema validation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -41,5 +43,5 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Run JS tests
+      - name: Verify that canonical-data.json files adhere to canonical-schema.json
         run: yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: All required files are present
         run: bin/check_required_files_present
 
-  schema-tests:
+  schema-validation:
     name: Schema validation
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This makes it easier to tell what test failed without leaving the PR view. It also clarifies what "Run JS tests" actually does.

Before: 

![grafik](https://user-images.githubusercontent.com/20866761/95868527-9a382f80-0d6a-11eb-95b2-f336c464b76c.png)

After:

![grafik](https://user-images.githubusercontent.com/20866761/95868550-a02e1080-0d6a-11eb-92ba-7be641a28f17.png)

---

@iHiD This would require changing the required check to `required-files` and `schema-validation`.