### PR TITLE
Hamming: remove tests that don't make sense per 1761

### DIFF
--- a/exercises/hamming/canonical-data.json
+++ b/exercises/hamming/canonical-data.json
@@ -79,26 +79,6 @@
         "strand2": "AGTG"
       },
       "expected": {"error": "left and right strands must be of equal length"}
-    },
-    {
-      "uuid": "5dce058b-28d4-4ca7-aa64-adfe4e17784c",
-      "description": "disallow left empty strand",
-      "property": "distance",
-      "input": {
-        "strand1": "",
-        "strand2": "G"
-      },
-      "expected": {"error": "left strand must not be empty"}
-    },
-    {
-      "uuid": "38826d4b-16fb-4639-ac3e-ba027dec8b5f",
-      "description": "disallow right empty strand",
-      "property": "distance",
-      "input": {
-        "strand1": "G",
-        "strand2": ""
-      },
-      "expected": {"error": "right strand must not be empty"}
     }
   ]
 }

--- a/exercises/hamming/canonical-data.json
+++ b/exercises/hamming/canonical-data.json
@@ -79,6 +79,50 @@
         "strand2": "AGTG"
       },
       "expected": {"error": "left and right strands must be of equal length"}
+    },
+    {
+      "uuid": "5dce058b-28d4-4ca7-aa64-adfe4e17784c",
+      "description": "disallow left empty strand",
+      "property": "distance",
+      "input": {
+        "strand1": "",
+        "strand2": "G"
+      },
+      "expected": {"error": "left strand must not be empty"}
+    },
+    {
+      "uuid": "db92e77e-7c72-499d-8fe6-9354d2bfd504",
+      "description": "disallow left empty strand",
+      "comments": ["Normalises error messages"],
+      "reimplements": "5dce058b-28d4-4ca7-aa64-adfe4e17784c",
+      "property": "distance",
+      "input": {
+        "strand1": "",
+        "strand2": "G"
+      },
+      "expected": {"error": "left and right strands must be of equal length"}
+    },
+    {
+      "uuid": "38826d4b-16fb-4639-ac3e-ba027dec8b5f",
+      "description": "disallow right empty strand",
+      "property": "distance",
+      "input": {
+        "strand1": "G",
+        "strand2": ""
+      },
+      "expected": {"error": "right strand must not be empty"}
+    },
+    {
+      "uuid": "920cd6e3-18f4-4143-b6b8-74270bb8f8a3",
+      "description": "disallow right empty strand",
+      "comments": ["Normalises error messages"],
+      "reimplements": "38826d4b-16fb-4639-ac3e-ba027dec8b5f",
+      "property": "distance",
+      "input": {
+        "strand1": "G",
+        "strand2": ""
+      },
+      "expected": {"error": "left and right strands must be of equal length"}
     }
   ]
 }


### PR DESCRIPTION
fixes #1761 

I note that removing test cases does not show up as a change for the canonical data syncer. Is this an issue?