### PR TITLE
canonical-schema: Fix UUID regex pattern

### DIFF
--- a/canonical-schema.json
+++ b/canonical-schema.json
@@ -109,9 +109,9 @@
           },
 
       "uuid":
-          { "description": "A universally unique identifier in the v4 format"
+          { "description": "A version 4 UUID (compliant with RFC 4122) in the canonical textual representation"
           , "type"       : "string"
-          , "pattern"    : "^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$"
+          , "pattern"    : "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           },
 
       "scenario":


### PR DESCRIPTION
Commit cea02afb494a (#1676) added a UUID to each test case. However, the
regex pattern that it added to the canonical schema was too permissive,
meaning that CI would pass on a PR that added, for example, a version 1
UUID (see #1735).

Changes:
- Use `a-f` instead of `a-z`
- The third group must start with `4`.
- The fourth group must start with `8`, `9`, `a` or `b`.

I also tried to improve the description.

Pinging @SleeplessByte.

Note: The schema validation CI check is expected to fail until we merge https://github.com/exercism/problem-specifications/pull/1760 and rebase this PR on top.