### PR TITLE
anagram: reimplement test case containing 'master'

### DIFF
--- a/exercises/anagram/canonical-data.json
+++ b/exercises/anagram/canonical-data.json
@@ -22,6 +22,20 @@
       "expected": ["stream", "maters"]
     },
     {
+      "uuid": "03eb9bbe-8906-4ea0-84fa-ffe711b52c8b",
+      "reimplements": "b3cca662-f50a-489e-ae10-ab8290a09bdc",
+      "comments": [
+        "Reimplemented to be consistent about removing references to 'master'"
+      ],
+      "description": "detects two anagrams",
+      "property": "findAnagrams",
+      "input": {
+        "subject": "solemn",
+        "candidates": ["lemons", "cherry", "melons"]
+      },
+      "expected": ["lemons", "melons"]
+    },
+    {
       "uuid": "a27558ee-9ba0-4552-96b1-ecf665b06556",
       "description": "does not detect anagram subsets",
       "property": "findAnagrams",


### PR DESCRIPTION

Exercism has now renamed the main branch of every repo from `master` to
`main`, which makes it logically consistent to also remove references to
`master` in exercise tests. The only one was in the `anagram` exercise:

https://github.com/exercism/problem-specifications/blob/ef9e1e17c84721ee6e9d5a65c8dd3ba2122eac91/exercises/anagram/canonical-data.json#L14-L23 

This commit adds a test case that tries to stay close to the one that it
reimplements, maintaining these properties:
- the `subject` is a six-letter word
- the `candidates` are three six-letter words
- the first and last `candidates` as anagrams
- the non-anagram has one letter in common with the `subject`

Minor hypothetical benefit: if all tracks magically changed to use this test
case it would make it easier to search for 'master' Exercism-wide and find
outdated links (which do redirect, however).

Closes: #1770