### PR TITLE
Grade school exercise: A student cannot simultaneously be in two grad…

### DIFF
--- a/exercises/grade-school/canonical-data.json
+++ b/exercises/grade-school/canonical-data.json
@@ -15,6 +15,19 @@
             "expected": ["Aimee"]
         },
         {
+          "uuid": "dece43c8-3ba5-11eb-8fdf-7f8daeaeb5f2",
+          "description": "A student can't be in two different grades",
+          "property": "roster",
+          "input": {
+            "students": [
+              ["Aimee", 2],
+              ["Aimee", 1]
+            ],
+            "desiredGrade": 2
+          },
+          "expected": []
+        },
+        {
             "uuid": "233be705-dd58-4968-889d-fb3c7954c9cc",
             "description": "Adding more students adds them to the sorted roster",
             "property": "roster",


### PR DESCRIPTION
In the grade school exercise names are meant to be unique and thus a user should only belong in a grade. This PR adds canonical data to verify this condition. And it has been discussed and implemented for the typescript class:

- [Former Issue](https://github.com/exercism/typescript/issues/361)
- [Pull Request on the Typescript track](https://github.com/exercism/typescript/pull/362)

