### PR TITLE
change: add simplest test case

### DIFF
--- a/exercises/change/canonical-data.json
+++ b/exercises/change/canonical-data.json
@@ -7,83 +7,187 @@
   ],
   "cases": [
     {
+      "uuid": "d0ebd0e1-9d27-4609-a654-df5c0ba1d83a",
+      "description": "change for 1 cent",
+      "property": "findFewestCoins",
+      "input": {
+        "coins": [
+          1,
+          5,
+          10,
+          25
+        ],
+        "target": 1
+      },
+      "expected": [
+        1
+      ]
+    },
+    {
       "uuid": "36887bea-7f92-4a9c-b0cc-c0e886b3ecc8",
       "description": "single coin change",
       "property": "findFewestCoins",
       "input": {
-        "coins": [1, 5, 10, 25, 100],
+        "coins": [
+          1,
+          5,
+          10,
+          25,
+          100
+        ],
         "target": 25
       },
-      "expected": [25]
+      "expected": [
+        25
+      ]
     },
     {
       "uuid": "cef21ccc-0811-4e6e-af44-f011e7eab6c6",
       "description": "multiple coin change",
       "property": "findFewestCoins",
       "input": {
-        "coins": [1, 5, 10, 25, 100],
+        "coins": [
+          1,
+          5,
+          10,
+          25,
+          100
+        ],
         "target": 15
       },
-      "expected": [5, 10]
+      "expected": [
+        5,
+        10
+      ]
     },
     {
       "uuid": "d60952bc-0c1a-4571-bf0c-41be72690cb3",
       "description": "change with Lilliputian Coins",
       "property": "findFewestCoins",
       "input": {
-        "coins": [1, 4, 15, 20, 50],
+        "coins": [
+          1,
+          4,
+          15,
+          20,
+          50
+        ],
         "target": 23
       },
-      "expected": [4, 4, 15]
+      "expected": [
+        4,
+        4,
+        15
+      ]
     },
     {
       "uuid": "408390b9-fafa-4bb9-b608-ffe6036edb6c",
       "description": "change with Lower Elbonia Coins",
       "property": "findFewestCoins",
       "input": {
-        "coins": [1, 5, 10, 21, 25],
+        "coins": [
+          1,
+          5,
+          10,
+          21,
+          25
+        ],
         "target": 63
       },
-      "expected": [21, 21, 21]
+      "expected": [
+        21,
+        21,
+        21
+      ]
     },
     {
       "uuid": "7421a4cb-1c48-4bf9-99c7-7f049689132f",
       "description": "large target values",
       "property": "findFewestCoins",
       "input": {
-        "coins": [1, 2, 5, 10, 20, 50, 100],
+        "coins": [
+          1,
+          2,
+          5,
+          10,
+          20,
+          50,
+          100
+        ],
         "target": 999
       },
-      "expected": [   2,   2,   5,  20,  20
-                  ,  50, 100, 100, 100, 100
-                  , 100, 100, 100, 100, 100 ]
+      "expected": [
+        2,
+        2,
+        5,
+        20,
+        20,
+        50,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100
+      ]
     },
     {
       "uuid": "f79d2e9b-0ae3-4d6a-bb58-dc978b0dba28",
       "description": "possible change without unit coins available",
       "property": "findFewestCoins",
       "input": {
-        "coins": [2, 5, 10, 20, 50],
+        "coins": [
+          2,
+          5,
+          10,
+          20,
+          50
+        ],
         "target": 21
       },
-      "expected": [2, 2, 2, 5, 10]
+      "expected": [
+        2,
+        2,
+        2,
+        5,
+        10
+      ]
     },
     {
       "uuid": "9a166411-d35d-4f7f-a007-6724ac266178",
       "description": "another possible change without unit coins available",
       "property": "findFewestCoins",
       "input": {
-        "coins": [4, 5],
+        "coins": [
+          4,
+          5
+        ],
         "target": 27
       },
-      "expected": [4, 4, 4, 5, 5, 5]
+      "expected": [
+        4,
+        4,
+        4,
+        5,
+        5,
+        5
+      ]
     },
     {
       "uuid": "bbbcc154-e9e9-4209-a4db-dd6d81ec26bb",
       "description": "no coins make 0 change",
       "property": "findFewestCoins",
       "input": {
-        "coins": [1, 5, 10, 21, 25],
+        "coins": [
+          1,
+          5,
+          10,
+          21,
+          25
+        ],
         "target": 0
       },
       "expected": []
@@ -93,30 +197,46 @@
       "description": "error testing for change smaller than the smallest of coins",
       "property": "findFewestCoins",
       "input": {
-        "coins": [5, 10],
+        "coins": [
+          5,
+          10
+        ],
         "target": 3
       },
-      "expected": {"error": "can't make target with given coins"}
+      "expected": {
+        "error": "can't make target with given coins"
+      }
     },
     {
       "uuid": "3c43e3e4-63f9-46ac-9476-a67516e98f68",
       "description": "error if no combination can add up to target",
       "property": "findFewestCoins",
       "input": {
-        "coins": [5, 10],
+        "coins": [
+          5,
+          10
+        ],
         "target": 94
       },
-      "expected": {"error": "can't make target with given coins"}
+      "expected": {
+        "error": "can't make target with given coins"
+      }
     },
     {
       "uuid": "8fe1f076-9b2d-4f44-89fe-8a6ccd63c8f3",
       "description": "cannot find negative change values",
       "property": "findFewestCoins",
       "input": {
-        "coins": [1, 2, 5],
+        "coins": [
+          1,
+          2,
+          5
+        ],
         "target": -5
       },
-      "expected": {"error": "target can't be negative"}
+      "expected": {
+        "error": "target can't be negative"
+      }
     }
   ]
 }


### PR DESCRIPTION
In JavaScript we've had this testcase to kick-off the exercise, input and output, without needing to write an actual algorithm. Adding it here for completeness.