### PR TITLE
diffie-hellman: add immutability / purity test case

### DIFF
--- a/SCENARIOS.txt
+++ b/SCENARIOS.txt
@@ -1,5 +1,6 @@
 big-integer
 floating-point
+immutable
 library-test
 unicode
 input-validation

--- a/canonical-schema.json
+++ b/canonical-schema.json
@@ -117,7 +117,15 @@
       "scenario":
           { "description": "An identifier for a specific scenario (kebab-case)"
           , "type": "string"
-          , "enum": ["big-integer", "floating-point", "library-test", "unicode", "input-validation", "runtime-validation"]
+          , "enum":
+                [ "big-integer"
+                , "floating-point"
+                , "immutable"
+                , "library-test"
+                , "unicode"
+                , "input-validation"
+                , "runtime-validation"
+                ]
           },
 
       "scenarios":
@@ -154,5 +162,4 @@
           }
 
     }
-
-}
+  }

--- a/exercises/diffie-hellman/canonical-data.json
+++ b/exercises/diffie-hellman/canonical-data.json
@@ -1,18 +1,20 @@
 {
   "exercise": "diffie-hellman",
   "comments": [
-    "Optional tests to consider:",
-    "* Validation of parameters:",
-    "  Validate that `p`, `g` are valid.",
-    "  Validate that keys given as inputs are valid.",
-    "  Resources that show what happens if parameters are not validated:",
-    "  http://cryptopals.com/sets/5/challenges/34",
-    "  http://cryptopals.com/sets/5/challenges/35",
-    "* Large numbers:",
-    "  Although the calculations fundamentally do not require large numbers,",
-    "  this is a reasonable real-world use for them",
-    "  and it may be instructive to have an exercise on their use.",
-    "  Consult tracks with this exercise (such as the Go track) for possible inputs to use."
+    "Optional tests to consider:                                              ",
+    "                                                                         ",
+    "* Validation of parameters:                                              ",
+    "  - Validate that `p`, `g` are valid.                                    ",
+    "  - Validate that keys given as inputs are valid.                        ",
+    "  Resources that show what happens if parameters are not validated:      ",
+    "  http://cryptopals.com/sets/5/challenges/34                             ",
+    "  http://cryptopals.com/sets/5/challenges/35                             ",
+    "                                                                         ",
+    "* Large numbers:                                                         ",
+    "  Although the calculations fundamentally do not require large numbers,  ",
+    "  this is a reasonable real-world use for them and it may be instructive ",
+    "  to have an exercise on their use. Consult tracks with this exercise    ",
+    "  (such as the Go track) for possible inputs to use.                     "
   ],
   "cases": [
     {

--- a/exercises/diffie-hellman/canonical-data.json
+++ b/exercises/diffie-hellman/canonical-data.json
@@ -48,6 +48,26 @@
       "expected": 8
     },
     {
+      "uuid": "0d25f8d7-4897-4338-a033-2d3d7a9af688",
+      "description": "can calculate public key when given a different private key",
+      "comments": [
+        "As this test is intended to test the immutability / purity           ",
+        "of the underlying structure, when implemented, it should first get a ",
+        "public key from different values, for example from the test with     ",
+        "uuid (b4161d8e-53a1-4241-ae8f-48cc86527f22).                         "
+      ],
+      "property": "publicKey",
+      "input": {
+        "p": 23,
+        "g": 5,
+        "privateKey": 15
+      },
+      "expected": 19,
+      "scenarios": [
+        "immutable"
+      ]
+    },
+    {
       "uuid": "cd02ad45-3f52-4510-99cc-5161dad948a8",
       "description": "can calculate secret using other party's public key",
       "property": "secret",


### PR DESCRIPTION
JavaScript has a test case to test if the algorithm is side-effect free, or has the appearance that it is. 

- Tracks that have a functional implementation may test if running the same function twice in succession generates the same result (not this test case)
- Tracks that have an object-oriented approach may test if running the same method with different input generates the correct result (which it arguably wouldn't if p or g were mutated in the process)