### PR TITLE
grains: Be more verbose in test-level descriptions

### DIFF
--- a/exercises/grains/canonical-data.json
+++ b/exercises/grains/canonical-data.json
@@ -10,7 +10,7 @@
       "cases": [
         {
           "uuid": "9fbde8de-36b2-49de-baf2-cd42d6f28405",
-          "description": "1",
+          "description": "grains on square 1",
           "property": "square",
           "input": {
             "square": 1
@@ -19,7 +19,7 @@
         },
         {
           "uuid": "ee1f30c2-01d8-4298-b25d-c677331b5e6d",
-          "description": "2",
+          "description": "grains on square 2",
           "property": "square",
           "input": {
             "square": 2
@@ -28,7 +28,7 @@
         },
         {
           "uuid": "10f45584-2fc3-4875-8ec6-666065d1163b",
-          "description": "3",
+          "description": "grains on square 3",
           "property": "square",
           "input": {
             "square": 3
@@ -37,7 +37,7 @@
         },
         {
           "uuid": "a7cbe01b-36f4-4601-b053-c5f6ae055170",
-          "description": "4",
+          "description": "grains on square 4",
           "property": "square",
           "input": {
             "square": 4
@@ -46,7 +46,7 @@
         },
         {
           "uuid": "c50acc89-8535-44e4-918f-b848ad2817d4",
-          "description": "16",
+          "description": "grains on square 16",
           "property": "square",
           "input": {
             "square": 16
@@ -55,7 +55,7 @@
         },
         {
           "uuid": "acd81b46-c2ad-4951-b848-80d15ed5a04f",
-          "description": "32",
+          "description": "grains on square 32",
           "property": "square",
           "input": {
             "square": 32
@@ -64,7 +64,7 @@
         },
         {
           "uuid": "c73b470a-5efb-4d53-9ac6-c5f6487f227b",
-          "description": "64",
+          "description": "grains on square 64",
           "property": "square",
           "input": {
             "square": 64


### PR DESCRIPTION
The top-level `description` of all these cases was:
```
  "description": "returns the number of grains on the square",
```
but each test-level `description` contained only a number.

The comments in `tests.toml` are generated only from the test-level
`description`, and so the comments there will now be more informative
the previously seen:
```toml
[canonical-tests]

# 1
"9fbde8de-36b2-49de-baf2-cd42d6f28405" = true

# 2
"ee1f30c2-01d8-4298-b25d-c677331b5e6d" = true

# 3
"10f45584-2fc3-4875-8ec6-666065d1163b" = true

# 4
"a7cbe01b-36f4-4601-b053-c5f6ae055170" = true

# 16
"c50acc89-8535-44e4-918f-b848ad2817d4" = true

# 32
"acd81b46-c2ad-4951-b848-80d15ed5a04f" = true

# 64
"c73b470a-5efb-4d53-9ac6-c5f6487f227b" = true

# square 0 raises an exception
"1d47d832-3e85-4974-9466-5bd35af484e3" = true

# negative square raises an exception
"61974483-eeb2-465e-be54-ca5dde366453" = true

# square greater than 64 raises an exception
"a95e4374-f32c-45a7-a10d-ffec475c012f" = true

# returns the total number of grains on the board
"6eb07385-3659-4b45-a6be-9dc474222750" = true
```