### PR TITLE
Workflows: Avoid duplicate builds

### DIFF
--- a/workflows/configlet.yml
+++ b/workflows/configlet.yml
@@ -2,7 +2,13 @@
 
 name: configlet
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
 
 jobs:
   lint:


### PR DESCRIPTION
This will prevent duplicate builds in PRs where the PR branch is part of the repo and not a fork.