### PR TITLE
list-ops: reimplement ambiguous tests

### DIFF
--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -280,18 +280,20 @@
       "description": "folds (reduces) the given list from the left with a function",
       "cases": [
         {
-          "uuid": "613b20b7-1873-4070-a3a6-70ae5f50d7cc",
+          "uuid": "36549237-f765-4a4c-bfd9-5d3a8f7b07d2",
+          "reimplements": "613b20b7-1873-4070-a3a6-70ae5f50d7cc",
           "description": "empty list",
           "property": "foldl",
           "input": {
             "list": [],
             "initial": 2,
-            "function": "(x, y) -> x * y"
+            "function": "(acc, el) -> el * acc"
           },
           "expected": 2
         },
         {
-          "uuid": "e56df3eb-9405-416a-b13a-aabb4c3b5194",
+          "uuid": "7a626a3c-03ec-42bc-9840-53f280e13067",
+          "reimplements": "e56df3eb-9405-416a-b13a-aabb4c3b5194",
           "description": "direction independent function applied to non-empty list",
           "property": "foldl",
           "input": {
@@ -302,23 +304,26 @@
               4
             ],
             "initial": 5,
-            "function": "(x, y) -> x + y"
+            "function": "(acc, el) -> el + acc"
           },
           "expected": 15
         },
         {
-          "uuid": "d2cf5644-aee1-4dfc-9b88-06896676fe27",
+          "uuid": "d7fcad99-e88e-40e1-a539-4c519681f390",
+          "reimplements": "d2cf5644-aee1-4dfc-9b88-06896676fe27",
           "description": "direction dependent function applied to non-empty list",
           "property": "foldl",
           "input": {
             "list": [
+              1,
               2,
-              5
+              3,
+              4
             ],
-            "initial": 5,
-            "function": "(x, y) -> x / y"
+            "initial": 24,
+            "function": "(acc, el) -> el / acc"
           },
-          "expected": 0
+          "expected": 64
         }
       ]
     },
@@ -326,18 +331,20 @@
       "description": "folds (reduces) the given list from the right with a function",
       "cases": [
         {
-          "uuid": "aeb576b9-118e-4a57-a451-db49fac20fdc",
+          "uuid": "17214edb-20ba-42fc-bda8-000a5ab525b0",
+          "reimplements": "aeb576b9-118e-4a57-a451-db49fac20fdc",
           "description": "empty list",
           "property": "foldr",
           "input": {
             "list": [],
             "initial": 2,
-            "function": "(x, y) -> x * y"
+            "function": "(acc, el) -> el * acc"
           },
           "expected": 2
         },
         {
-          "uuid": "c4b64e58-313e-4c47-9c68-7764964efb8e",
+          "uuid": "e1c64db7-9253-4a3d-a7c4-5273b9e2a1bd",
+          "reimplements": "c4b64e58-313e-4c47-9c68-7764964efb8e",
           "description": "direction independent function applied to non-empty list",
           "property": "foldr",
           "input": {
@@ -348,23 +355,26 @@
               4
             ],
             "initial": 5,
-            "function": "(x, y) -> x + y"
+            "function": "(acc, el) -> el + acc"
           },
           "expected": 15
         },
         {
-          "uuid": "be396a53-c074-4db3-8dd6-f7ed003cce7c",
+          "uuid": "8066003b-f2ff-437e-9103-66e6df474844",
+          "reimplements": "be396a53-c074-4db3-8dd6-f7ed003cce7c",
           "description": "direction dependent function applied to non-empty list",
           "property": "foldr",
           "input": {
             "list": [
+              1,
               2,
-              5
+              3,
+              4
             ],
-            "initial": 5,
-            "function": "(x, y) -> x / y"
+            "initial": 24,
+            "function": "(acc, el) -> el / acc"
           },
-          "expected": 2
+          "expected": 64
         }
       ]
     },

--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -283,8 +283,53 @@
       ],
       "cases": [
         {
+          "uuid": "613b20b7-1873-4070-a3a6-70ae5f50d7cc",
+          "description": "empty list",
+          "property": "foldl",
+          "input": {
+            "list": [],
+            "initial": 2,
+            "function": "(x, y) -> x * y"
+          },
+          "expected": 2
+        },
+        {
+          "uuid": "e56df3eb-9405-416a-b13a-aabb4c3b5194",
+          "description": "direction independent function applied to non-empty list",
+          "property": "foldl",
+          "input": {
+            "list": [
+              1,
+              2,
+              3,
+              4
+            ],
+            "initial": 5,
+            "function": "(x, y) -> x + y"
+          },
+          "expected": 15
+        },
+        {
+          "uuid": "d2cf5644-aee1-4dfc-9b88-06896676fe27",
+          "description": "direction dependent function applied to non-empty list",
+          "property": "foldl",
+          "input": {
+            "list": [
+              2,
+              5
+            ],
+            "initial": 5,
+            "function": "(x, y) -> x / y"
+          },
+          "expected": 0
+        },
+        {
           "uuid": "36549237-f765-4a4c-bfd9-5d3a8f7b07d2",
           "reimplements": "613b20b7-1873-4070-a3a6-70ae5f50d7cc",
+          "comments": [
+            "Reimplemented to remove ambiguity about the parameters of the    ",
+            "function input."
+          ],
           "description": "empty list",
           "property": "foldl",
           "input": {
@@ -297,6 +342,10 @@
         {
           "uuid": "7a626a3c-03ec-42bc-9840-53f280e13067",
           "reimplements": "e56df3eb-9405-416a-b13a-aabb4c3b5194",
+          "comments": [
+            "Reimplemented to remove ambiguity about the parameters of the    ",
+            "function input."
+          ],
           "description": "direction independent function applied to non-empty list",
           "property": "foldl",
           "input": {
@@ -314,6 +363,10 @@
         {
           "uuid": "d7fcad99-e88e-40e1-a539-4c519681f390",
           "reimplements": "d2cf5644-aee1-4dfc-9b88-06896676fe27",
+          "comments": [
+            "Reimplemented to remove ambiguity about the parameters of the    ",
+            "function input."
+          ],
           "description": "direction dependent function applied to non-empty list",
           "property": "foldl",
           "input": {
@@ -337,8 +390,53 @@
       ],
       "cases": [
         {
+          "uuid": "aeb576b9-118e-4a57-a451-db49fac20fdc",
+          "description": "empty list",
+          "property": "foldr",
+          "input": {
+            "list": [],
+            "initial": 2,
+            "function": "(x, y) -> x * y"
+          },
+          "expected": 2
+        },
+        {
+          "uuid": "c4b64e58-313e-4c47-9c68-7764964efb8e",
+          "description": "direction independent function applied to non-empty list",
+          "property": "foldr",
+          "input": {
+            "list": [
+              1,
+              2,
+              3,
+              4
+            ],
+            "initial": 5,
+            "function": "(x, y) -> x + y"
+          },
+          "expected": 15
+        },
+        {
+          "uuid": "be396a53-c074-4db3-8dd6-f7ed003cce7c",
+          "description": "direction dependent function applied to non-empty list",
+          "property": "foldr",
+          "input": {
+            "list": [
+              2,
+              5
+            ],
+            "initial": 5,
+            "function": "(x, y) -> x / y"
+          },
+          "expected": 2
+        },
+        {
           "uuid": "17214edb-20ba-42fc-bda8-000a5ab525b0",
           "reimplements": "aeb576b9-118e-4a57-a451-db49fac20fdc",
+          "comments": [
+            "Reimplemented to remove ambiguity about the parameters of the    ",
+            "function input."
+          ],
           "description": "empty list",
           "property": "foldr",
           "input": {
@@ -351,6 +449,10 @@
         {
           "uuid": "e1c64db7-9253-4a3d-a7c4-5273b9e2a1bd",
           "reimplements": "c4b64e58-313e-4c47-9c68-7764964efb8e",
+          "comments": [
+            "Reimplemented to remove ambiguity about the parameters of the    ",
+            "function input."
+          ],
           "description": "direction independent function applied to non-empty list",
           "property": "foldr",
           "input": {
@@ -368,6 +470,10 @@
         {
           "uuid": "8066003b-f2ff-437e-9103-66e6df474844",
           "reimplements": "be396a53-c074-4db3-8dd6-f7ed003cce7c",
+          "comments": [
+            "Reimplemented to remove ambiguity about the parameters of the    ",
+            "function input."
+          ],
           "description": "direction dependent function applied to non-empty list",
           "property": "foldr",
           "input": {

--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -25,29 +25,64 @@
           "property": "append",
           "input": {
             "list1": [],
-            "list2": [1, 2, 3, 4]
+            "list2": [
+              1,
+              2,
+              3,
+              4
+            ]
           },
-          "expected": [1, 2, 3, 4]
+          "expected": [
+            1,
+            2,
+            3,
+            4
+          ]
         },
         {
           "uuid": "e842efed-3bf6-4295-b371-4d67a4fdf19c",
           "description": "empty list to list",
           "property": "append",
           "input": {
-            "list1": [1, 2, 3, 4],
+            "list1": [
+              1,
+              2,
+              3,
+              4
+            ],
             "list2": []
           },
-          "expected": [1, 2, 3, 4]
+          "expected": [
+            1,
+            2,
+            3,
+            4
+          ]
         },
         {
           "uuid": "71dcf5eb-73ae-4a0e-b744-a52ee387922f",
           "description": "non-empty lists",
           "property": "append",
           "input": {
-            "list1": [1, 2],
-            "list2": [2, 3, 4, 5]
+            "list1": [
+              1,
+              2
+            ],
+            "list2": [
+              2,
+              3,
+              4,
+              5
+            ]
           },
-          "expected": [1, 2, 2, 3, 4, 5]
+          "expected": [
+            1,
+            2,
+            2,
+            3,
+            4,
+            5
+          ]
         }
       ]
     },
@@ -68,18 +103,79 @@
           "description": "list of lists",
           "property": "concat",
           "input": {
-            "lists": [[1, 2], [3], [], [4, 5, 6]]
+            "lists": [
+              [
+                1,
+                2
+              ],
+              [
+                3
+              ],
+              [],
+              [
+                4,
+                5,
+                6
+              ]
+            ]
           },
-          "expected": [1, 2, 3, 4, 5, 6]
+          "expected": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+          ]
         },
         {
           "uuid": "d6ecd72c-197f-40c3-89a4-aa1f45827e09",
           "description": "list of nested lists",
           "property": "concat",
           "input": {
-            "lists": [[[1], [2]], [[3]], [[]], [[4, 5, 6]]]
+            "lists": [
+              [
+                [
+                  1
+                ],
+                [
+                  2
+                ]
+              ],
+              [
+                [
+                  3
+                ]
+              ],
+              [
+                []
+              ],
+              [
+                [
+                  4,
+                  5,
+                  6
+                ]
+              ]
+            ]
           },
-          "expected": [[1], [2], [3], [], [4, 5, 6]]
+          "expected": [
+            [
+              1
+            ],
+            [
+              2
+            ],
+            [
+              3
+            ],
+            [],
+            [
+              4,
+              5,
+              6
+            ]
+          ]
         }
       ]
     },
@@ -101,10 +197,19 @@
           "description": "non-empty list",
           "property": "filter",
           "input": {
-            "list": [1, 2, 3, 5],
+            "list": [
+              1,
+              2,
+              3,
+              5
+            ],
             "function": "(x) -> x modulo 2 == 1"
           },
-          "expected": [1, 3, 5]
+          "expected": [
+            1,
+            3,
+            5
+          ]
         }
       ]
     },
@@ -125,7 +230,12 @@
           "description": "non-empty list",
           "property": "length",
           "input": {
-            "list": [1, 2, 3, 4]
+            "list": [
+              1,
+              2,
+              3,
+              4
+            ]
           },
           "expected": 4
         }
@@ -149,10 +259,20 @@
           "description": "non-empty list",
           "property": "map",
           "input": {
-            "list": [1, 3, 5, 7],
+            "list": [
+              1,
+              3,
+              5,
+              7
+            ],
             "function": "(x) -> x + 1"
           },
-          "expected": [2, 4, 6, 8]
+          "expected": [
+            2,
+            4,
+            6,
+            8
+          ]
         }
       ]
     },
@@ -175,7 +295,12 @@
           "description": "direction independent function applied to non-empty list",
           "property": "foldl",
           "input": {
-            "list": [1, 2, 3, 4],
+            "list": [
+              1,
+              2,
+              3,
+              4
+            ],
             "initial": 5,
             "function": "(x, y) -> x + y"
           },
@@ -186,7 +311,10 @@
           "description": "direction dependent function applied to non-empty list",
           "property": "foldl",
           "input": {
-            "list": [2, 5],
+            "list": [
+              2,
+              5
+            ],
             "initial": 5,
             "function": "(x, y) -> x / y"
           },
@@ -213,7 +341,12 @@
           "description": "direction independent function applied to non-empty list",
           "property": "foldr",
           "input": {
-            "list": [1, 2, 3, 4],
+            "list": [
+              1,
+              2,
+              3,
+              4
+            ],
             "initial": 5,
             "function": "(x, y) -> x + y"
           },
@@ -224,7 +357,10 @@
           "description": "direction dependent function applied to non-empty list",
           "property": "foldr",
           "input": {
-            "list": [2, 5],
+            "list": [
+              2,
+              5
+            ],
             "initial": 5,
             "function": "(x, y) -> x / y"
           },
@@ -249,18 +385,56 @@
           "description": "non-empty list",
           "property": "reverse",
           "input": {
-            "list": [1, 3, 5, 7]
+            "list": [
+              1,
+              3,
+              5,
+              7
+            ]
           },
-          "expected": [7, 5, 3, 1]
+          "expected": [
+            7,
+            5,
+            3,
+            1
+          ]
         },
         {
           "uuid": "40872990-b5b8-4cb8-9085-d91fc0d05d26",
           "description": "list of lists is not flattened",
           "property": "reverse",
           "input": {
-            "list": [[1, 2], [3], [], [4, 5, 6]]
+            "list": [
+              [
+                1,
+                2
+              ],
+              [
+                3
+              ],
+              [],
+              [
+                4,
+                5,
+                6
+              ]
+            ]
           },
-          "expected": [[4, 5, 6], [], [3], [1, 2]]
+          "expected": [
+            [
+              4,
+              5,
+              6
+            ],
+            [],
+            [
+              3
+            ],
+            [
+              1,
+              2
+            ]
+          ]
         }
       ]
     }

--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -278,6 +278,9 @@
     },
     {
       "description": "folds (reduces) the given list from the left with a function",
+      "comments": [
+        "For function: acc is the accumulator and el is the current element"
+      ],
       "cases": [
         {
           "uuid": "36549237-f765-4a4c-bfd9-5d3a8f7b07d2",
@@ -329,6 +332,9 @@
     },
     {
       "description": "folds (reduces) the given list from the right with a function",
+      "comments": [
+        "For function: acc is the accumulator and el is the current element"
+      ],
       "cases": [
         {
           "uuid": "17214edb-20ba-42fc-bda8-000a5ab525b0",

--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -159,7 +159,10 @@
     {
       "description": "folds (reduces) the given list from the left with a function",
       "comments": [
-        "For function: acc is the accumulator and el is the current element"
+        "For function: acc is the accumulator and el is the current element.  ",
+        "The order of the arguments (ie. acc, el or el, acc) should match the ",
+        "conventions common to the language of the track implementing this.   ",
+        "See https://github.com/exercism/problem-specifications/pull/1746#discussion_r548303995 for further advice."
       ],
       "cases": [
         {
@@ -254,7 +257,10 @@
     {
       "description": "folds (reduces) the given list from the right with a function",
       "comments": [
-        "For function: acc is the accumulator and el is the current element"
+        "For function: acc is the accumulator and el is the current element   ",
+        "The order of the arguments (ie. acc, el or el, acc) should match the ",
+        "conventions common to the language of the track implementing this.   ",
+        "See https://github.com/exercism/problem-specifications/pull/1746#discussion_r548303995 for further advice."
       ],
       "cases": [
         {

--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -25,64 +25,29 @@
           "property": "append",
           "input": {
             "list1": [],
-            "list2": [
-              1,
-              2,
-              3,
-              4
-            ]
+            "list2": [1, 2, 3, 4]
           },
-          "expected": [
-            1,
-            2,
-            3,
-            4
-          ]
+          "expected": [1, 2, 3, 4]
         },
         {
           "uuid": "e842efed-3bf6-4295-b371-4d67a4fdf19c",
           "description": "empty list to list",
           "property": "append",
           "input": {
-            "list1": [
-              1,
-              2,
-              3,
-              4
-            ],
+            "list1": [1, 2, 3, 4],
             "list2": []
           },
-          "expected": [
-            1,
-            2,
-            3,
-            4
-          ]
+          "expected": [1, 2, 3, 4]
         },
         {
           "uuid": "71dcf5eb-73ae-4a0e-b744-a52ee387922f",
           "description": "non-empty lists",
           "property": "append",
           "input": {
-            "list1": [
-              1,
-              2
-            ],
-            "list2": [
-              2,
-              3,
-              4,
-              5
-            ]
+            "list1": [1, 2],
+            "list2": [2, 3, 4, 5]
           },
-          "expected": [
-            1,
-            2,
-            2,
-            3,
-            4,
-            5
-          ]
+          "expected": [1, 2, 2, 3, 4, 5]
         }
       ]
     },
@@ -103,79 +68,18 @@
           "description": "list of lists",
           "property": "concat",
           "input": {
-            "lists": [
-              [
-                1,
-                2
-              ],
-              [
-                3
-              ],
-              [],
-              [
-                4,
-                5,
-                6
-              ]
-            ]
+            "lists": [[1, 2], [3], [], [4, 5, 6]]
           },
-          "expected": [
-            1,
-            2,
-            3,
-            4,
-            5,
-            6
-          ]
+          "expected": [1, 2, 3, 4, 5, 6]
         },
         {
           "uuid": "d6ecd72c-197f-40c3-89a4-aa1f45827e09",
           "description": "list of nested lists",
           "property": "concat",
           "input": {
-            "lists": [
-              [
-                [
-                  1
-                ],
-                [
-                  2
-                ]
-              ],
-              [
-                [
-                  3
-                ]
-              ],
-              [
-                []
-              ],
-              [
-                [
-                  4,
-                  5,
-                  6
-                ]
-              ]
-            ]
+            "lists": [[[1], [2]], [[3]], [[]], [[4, 5, 6]]]
           },
-          "expected": [
-            [
-              1
-            ],
-            [
-              2
-            ],
-            [
-              3
-            ],
-            [],
-            [
-              4,
-              5,
-              6
-            ]
-          ]
+          "expected": [[1], [2], [3], [], [4, 5, 6]]
         }
       ]
     },
@@ -197,19 +101,10 @@
           "description": "non-empty list",
           "property": "filter",
           "input": {
-            "list": [
-              1,
-              2,
-              3,
-              5
-            ],
+            "list": [1, 2, 3, 5],
             "function": "(x) -> x modulo 2 == 1"
           },
-          "expected": [
-            1,
-            3,
-            5
-          ]
+          "expected": [1, 3, 5]
         }
       ]
     },
@@ -230,12 +125,7 @@
           "description": "non-empty list",
           "property": "length",
           "input": {
-            "list": [
-              1,
-              2,
-              3,
-              4
-            ]
+            "list": [1, 2, 3, 4]
           },
           "expected": 4
         }
@@ -259,20 +149,10 @@
           "description": "non-empty list",
           "property": "map",
           "input": {
-            "list": [
-              1,
-              3,
-              5,
-              7
-            ],
+            "list": [1, 3, 5, 7],
             "function": "(x) -> x + 1"
           },
-          "expected": [
-            2,
-            4,
-            6,
-            8
-          ]
+          "expected": [2, 4, 6, 8]
         }
       ]
     },
@@ -298,12 +178,7 @@
           "description": "direction independent function applied to non-empty list",
           "property": "foldl",
           "input": {
-            "list": [
-              1,
-              2,
-              3,
-              4
-            ],
+            "list": [1, 2, 3, 4],
             "initial": 5,
             "function": "(x, y) -> x + y"
           },
@@ -312,12 +187,12 @@
         {
           "uuid": "d2cf5644-aee1-4dfc-9b88-06896676fe27",
           "description": "direction dependent function applied to non-empty list",
+          "comments": [
+            "Expects integer division (expects / to discard fractions).       "
+          ],
           "property": "foldl",
           "input": {
-            "list": [
-              2,
-              5
-            ],
+            "list": [2, 5],
             "initial": 5,
             "function": "(x, y) -> x / y"
           },
@@ -349,12 +224,7 @@
           "description": "direction independent function applied to non-empty list",
           "property": "foldl",
           "input": {
-            "list": [
-              1,
-              2,
-              3,
-              4
-            ],
+            "list": [1, 2, 3, 4],
             "initial": 5,
             "function": "(acc, el) -> el + acc"
           },
@@ -365,17 +235,15 @@
           "reimplements": "d2cf5644-aee1-4dfc-9b88-06896676fe27",
           "comments": [
             "Reimplemented to remove ambiguity about the parameters of the    ",
-            "function input."
+            "function input. Expects / to preserve fractions. Integer division",
+            "will not work here, since it would compute 1 / 24 = 0. Use the   ",
+            "original test values (d2cf5644-aee1-4dfc-9b88-06896676fe27) if   ",
+            "integer division is expected / required.                         "
           ],
           "description": "direction dependent function applied to non-empty list",
           "property": "foldl",
           "input": {
-            "list": [
-              1,
-              2,
-              3,
-              4
-            ],
+            "list": [1, 2, 3, 4],
             "initial": 24,
             "function": "(acc, el) -> el / acc"
           },
@@ -405,12 +273,7 @@
           "description": "direction independent function applied to non-empty list",
           "property": "foldr",
           "input": {
-            "list": [
-              1,
-              2,
-              3,
-              4
-            ],
+            "list": [1, 2, 3, 4],
             "initial": 5,
             "function": "(x, y) -> x + y"
           },
@@ -419,12 +282,12 @@
         {
           "uuid": "be396a53-c074-4db3-8dd6-f7ed003cce7c",
           "description": "direction dependent function applied to non-empty list",
+          "comments": [
+            "Expects integer division (expects / to discard fractions).       "
+          ],
           "property": "foldr",
           "input": {
-            "list": [
-              2,
-              5
-            ],
+            "list": [2, 5],
             "initial": 5,
             "function": "(x, y) -> x / y"
           },
@@ -456,12 +319,7 @@
           "description": "direction independent function applied to non-empty list",
           "property": "foldr",
           "input": {
-            "list": [
-              1,
-              2,
-              3,
-              4
-            ],
+            "list": [1, 2, 3, 4],
             "initial": 5,
             "function": "(acc, el) -> el + acc"
           },
@@ -472,21 +330,19 @@
           "reimplements": "be396a53-c074-4db3-8dd6-f7ed003cce7c",
           "comments": [
             "Reimplemented to remove ambiguity about the parameters of the    ",
-            "function input."
+            "function input. Expects / to preserve fractions. Integer division",
+            "will not work here, since it would compute 4 / 24 = 1 / 6. Use   ",
+            "the original test values (be396a53-c074-4db3-8dd6-f7ed003cce7c)  ",
+            "if integer division is expected / required."
           ],
           "description": "direction dependent function applied to non-empty list",
           "property": "foldr",
           "input": {
-            "list": [
-              1,
-              2,
-              3,
-              4
-            ],
+            "list": [1, 2, 3, 4],
             "initial": 24,
             "function": "(acc, el) -> el / acc"
           },
-          "expected": 64
+          "expected": 9
         }
       ]
     },
@@ -507,56 +363,18 @@
           "description": "non-empty list",
           "property": "reverse",
           "input": {
-            "list": [
-              1,
-              3,
-              5,
-              7
-            ]
+            "list": [1, 3, 5, 7]
           },
-          "expected": [
-            7,
-            5,
-            3,
-            1
-          ]
+          "expected": [7, 5, 3, 1]
         },
         {
           "uuid": "40872990-b5b8-4cb8-9085-d91fc0d05d26",
           "description": "list of lists is not flattened",
           "property": "reverse",
           "input": {
-            "list": [
-              [
-                1,
-                2
-              ],
-              [
-                3
-              ],
-              [],
-              [
-                4,
-                5,
-                6
-              ]
-            ]
+            "list": [[1, 2], [3], [], [4, 5, 6]]
           },
-          "expected": [
-            [
-              4,
-              5,
-              6
-            ],
-            [],
-            [
-              3
-            ],
-            [
-              1,
-              2
-            ]
-          ]
+          "expected": [[4, 5, 6], [], [3], [1, 2]]
         }
       ]
     }


### PR DESCRIPTION
The notation `(x, y) => x + y` for `foldl` and `foldr` is ambigious. Yes, there is a mathy standard for fold, but the fact is that this ordering is not consistent across languages, nor is it well known.

This attempts to make it completely un-ambigious what each parameter means, but since they _were_ ambiguous, it's technically a breaking change.