### PR TITLE
hamming: normalize error messages

### DIFF
--- a/exercises/hamming/canonical-data.json
+++ b/exercises/hamming/canonical-data.json
@@ -71,6 +71,18 @@
       "expected": {"error": "left and right strands must be of equal length"}
     },
     {
+      "uuid": "b9228bb1-465f-4141-b40f-1f99812de5a8",
+      "description": "disallow first strand longer",
+      "comments": ["Normalises error messages"],
+      "reimplements": "919f8ef0-b767-4d1b-8516-6379d07fcb28",
+      "property": "distance",
+      "input": {
+        "strand1": "AATG",
+        "strand2": "AAA"
+      },
+      "expected": {"error": "strands must be of equal length"}
+    },
+    {
       "uuid": "8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e",
       "description": "disallow second strand longer",
       "property": "distance",
@@ -79,6 +91,18 @@
         "strand2": "AGTG"
       },
       "expected": {"error": "left and right strands must be of equal length"}
+    },
+    {
+      "uuid": "dab38838-26bb-4fff-acbe-3b0a9bfeba2d",
+      "description": "disallow second strand longer",
+      "comments": ["Normalises error messages"],
+      "reimplements": "8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e",
+      "property": "distance",
+      "input": {
+        "strand1": "ATA",
+        "strand2": "AGTG"
+      },
+      "expected": {"error": "strands must be of equal length"}
     },
     {
       "uuid": "5dce058b-28d4-4ca7-aa64-adfe4e17784c",
@@ -103,6 +127,18 @@
       "expected": {"error": "left and right strands must be of equal length"}
     },
     {
+      "uuid": "b764d47c-83ff-4de2-ab10-6cfe4b15c0f3",
+      "description": "disallow empty first strand",
+      "comments": ["Normalises error messages"],
+      "reimplements": "db92e77e-7c72-499d-8fe6-9354d2bfd504",
+      "property": "distance",
+      "input": {
+        "strand1": "",
+        "strand2": "G"
+      },
+      "expected": {"error": "strands must be of equal length"}
+    },
+    {
       "uuid": "38826d4b-16fb-4639-ac3e-ba027dec8b5f",
       "description": "disallow right empty strand",
       "property": "distance",
@@ -123,6 +159,18 @@
         "strand2": ""
       },
       "expected": {"error": "left and right strands must be of equal length"}
+    },
+    {
+      "uuid": "9ab9262f-3521-4191-81f5-0ed184a5aa89",
+      "description": "disallow empty second strand",
+      "comments": ["Normalises error messages"],
+      "reimplements": "920cd6e3-18f4-4143-b6b8-74270bb8f8a3",
+      "property": "distance",
+      "input": {
+        "strand1": "G",
+        "strand2": ""
+      },
+      "expected": {"error": "strands must be of equal length"}
     }
   ]
 }


### PR DESCRIPTION
I realised that #1762 does not normalize the error messages, it just makes them the same

Additionally, took the opportunity to normalize descriptions to use first strand/second strand, rather than a mix of that and left strand/right strand