### PR TITLE
rational-numbers: Add ordering to spec

### DIFF
--- a/exercises/rational-numbers/canonical-data.json
+++ b/exercises/rational-numbers/canonical-data.json
@@ -422,6 +422,30 @@
           "expected": [1, 1]
         }
       ]
+    },
+    {
+      "uuid": "bd1eab16-7603-4a77-ae4e-23c930fe39cd",
+      "description": "Ordering",
+      "property": "<",
+      "comments": [
+        "Depending on your language's features, you may have to implement the following operators:",
+        "=, !=, <=, <, >=, >",
+        "",
+        "To test the ordering, it's recommended to iterate through a = -5..5, b = -5..5, c = -5..5, d = -5..5,",
+        "define rational numbers r = a / b, s = c / d,",
+        "and compare the result of r $op c,",
+        "where $op = {=, !=, <=, <, >=, >}",
+        "to the result of the corresponding floating point comparisons",
+        "a / b $op c. Analogously, compare r $op s with a / b $op c / d.",
+        "Skip the iteration step when a == b == 0 or c == d == 0, since 0/0 is undefined.",
+        "",
+        "Depending on your implementation of the exercise, you may need to consider",
+        "division by zero differently in the iteration.",
+        "",
+        "This testing method is based on Julia Base tests[1], released under the MIT licence[2].",
+        "[1]: https://github.com/JuliaLang/julia/blob/52bafeb981bac548afd2264edb518d8d86944dca/test/rational.jl",
+        "[2]: https://github.com/JuliaLang/julia/blob/52bafeb981bac548afd2264edb518d8d86944dca/LICENSE.md"
+      ]
     }
   ]
 }

--- a/exercises/rational-numbers/description.md
+++ b/exercises/rational-numbers/description.md
@@ -18,9 +18,12 @@ Exponentiation of a rational number `r = a/b` to a real (floating-point) number 
 
 Exponentiation of a real number `x` to a rational number `r = a/b` is `x^(a/b) = root(x^a, b)`, where `root(p, q)` is the `q`th root of `p`.
 
+Ordering of rational numbers: `a/b < c/d` if and only if `a * sign(b) * |d| < |b| * c * sign(d)`.
+
 Implement the following operations:
  - addition, subtraction, multiplication and division of two rational numbers,
  - absolute value, exponentiation of a given rational number to an integer power, exponentiation of a given rational number to a real (floating-point) power, exponentiation of a real number to a rational number.
+ - the ordering of rational numbers.
 
 Your implementation of rational numbers should always be reduced to lowest terms. For example, `4/4` should reduce to `1/1`, `30/60` should reduce to `1/2`, `12/8` should reduce to `3/2`, etc. To reduce a rational number `r = a/b`, divide `a` and `b` by the greatest common divisor (gcd) of `a` and `b`. So, for example, `gcd(12, 8) = 4`, so `r = 12/8` can be reduced to `(12/4)/(8/4) = 3/2`.
 


### PR DESCRIPTION
This is a fun one, because I can't think of any sensible way to represent this in JSON. Therefore the test data is described in a comment. Testing only specific order operations would require adding dozens, possibly hundreds, of tests to cover all cases, so I don't think that's a feasible way of adding it to the canonical data.

An example implementation can be found [on the Julia track](https://github.com/exercism/julia/blob/005c0042b25e861240fc18c7fd83eb0a4aeb0dc9/exercises/rational-numbers/runtests.jl#L103-L129).

---

This also raises the question: How are new optional test cases handled if they require an addition to the description?