### PR TITLE
Bring markdown files in line with new heading spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# problem-specifications
+# Problem Specifications
 
 Shared metadata for Exercism exercises.
 

--- a/exercises/affine-cipher/description.md
+++ b/exercises/affine-cipher/description.md
@@ -8,14 +8,14 @@ its new numeric value. Although all monoalphabetic ciphers are weak,
 the affine cypher is much stronger than the atbash cipher,
 because it has many more keys.
 
-the encryption function is:
+The encryption function is:
 
   `E(x) = (ax + b) mod m`
   -  where `x` is the letter's index from 0 - length of alphabet - 1
   -  `m` is the length of the alphabet. For the roman alphabet `m == 26`.
   -  and `a` and `b` make the key
 
-the decryption function is:
+The decryption function is:
 
   `D(y) = a^-1(y - b) mod m`
   -  where `y` is the numeric value of an encrypted letter, ie. `y = E(x)`
@@ -45,7 +45,7 @@ Ciphertext is written out in groups of fixed length, the traditional group
 size being 5 letters, and punctuation is excluded. This is to make it
 harder to guess things based on word boundaries.
 
-## Examples
+## General Examples
 
  - Encoding `test` gives `ybty` with the key a=5 b=7
  - Decoding `ybty` gives `test` with the key a=5 b=7
@@ -56,7 +56,7 @@ harder to guess things based on word boundaries.
    - gives `Error: a and m must be coprime.`
    - because a and m are not relatively prime
 
-### Examples of finding a Modular Multiplicative Inverse (MMI)
+## Examples of finding a Modular Multiplicative Inverse (MMI)
 
   - simple example:
     - `9 mod 26 = 9`

--- a/exercises/etl/description.md
+++ b/exercises/etl/description.md
@@ -1,6 +1,6 @@
 We are going to do the `Transform` step of an Extract-Transform-Load.
 
-### ETL
+## ETL
 
 Extract-Transform-Load (ETL) is a fancy way of saying, "We have some crufty, legacy data over in this system, and now we need it in this shiny new system over here, so
 we're going to migrate this."
@@ -9,7 +9,7 @@ we're going to migrate this."
 once." That's then typically followed by much forehead slapping and
 moaning about how stupid we could possibly be.)
 
-### The goal
+## The goal
 
 We're going to extract some Scrabble scores from a legacy system.
 
@@ -37,7 +37,7 @@ input letters:
 Your mission, should you choose to accept it, is to transform the legacy data
 format to the shiny new format.
 
-### Notes
+## Notes
 
 A final note about scoring, Scrabble is played around the world in a
 variety of languages, each with its own unique scoring table. For

--- a/exercises/grep/description.md
+++ b/exercises/grep/description.md
@@ -31,7 +31,7 @@ hello
 hello again
 ```
 
-### Flags
+## Flags
 
 As said earlier, the `grep` command should also support the following flags:
 

--- a/exercises/rest-api/description.md
+++ b/exercises/rest-api/description.md
@@ -4,9 +4,9 @@ Four roommates have a habit of borrowing money from each other frequently, and h
 
 Your task is to implement a simple [RESTful API](https://en.wikipedia.org/wiki/Representational_state_transfer) that receives [IOU](https://en.wikipedia.org/wiki/IOU)s as POST requests, and can deliver specified summary information via GET requests.
 
-### API Specification
+## API Specification
 
-#### User object
+### User object
 ```json
 {
   "name": "Adam",
@@ -23,7 +23,7 @@ Your task is to implement a simple [RESTful API](https://en.wikipedia.org/wiki/R
 }
 ```
 
-#### Methods
+### Methods
 
 | Description | HTTP Method | URL | Payload Format | Response w/o Payload | Response w/ Payload |
 | --- | --- | --- | --- | --- | --- |
@@ -31,7 +31,7 @@ Your task is to implement a simple [RESTful API](https://en.wikipedia.org/wiki/R
 | Create user | POST | /add | `{"user":<name of new user (unique)>}` | N/A | `<User object for new user>` |
 | Create IOU | POST | /iou | `{"lender":<name of lender>,"borrower":<name of borrower>,"amount":5.25}` | N/A | `{"users":<updated User objects for <lender> and <borrower> (sorted by name)>}` |
 
-### Other Resources:
+## Other Resources:
 - https://restfulapi.net/
 - Example RESTful APIs
   - [GitHub](https://developer.github.com/v3/)

--- a/exercises/spiral-matrix/description.md
+++ b/exercises/spiral-matrix/description.md
@@ -13,7 +13,7 @@ like these examples:
 7 6 5
 ```
 
-**Spiral matrix of size 4:*
+### Spiral matrix of size 4
 
 ```text
  1  2  3 4

--- a/exercises/spiral-matrix/description.md
+++ b/exercises/spiral-matrix/description.md
@@ -4,7 +4,8 @@ The matrix should be filled with natural numbers, starting from 1
 in the top-left corner, increasing in an inward, clockwise spiral order,
 like these examples:
 
-**Spiral matrix of size 3:**
+## Examples
+### Spiral matrix of size 3
 
 ```text
 1 2 3

--- a/exercises/spiral-matrix/description.md
+++ b/exercises/spiral-matrix/description.md
@@ -4,7 +4,7 @@ The matrix should be filled with natural numbers, starting from 1
 in the top-left corner, increasing in an inward, clockwise spiral order,
 like these examples:
 
-###### Spiral matrix of size 3
+**Spiral matrix of size 3:**
 
 ```text
 1 2 3
@@ -12,7 +12,7 @@ like these examples:
 7 6 5
 ```
 
-###### Spiral matrix of size 4
+**Spiral matrix of size 4:*
 
 ```text
  1  2  3 4

--- a/exercises/tournament/description.md
+++ b/exercises/tournament/description.md
@@ -23,9 +23,7 @@ A win earns a team 3 points. A draw earns 1. A loss earns 0.
 
 The outcome should be ordered by points, descending. In case of a tie, teams are ordered alphabetically.
 
-###
-
-Input
+## Input
 
 Your tallying program will receive input that looks like:
 
@@ -38,13 +36,13 @@ Blithering Badgers;Devastating Donkeys;loss
 Allegoric Alaskans;Courageous Californians;win
 ```
 
-The result of the match refers to the first team listed. So this line
+The result of the match refers to the first team listed. So this line:
 
 ```text
 Allegoric Alaskans;Blithering Badgers;win
 ```
 
-Means that the Allegoric Alaskans beat the Blithering Badgers.
+means that the Allegoric Alaskans beat the Blithering Badgers.
 
 This line:
 
@@ -52,7 +50,7 @@ This line:
 Courageous Californians;Blithering Badgers;loss
 ```
 
-Means that the Blithering Badgers beat the Courageous Californians.
+means that the Blithering Badgers beat the Courageous Californians.
 
 And this line:
 
@@ -60,4 +58,4 @@ And this line:
 Devastating Donkeys;Courageous Californians;draw
 ```
 
-Means that the Devastating Donkeys and Courageous Californians tied.
+means that the Devastating Donkeys and Courageous Californians tied.


### PR DESCRIPTION
This brings markdown files in line with our new spec (https://github.com/exercism/docs/pull/38) in terms of secondary headers.

@ErikSchierboom will script-PR a `#` header to all exercises seperately.