### PR TITLE
grade-school: Change a UUID to be version 4

### DIFF
--- a/exercises/grade-school/canonical-data.json
+++ b/exercises/grade-school/canonical-data.json
@@ -15,7 +15,7 @@
             "expected": ["Aimee"]
         },
         {
-          "uuid": "dece43c8-3ba5-11eb-8fdf-7f8daeaeb5f2",
+          "uuid": "c125dab7-2a53-492f-a99a-56ad511940d8",
           "description": "A student can't be in two different grades",
           "property": "roster",
           "input": {


### PR DESCRIPTION
Commit 03529d08e743 (#1735) added a new test case for the `grade-school`
exercise, but the UUID added was version 1 rather than version 4. This
was not caught by CI because the regex in the schema validator was
too permissive (fixed by #1759).

Some reasons to prefer version 4 UUIDs:
- Version 4 is the right version for a fully random and unique
  identifer; we don't want to indicate anything about the machine that
  generated the UUID, and version 1 UUIDs have a timestamp and MAC
  address component.
- All of the other UUIDs currently in `problem-specifications` are valid
  version 4 UUIDs.
- `configlet uuid` generates a version 4 UUID.
- A reader familiar with the UUID specification (RFC 4122) might see a
  version 1 UUID and infer that the timestamp or MAC address component
  is useful, causing them to wonder why the others are version 4.
- A user who generates a version 1 UUID might unintentionally leak their
  MAC address.

See also:
- https://tools.ietf.org/html/rfc4122.html

Note: the CI check is expected to fail.
```
The following tests have been deleted illegally:
 - dece43c8-3ba5-11eb-8fdf-7f8daeaeb5f2
 ```

Ping @SleeplessByte.