### PR TITLE
run-length-encoding: 'lower case' -> 'lowercase'

### DIFF
--- a/exercises/run-length-encoding/canonical-data.json
+++ b/exercises/run-length-encoding/canonical-data.json
@@ -110,7 +110,7 @@
         },
         {
           "uuid": "29f721de-9aad-435f-ba37-7662df4fb551",
-          "description": "lower case string",
+          "description": "lowercase string",
           "property": "decode",
           "input": {
             "string": "2a3b4c"


### PR DESCRIPTION
This makes it more consistent with another test:
https://github.com/exercism/problem-specifications/blob/ea119358dde6e7c3ce5673a5d939bb4976a80d88/exercises/run-length-encoding/canonical-data.json#L53-L54

Both forms are correct, but "lowercase" is more common. See:
https://english.stackexchange.com/questions/59409

We probably don't need to mandate an exercism-wide style for this, but I think it should at least be consistent within an exercise. The other exercise that is inconsistent within its `canonical-data.json` is `isogram`. 

Here are the relevant occurances of "lower":
```
acronym/canonical-data.json
18:          "description": "lowercase words",

affine-cipher/canonical-data.json
6:    "* Decoding from affine cipher to all-lowercase-mashed-together English"

atbash-cipher/canonical-data.json
6:    "* Decoding from atbash cipher to all-lowercase-mashed-together English"

crypto-square/canonical-data.json
15:      "description": "Lowercase",

etl/description.md
28:also stores the letters in lower-case regardless of the case of the

isogram/canonical-data.json
24:          "description": "isogram with only lower case characters",
69:          "description": "word with duplicated character in mixed case, lowercase first",

pangram/canonical-data.json
19:      "description": "perfect lower case",
28:      "description": "only lower case",

run-length-encoding/canonical-data.json
54:          "description": "lowercase characters",
113:          "description": "lower case string",

run-length-encoding/description.md
20:the letters A through Z (either lower or upper case) and whitespace. This way

scale-generator/description.md
38:"half step", or "minor second" (sometimes written as a lower-case "m").

scrabble-score/canonical-data.json
6:      "description": "lowercase letter",

sgf-parsing/canonical-data.json
91:            "description": "all lowercase property",
102:            "description": "upper and lowercase property",

simple-cipher/canonical-data.json
43:          "description": "Key is made only of lowercase letters",

simple-cipher/description.md
59:of randomness and ensuring that the key contains only lowercase letters.
62:at least 100 lowercase characters in length.
```


And "upper":
```
$ rg --sort path -i upper
robot-name/description.md
6:of two uppercase letters followed by three digits, such as RX837 or BC811.

run-length-encoding/description.md
20:the letters A through Z (either lower or upper case) and whitespace. This way

scale-generator/description.md
40:a "whole step" or "major second" (written as an upper-case "M"). The

scrabble-score/canonical-data.json
15:      "description": "uppercase letter",

sgf-parsing/canonical-data.json
97:                "error": "property must be in uppercase"
102:            "description": "upper and lowercase property",
108:                "error": "property must be in uppercase"
```