### PR TITLE
Add error scenario

### DIFF
--- a/SCENARIOS.txt
+++ b/SCENARIOS.txt
@@ -2,3 +2,4 @@ big-integer
 floating-point
 library-test
 unicode
+error

--- a/SCENARIOS.txt
+++ b/SCENARIOS.txt
@@ -2,4 +2,5 @@ big-integer
 floating-point
 library-test
 unicode
-error
+input-validation
+runtime-validation

--- a/canonical-schema.json
+++ b/canonical-schema.json
@@ -117,7 +117,7 @@
       "scenario":
           { "description": "An identifier for a specific scenario (kebab-case)"
           , "type": "string"
-          , "enum": ["big-integer", "floating-point", "library-test", "unicode"]
+          , "enum": ["big-integer", "floating-point", "library-test", "unicode", "input-validation", "runtime-validation"]
           },
 
       "scenarios":


### PR DESCRIPTION
When working with canonical data, I often found that one of the first criteria for me to decide whether I want a test case to be implemented is whether it does error handling. In some cases, error handling fits the exercise well, in others less so. While one _can_ figure this out by looking at the structure of the `expected` value, it might be convenient to also add a scenario to these error test cases to allow for easy filtering. Let me know what you think.