### PR TITLE
isogram: add test case with repeated letters and two hyphens

### DIFF
--- a/exercises/isogram/canonical-data.json
+++ b/exercises/isogram/canonical-data.json
@@ -129,7 +129,8 @@
         },
         {
           "uuid": "0d0b8644-0a1e-4a31-a432-2b3ee270d847",
-          "description": "word with duplicated character with two hyphens",
+          "description": "word with duplicated character and with two hyphens",
+          "comments": ["This test aims to catch buggy implementations that check for duplicate spaces or hyphens."],
           "property": "isIsogram",
           "input": {
             "phrase": "up-to-date"

--- a/exercises/isogram/canonical-data.json
+++ b/exercises/isogram/canonical-data.json
@@ -126,6 +126,15 @@
             "phrase": "angola"
           },
           "expected": false
+        },
+        {
+          "uuid": "0d0b8644-0a1e-4a31-a432-2b3ee270d847",
+          "description": "word with duplicated character with two hyphens",
+          "property": "isIsogram",
+          "input": {
+            "phrase": "up-to-date"
+          },
+          "expected": false
         }
       ]
     }


### PR DESCRIPTION
This test case was inspired by a solution I saw on the Go track that passes the tests but has a bug. This new test case makes the tests fails for that bug. The solution goes like this:

```go
func IsIsogram(inp string) bool {
	input := strings.ToLower(inp)

	dict := map[rune]int{}

	for _, r := range input {
		_, found := dict[r]
		if found {
			if r == '-' || r == ' ' {
				break
			}
			return false
		} else {
			dict[r] = 0
		}
	}

	return true
}
```

Here the student is using a map as a set to keep track of duplicates, which is standard for this exercise. However they are breaking early if the character is `'-'` or `' '` and is a duplicate, in which case they return `true`. The problem with this solution happens if the string has two or more hyphens (or two spaces) and a character after the second hyphen (or space) makes the word not be a isogram. They effectively stop checking the rest of the string early, when they should continue. This new test catches that and fails.
