### PR TITLE
CI: Add workflow_dispatch as manual trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push: 
     branches: 
       - master
+  workflow_dispatch:
 
 jobs:
   required-files:


### PR DESCRIPTION
This is useful for debugging CI or when working on a branch before opening a PR