### PR TITLE
Remove unneeded nesting

### DIFF
--- a/exercises/acronym/canonical-data.json
+++ b/exercises/acronym/canonical-data.json
@@ -2,90 +2,85 @@
   "exercise": "acronym",
   "cases": [
     {
-      "description": "Abbreviate a phrase",
-      "cases": [
-        {
-          "uuid": "1e22cceb-c5e4-4562-9afe-aef07ad1eaf4",
-          "description": "basic",
-          "property": "abbreviate",
-          "input": {
-            "phrase": "Portable Network Graphics"
-          },
-          "expected": "PNG"
-        },
-        {
-          "uuid": "79ae3889-a5c0-4b01-baf0-232d31180c08",
-          "description": "lowercase words",
-          "property": "abbreviate",
-          "input": {
-            "phrase": "Ruby on Rails"
-          },
-          "expected": "ROR"
-        },
-        {
-          "uuid": "ec7000a7-3931-4a17-890e-33ca2073a548",
-          "description": "punctuation",
-          "property": "abbreviate",
-          "input": {
-            "phrase": "First In, First Out"
-          },
-          "expected": "FIFO"
-        },
-        {
-          "uuid": "32dd261c-0c92-469a-9c5c-b192e94a63b0",
-          "description": "all caps word",
-          "property": "abbreviate",
-          "input": {
-            "phrase": "GNU Image Manipulation Program"
-          },
-          "expected": "GIMP"
-        },
-        {
-          "uuid": "ae2ac9fa-a606-4d05-8244-3bcc4659c1d4",
-          "description": "punctuation without whitespace",
-          "property": "abbreviate",
-          "input": {
-            "phrase": "Complementary metal-oxide semiconductor"
-          },
-          "expected": "CMOS"
-        },
-        {
-          "uuid": "0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9",
-          "description": "very long abbreviation",
-          "property": "abbreviate",
-          "input": {
-            "phrase": "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me"
-          },
-          "expected": "ROTFLSHTMDCOALM"
-        },
-        {
-          "uuid": "6a078f49-c68d-4b7b-89af-33a1a98c28cc",
-          "description": "consecutive delimiters",
-          "property": "abbreviate",
-          "input": {
-            "phrase": "Something - I made up from thin air"
-          },
-          "expected": "SIMUFTA"
-        },
-        {
-          "uuid": "5118b4b1-4572-434c-8d57-5b762e57973e",
-          "description": "apostrophes",
-          "property": "abbreviate",
-          "input": {
-            "phrase": "Halley's Comet"
-          },
-          "expected": "HC"
-        },
-        {
-          "uuid": "adc12eab-ec2d-414f-b48c-66a4fc06cdef",
-          "description": "underscore emphasis",
-          "property": "abbreviate",
-          "input": {
-            "phrase": "The Road _Not_ Taken"
-          },
-          "expected": "TRNT"
-        }
-      ]
+      "uuid": "1e22cceb-c5e4-4562-9afe-aef07ad1eaf4",
+      "description": "basic",
+      "property": "abbreviate",
+      "input": {
+        "phrase": "Portable Network Graphics"
+      },
+      "expected": "PNG"
+    },
+    {
+      "uuid": "79ae3889-a5c0-4b01-baf0-232d31180c08",
+      "description": "lowercase words",
+      "property": "abbreviate",
+      "input": {
+        "phrase": "Ruby on Rails"
+      },
+      "expected": "ROR"
+    },
+    {
+      "uuid": "ec7000a7-3931-4a17-890e-33ca2073a548",
+      "description": "punctuation",
+      "property": "abbreviate",
+      "input": {
+        "phrase": "First In, First Out"
+      },
+      "expected": "FIFO"
+    },
+    {
+      "uuid": "32dd261c-0c92-469a-9c5c-b192e94a63b0",
+      "description": "all caps word",
+      "property": "abbreviate",
+      "input": {
+        "phrase": "GNU Image Manipulation Program"
+      },
+      "expected": "GIMP"
+    },
+    {
+      "uuid": "ae2ac9fa-a606-4d05-8244-3bcc4659c1d4",
+      "description": "punctuation without whitespace",
+      "property": "abbreviate",
+      "input": {
+        "phrase": "Complementary metal-oxide semiconductor"
+      },
+      "expected": "CMOS"
+    },
+    {
+      "uuid": "0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9",
+      "description": "very long abbreviation",
+      "property": "abbreviate",
+      "input": {
+        "phrase": "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me"
+      },
+      "expected": "ROTFLSHTMDCOALM"
+    },
+    {
+      "uuid": "6a078f49-c68d-4b7b-89af-33a1a98c28cc",
+      "description": "consecutive delimiters",
+      "property": "abbreviate",
+      "input": {
+        "phrase": "Something - I made up from thin air"
+      },
+      "expected": "SIMUFTA"
+    },
+    {
+      "uuid": "5118b4b1-4572-434c-8d57-5b762e57973e",
+      "description": "apostrophes",
+      "property": "abbreviate",
+      "input": {
+        "phrase": "Halley's Comet"
+      },
+      "expected": "HC"
+    },
+    {
+      "uuid": "adc12eab-ec2d-414f-b48c-66a4fc06cdef",
+      "description": "underscore emphasis",
+      "property": "abbreviate",
+      "input": {
+        "phrase": "The Road _Not_ Taken"
+      },
+      "expected": "TRNT"
     }
   ]
 }

--- a/exercises/alphametics/canonical-data.json
+++ b/exercises/alphametics/canonical-data.json
@@ -2,158 +2,153 @@
   "exercise": "alphametics",
   "cases": [
     {
-      "description": "Solve the alphametics puzzle",
-      "cases": [
-        {
-          "uuid": "e0c08b07-9028-4d5f-91e1-d178fead8e1a",
-          "description": "puzzle with three letters",
-          "property": "solve",
-          "input": {
-            "puzzle": "I + BB == ILL"
-          },
-          "expected": {
-            "I": 1,
-            "B": 9,
-            "L": 0
-          }
-        },
-        {
-          "uuid": "a504ee41-cb92-4ec2-9f11-c37e95ab3f25",
-          "description": "solution must have unique value for each letter",
-          "property": "solve",
-          "input": {
-            "puzzle": "A == B"
-          },
-          "expected": null
-        },
-        {
-          "uuid": "4e3b81d2-be7b-4c5c-9a80-cd72bc6d465a",
-          "description": "leading zero solution is invalid",
-          "property": "solve",
-          "input": {
-            "puzzle": "ACA + DD == BD"
-          },
-          "expected": null
-        },
-        {
-          "uuid": "8a3e3168-d1ee-4df7-94c7-b9c54845ac3a",
-          "description": "puzzle with two digits final carry",
-          "property": "solve",
-          "input": {
-            "puzzle": "A + A + A + A + A + A + A + A + A + A + A + B == BCC"
-          },
-          "expected": {
-            "A": 9,
-            "B": 1,
-            "C": 0
-          }
-        },
-        {
-          "uuid": "a9630645-15bd-48b6-a61e-d85c4021cc09",
-          "description": "puzzle with four letters",
-          "property": "solve",
-          "input": {
-            "puzzle": "AS + A == MOM"
-          },
-          "expected": {
-            "A": 9,
-            "S": 2,
-            "M": 1,
-            "O": 0
-          }
-        },
-        {
-          "uuid": "3d905a86-5a52-4e4e-bf80-8951535791bd",
-          "description": "puzzle with six letters",
-          "property": "solve",
-          "input": {
-            "puzzle": "NO + NO + TOO == LATE"
-          },
-          "expected": {
-            "N": 7,
-            "O": 4,
-            "T": 9,
-            "L": 1,
-            "A": 0,
-            "E": 2
-          }
-        },
-        {
-          "uuid": "4febca56-e7b7-4789-97b9-530d09ba95f0",
-          "description": "puzzle with seven letters",
-          "property": "solve",
-          "input": {
-            "puzzle": "HE + SEES + THE == LIGHT"
-          },
-          "expected": {
-            "E": 4,
-            "G": 2,
-            "H": 5,
-            "I": 0,
-            "L": 1,
-            "S": 9,
-            "T": 7
-          }
-        },
-        {
-          "uuid": "12125a75-7284-4f9a-a5fa-191471e0d44f",
-          "description": "puzzle with eight letters",
-          "property": "solve",
-          "input": {
-            "puzzle": "SEND + MORE == MONEY"
-          },
-          "expected": {
-            "S": 9,
-            "E": 5,
-            "N": 6,
-            "D": 7,
-            "M": 1,
-            "O": 0,
-            "R": 8,
-            "Y": 2
-          }
-        },
-        {
-          "uuid": "fb05955f-38dc-477a-a0b6-5ef78969fffa",
-          "description": "puzzle with ten letters",
-          "property": "solve",
-          "input": {
-            "puzzle": "AND + A + STRONG + OFFENSE + AS + A + GOOD == DEFENSE"
-          },
-          "expected": {
-            "A": 5,
-            "D": 3,
-            "E": 4,
-            "F": 7,
-            "G": 8,
-            "N": 0,
-            "O": 2,
-            "R": 1,
-            "S": 6,
-            "T": 9
-          }
-        },
-        {
-          "uuid": "9a101e81-9216-472b-b458-b513a7adacf7",
-          "description": "puzzle with ten letters and 199 addends",
-          "property": "solve",
-          "input": {
-            "puzzle": "THIS + A + FIRE + THEREFORE + FOR + ALL + HISTORIES + I + TELL + A + TALE + THAT + FALSIFIES + ITS + TITLE + TIS + A + LIE + THE + TALE + OF + THE + LAST + FIRE + HORSES + LATE + AFTER + THE + FIRST + FATHERS + FORESEE + THE + HORRORS + THE + LAST + FREE + TROLL + TERRIFIES + THE + HORSES + OF + FIRE + THE + TROLL + RESTS + AT + THE + HOLE + OF + LOSSES + IT + IS + THERE + THAT + SHE + STORES + ROLES + OF + LEATHERS + AFTER + SHE + SATISFIES + HER + HATE + OFF + THOSE + FEARS + A + TASTE + RISES + AS + SHE + HEARS + THE + LEAST + FAR + HORSE + THOSE + FAST + HORSES + THAT + FIRST + HEAR + THE + TROLL + FLEE + OFF + TO + THE + FOREST + THE + HORSES + THAT + ALERTS + RAISE + THE + STARES + OF + THE + OTHERS + AS + THE + TROLL + ASSAILS + AT + THE + TOTAL + SHIFT + HER + TEETH + TEAR + HOOF + OFF + TORSO + AS + THE + LAST + HORSE + FORFEITS + ITS + LIFE + THE + FIRST + FATHERS + HEAR + OF + THE + HORRORS + THEIR + FEARS + THAT + THE + FIRES + FOR + THEIR + FEASTS + ARREST + AS + THE + FIRST + FATHERS + RESETTLE + THE + LAST + OF + THE + FIRE + HORSES + THE + LAST + TROLL + HARASSES + THE + FOREST + HEART + FREE + AT + LAST + OF + THE + LAST + TROLL + ALL + OFFER + THEIR + FIRE + HEAT + TO + THE + ASSISTERS + FAR + OFF + THE + TROLL + FASTS + ITS + LIFE + SHORTER + AS + STARS + RISE + THE + HORSES + REST + SAFE + AFTER + ALL + SHARE + HOT + FISH + AS + THEIR + AFFILIATES + TAILOR + A + ROOFS + FOR + THEIR + SAFE == FORTRESSES"
-          },
-          "expected": {
-             "A": 1,
-             "E": 0,
-             "F": 5,
-             "H": 8,
-             "I": 7,
-             "L": 2,
-             "O": 6,
-             "R": 3,
-             "S": 4,
-             "T": 9
-          }
-        }
-      ]
+      "uuid": "e0c08b07-9028-4d5f-91e1-d178fead8e1a",
+      "description": "puzzle with three letters",
+      "property": "solve",
+      "input": {
+        "puzzle": "I + BB == ILL"
+      },
+      "expected": {
+        "I": 1,
+        "B": 9,
+        "L": 0
+      }
+    },
+    {
+      "uuid": "a504ee41-cb92-4ec2-9f11-c37e95ab3f25",
+      "description": "solution must have unique value for each letter",
+      "property": "solve",
+      "input": {
+        "puzzle": "A == B"
+      },
+      "expected": null
+    },
+    {
+      "uuid": "4e3b81d2-be7b-4c5c-9a80-cd72bc6d465a",
+      "description": "leading zero solution is invalid",
+      "property": "solve",
+      "input": {
+        "puzzle": "ACA + DD == BD"
+      },
+      "expected": null
+    },
+    {
+      "uuid": "8a3e3168-d1ee-4df7-94c7-b9c54845ac3a",
+      "description": "puzzle with two digits final carry",
+      "property": "solve",
+      "input": {
+        "puzzle": "A + A + A + A + A + A + A + A + A + A + A + B == BCC"
+      },
+      "expected": {
+        "A": 9,
+        "B": 1,
+        "C": 0
+      }
+    },
+    {
+      "uuid": "a9630645-15bd-48b6-a61e-d85c4021cc09",
+      "description": "puzzle with four letters",
+      "property": "solve",
+      "input": {
+        "puzzle": "AS + A == MOM"
+      },
+      "expected": {
+        "A": 9,
+        "S": 2,
+        "M": 1,
+        "O": 0
+      }
+    },
+    {
+      "uuid": "3d905a86-5a52-4e4e-bf80-8951535791bd",
+      "description": "puzzle with six letters",
+      "property": "solve",
+      "input": {
+        "puzzle": "NO + NO + TOO == LATE"
+      },
+      "expected": {
+        "N": 7,
+        "O": 4,
+        "T": 9,
+        "L": 1,
+        "A": 0,
+        "E": 2
+      }
+    },
+    {
+      "uuid": "4febca56-e7b7-4789-97b9-530d09ba95f0",
+      "description": "puzzle with seven letters",
+      "property": "solve",
+      "input": {
+        "puzzle": "HE + SEES + THE == LIGHT"
+      },
+      "expected": {
+        "E": 4,
+        "G": 2,
+        "H": 5,
+        "I": 0,
+        "L": 1,
+        "S": 9,
+        "T": 7
+      }
+    },
+    {
+      "uuid": "12125a75-7284-4f9a-a5fa-191471e0d44f",
+      "description": "puzzle with eight letters",
+      "property": "solve",
+      "input": {
+        "puzzle": "SEND + MORE == MONEY"
+      },
+      "expected": {
+        "S": 9,
+        "E": 5,
+        "N": 6,
+        "D": 7,
+        "M": 1,
+        "O": 0,
+        "R": 8,
+        "Y": 2
+      }
+    },
+    {
+      "uuid": "fb05955f-38dc-477a-a0b6-5ef78969fffa",
+      "description": "puzzle with ten letters",
+      "property": "solve",
+      "input": {
+        "puzzle": "AND + A + STRONG + OFFENSE + AS + A + GOOD == DEFENSE"
+      },
+      "expected": {
+        "A": 5,
+        "D": 3,
+        "E": 4,
+        "F": 7,
+        "G": 8,
+        "N": 0,
+        "O": 2,
+        "R": 1,
+        "S": 6,
+        "T": 9
+      }
+    },
+    {
+      "uuid": "9a101e81-9216-472b-b458-b513a7adacf7",
+      "description": "puzzle with ten letters and 199 addends",
+      "property": "solve",
+      "input": {
+        "puzzle": "THIS + A + FIRE + THEREFORE + FOR + ALL + HISTORIES + I + TELL + A + TALE + THAT + FALSIFIES + ITS + TITLE + TIS + A + LIE + THE + TALE + OF + THE + LAST + FIRE + HORSES + LATE + AFTER + THE + FIRST + FATHERS + FORESEE + THE + HORRORS + THE + LAST + FREE + TROLL + TERRIFIES + THE + HORSES + OF + FIRE + THE + TROLL + RESTS + AT + THE + HOLE + OF + LOSSES + IT + IS + THERE + THAT + SHE + STORES + ROLES + OF + LEATHERS + AFTER + SHE + SATISFIES + HER + HATE + OFF + THOSE + FEARS + A + TASTE + RISES + AS + SHE + HEARS + THE + LEAST + FAR + HORSE + THOSE + FAST + HORSES + THAT + FIRST + HEAR + THE + TROLL + FLEE + OFF + TO + THE + FOREST + THE + HORSES + THAT + ALERTS + RAISE + THE + STARES + OF + THE + OTHERS + AS + THE + TROLL + ASSAILS + AT + THE + TOTAL + SHIFT + HER + TEETH + TEAR + HOOF + OFF + TORSO + AS + THE + LAST + HORSE + FORFEITS + ITS + LIFE + THE + FIRST + FATHERS + HEAR + OF + THE + HORRORS + THEIR + FEARS + THAT + THE + FIRES + FOR + THEIR + FEASTS + ARREST + AS + THE + FIRST + FATHERS + RESETTLE + THE + LAST + OF + THE + FIRE + HORSES + THE + LAST + TROLL + HARASSES + THE + FOREST + HEART + FREE + AT + LAST + OF + THE + LAST + TROLL + ALL + OFFER + THEIR + FIRE + HEAT + TO + THE + ASSISTERS + FAR + OFF + THE + TROLL + FASTS + ITS + LIFE + SHORTER + AS + STARS + RISE + THE + HORSES + REST + SAFE + AFTER + ALL + SHARE + HOT + FISH + AS + THEIR + AFFILIATES + TAILOR + A + ROOFS + FOR + THEIR + SAFE == FORTRESSES"
+      },
+      "expected": {
+          "A": 1,
+          "E": 0,
+          "F": 5,
+          "H": 8,
+          "I": 7,
+          "L": 2,
+          "O": 6,
+          "R": 3,
+          "S": 4,
+          "T": 9
+      }
     }
   ]
 }

--- a/exercises/book-store/canonical-data.json
+++ b/exercises/book-store/canonical-data.json
@@ -1,168 +1,163 @@
 {
   "exercise": "book-store",
+  "comments": [
+    "Calculate lowest price for a shopping basket containing books only from ",
+    "a single series.  There is no discount advantage for having more than ",
+    "one copy of any single book in a grouping.",
+    "implementors should use proper fixed-point or currency data types of the ",
+    "corresponding language and not float.",
+    "All 'expected' amounts are in cents."
+  ],
   "cases": [
     {
-      "description": "Return the total basket price after applying the best discount.",
-      "comments": [
-        "Calculate lowest price for a shopping basket containing books only from ",
-        "a single series.  There is no discount advantage for having more than ",
-        "one copy of any single book in a grouping.",
-        "implementors should use proper fixed-point or currency data types of the ",
-        "corresponding language and not float.",
-        "All 'expected' amounts are in cents."
-      ],
-      "cases": [
-        {
-         "uuid": "17146bd5-2e80-4557-ab4c-05632b6b0d01",
-         "property": "total",
-         "description": "Only a single book",
-         "comments": ["Suggested grouping, [[1]]."],
-         "input": {
-           "basket": [1]
-         },
-         "expected": 800
-        },
-        {
-         "uuid": "cc2de9ac-ff2a-4efd-b7c7-bfe0f43271ce",
-         "property": "total",
-         "description": "Two of the same book",
-         "comments": ["Suggested grouping, [[2],[2]]."],
-         "input": {
-           "basket": [2,2]
-         },
-         "expected": 1600
-        },
-        {
-         "uuid": "5a86eac0-45d2-46aa-bbf0-266b94393a1a",
-         "property": "total",
-         "description": "Empty basket",
-         "comments": ["Suggested grouping, []."],
-         "input": {
-           "basket": []
-         },
-         "expected": 0
-        },
-        {
-         "uuid": "158bd19a-3db4-4468-ae85-e0638a688990",
-         "property": "total",
-         "description": "Two different books",
-         "comments": ["Suggested grouping, [[1,2]]."],
-         "input": {
-           "basket": [1,2]
-         },
-         "expected": 1520
-        },
-        {
-         "uuid": "f3833f6b-9332-4a1f-ad98-6c3f8e30e163",
-         "property": "total",
-         "description": "Three different books",
-         "comments": ["Suggested grouping, [[1,2,3]]."],
-         "input": {
-           "basket": [1,2,3]
-         },
-         "expected": 2160
-        },
-        {
-         "uuid": "1951a1db-2fb6-4cd1-a69a-f691b6dd30a2",
-         "property": "total",
-         "description": "Four different books",
-         "comments": ["Suggested grouping, [[1,2,3,4]]."],
-         "input": {
-           "basket": [1,2,3,4]
-         },
-         "expected": 2560
-        },
-        {
-         "uuid": "d70f6682-3019-4c3f-aede-83c6a8c647a3",
-         "property": "total",
-         "description": "Five different books",
-         "comments": ["Suggested grouping, [[1,2,3,4,5]]."],
-         "input": {
-           "basket": [1,2,3,4,5]
-         },
-         "expected": 3000
-        },
-        {
-         "uuid": "78cacb57-911a-45f1-be52-2a5bd428c634",
-         "property": "total",
-         "description": "Two groups of four is cheaper than group of five plus group of three",
-         "comments": ["Suggested grouping, [[1,2,3,4],[1,2,3,5]]."],
-         "input": {
-           "basket": [1,1,2,2,3,3,4,5]
-         },
-         "expected": 5120
-        },
-        {
-         "uuid": "f808b5a4-e01f-4c0d-881f-f7b90d9739da",
-         "property": "total",
-         "description": "Two groups of four is cheaper than groups of five and three",
-         "comments": ["Suggested grouping, [[1,2,4,5],[1,3,4,5]]. This differs from the other 'two groups of four' test in that it will fail for solutions that add books to groups in the order in which they appear in the list."],
-         "input": {
-           "basket": [1,1,2,3,4,4,5,5]
-         },
-         "expected": 5120
-        },
-        {
-         "uuid": "fe96401c-5268-4be2-9d9e-19b76478007c",
-         "property": "total",
-         "description": "Group of four plus group of two is cheaper than two groups of three",
-         "comments": ["Suggested grouping, [[1,2,3,4],[1,2]]."],
-         "input": {
-           "basket": [1,1,2,2,3,4]
-         },
-         "expected": 4080
-        },
-        {
-         "uuid": "68ea9b78-10ad-420e-a766-836a501d3633",
-         "property": "total",
-         "description": "Two each of first 4 books and 1 copy each of rest",
-         "comments": ["Suggested grouping, [[1,2,3,4,5],[1,2,3,4]]."],
-         "input": {
-           "basket": [1,1,2,2,3,3,4,4,5]
-         },
-         "expected": 5560
-        },
-        {
-         "uuid": "c0a779d5-a40c-47ae-9828-a340e936b866",
-         "property": "total",
-         "description": "Two copies of each book",
-         "comments": ["Suggested grouping, [[1,2,3,4,5],[1,2,3,4,5]]."],
-         "input": {
-           "basket": [1,1,2,2,3,3,4,4,5,5]
-         },
-         "expected": 6000
-        },
-        {
-         "uuid": "18fd86fe-08f1-4b68-969b-392b8af20513",
-         "property": "total",
-         "description": "Three copies of first book and 2 each of remaining",
-         "comments": ["Suggested grouping, [[1,2,3,4,5],[1,2,3,4,5],[1]]."],
-         "input": {
-           "basket": [1,1,2,2,3,3,4,4,5,5,1]
-         },
-         "expected": 6800
-        },
-        {
-         "uuid": "0b19a24d-e4cf-4ec8-9db2-8899a41af0da",
-         "property": "total",
-         "description": "Three each of first 2 books and 2 each of remaining books",
-         "comments": ["Suggested grouping, [[1,2,3,4,5],[1,2,3,4,5],[1,2]]."],
-         "input": {
-           "basket": [1,1,2,2,3,3,4,4,5,5,1,2]
-         },
-         "expected": 7520
-        },
-        {
-         "uuid": "bb376344-4fb2-49ab-ab85-e38d8354a58d",
-         "property": "total",
-         "description": "Four groups of four are cheaper than two groups each of five and three",
-         "comments": ["Suggested grouping, [[1,2,3,4],[1,2,3,5],[1,2,3,4],[1,2,3,5]]."],
-         "input": {
-           "basket": [1,1,2,2,3,3,4,5,1,1,2,2,3,3,4,5]
-         },
-         "expected": 10240
-        }
-     ]
+      "uuid": "17146bd5-2e80-4557-ab4c-05632b6b0d01",
+      "property": "total",
+      "description": "Only a single book",
+      "comments": ["Suggested grouping, [[1]]."],
+      "input": {
+        "basket": [1]
+      },
+      "expected": 800
+    },
+    {
+      "uuid": "cc2de9ac-ff2a-4efd-b7c7-bfe0f43271ce",
+      "property": "total",
+      "description": "Two of the same book",
+      "comments": ["Suggested grouping, [[2],[2]]."],
+      "input": {
+        "basket": [2,2]
+      },
+      "expected": 1600
+    },
+    {
+      "uuid": "5a86eac0-45d2-46aa-bbf0-266b94393a1a",
+      "property": "total",
+      "description": "Empty basket",
+      "comments": ["Suggested grouping, []."],
+      "input": {
+        "basket": []
+      },
+      "expected": 0
+    },
+    {
+      "uuid": "158bd19a-3db4-4468-ae85-e0638a688990",
+      "property": "total",
+      "description": "Two different books",
+      "comments": ["Suggested grouping, [[1,2]]."],
+      "input": {
+        "basket": [1,2]
+      },
+      "expected": 1520
+    },
+    {
+      "uuid": "f3833f6b-9332-4a1f-ad98-6c3f8e30e163",
+      "property": "total",
+      "description": "Three different books",
+      "comments": ["Suggested grouping, [[1,2,3]]."],
+      "input": {
+        "basket": [1,2,3]
+      },
+      "expected": 2160
+    },
+    {
+      "uuid": "1951a1db-2fb6-4cd1-a69a-f691b6dd30a2",
+      "property": "total",
+      "description": "Four different books",
+      "comments": ["Suggested grouping, [[1,2,3,4]]."],
+      "input": {
+        "basket": [1,2,3,4]
+      },
+      "expected": 2560
+    },
+    {
+      "uuid": "d70f6682-3019-4c3f-aede-83c6a8c647a3",
+      "property": "total",
+      "description": "Five different books",
+      "comments": ["Suggested grouping, [[1,2,3,4,5]]."],
+      "input": {
+        "basket": [1,2,3,4,5]
+      },
+      "expected": 3000
+    },
+    {
+      "uuid": "78cacb57-911a-45f1-be52-2a5bd428c634",
+      "property": "total",
+      "description": "Two groups of four is cheaper than group of five plus group of three",
+      "comments": ["Suggested grouping, [[1,2,3,4],[1,2,3,5]]."],
+      "input": {
+        "basket": [1,1,2,2,3,3,4,5]
+      },
+      "expected": 5120
+    },
+    {
+      "uuid": "f808b5a4-e01f-4c0d-881f-f7b90d9739da",
+      "property": "total",
+      "description": "Two groups of four is cheaper than groups of five and three",
+      "comments": ["Suggested grouping, [[1,2,4,5],[1,3,4,5]]. This differs from the other 'two groups of four' test in that it will fail for solutions that add books to groups in the order in which they appear in the list."],
+      "input": {
+        "basket": [1,1,2,3,4,4,5,5]
+      },
+      "expected": 5120
+    },
+    {
+      "uuid": "fe96401c-5268-4be2-9d9e-19b76478007c",
+      "property": "total",
+      "description": "Group of four plus group of two is cheaper than two groups of three",
+      "comments": ["Suggested grouping, [[1,2,3,4],[1,2]]."],
+      "input": {
+        "basket": [1,1,2,2,3,4]
+      },
+      "expected": 4080
+    },
+    {
+      "uuid": "68ea9b78-10ad-420e-a766-836a501d3633",
+      "property": "total",
+      "description": "Two each of first 4 books and 1 copy each of rest",
+      "comments": ["Suggested grouping, [[1,2,3,4,5],[1,2,3,4]]."],
+      "input": {
+        "basket": [1,1,2,2,3,3,4,4,5]
+      },
+      "expected": 5560
+    },
+    {
+      "uuid": "c0a779d5-a40c-47ae-9828-a340e936b866",
+      "property": "total",
+      "description": "Two copies of each book",
+      "comments": ["Suggested grouping, [[1,2,3,4,5],[1,2,3,4,5]]."],
+      "input": {
+        "basket": [1,1,2,2,3,3,4,4,5,5]
+      },
+      "expected": 6000
+    },
+    {
+      "uuid": "18fd86fe-08f1-4b68-969b-392b8af20513",
+      "property": "total",
+      "description": "Three copies of first book and 2 each of remaining",
+      "comments": ["Suggested grouping, [[1,2,3,4,5],[1,2,3,4,5],[1]]."],
+      "input": {
+        "basket": [1,1,2,2,3,3,4,4,5,5,1]
+      },
+      "expected": 6800
+    },
+    {
+      "uuid": "0b19a24d-e4cf-4ec8-9db2-8899a41af0da",
+      "property": "total",
+      "description": "Three each of first 2 books and 2 each of remaining books",
+      "comments": ["Suggested grouping, [[1,2,3,4,5],[1,2,3,4,5],[1,2]]."],
+      "input": {
+        "basket": [1,1,2,2,3,3,4,4,5,5,1,2]
+      },
+      "expected": 7520
+    },
+    {
+      "uuid": "bb376344-4fb2-49ab-ab85-e38d8354a58d",
+      "property": "total",
+      "description": "Four groups of four are cheaper than two groups each of five and three",
+      "comments": ["Suggested grouping, [[1,2,3,4],[1,2,3,5],[1,2,3,4],[1,2,3,5]]."],
+      "input": {
+        "basket": [1,1,2,2,3,3,4,5,1,1,2,2,3,3,4,5]
+      },
+      "expected": 10240
     }
   ]
 }

--- a/exercises/etl/canonical-data.json
+++ b/exercises/etl/canonical-data.json
@@ -1,90 +1,85 @@
 {
   "exercise": "etl",
+  "comments": [
+    "Transforms a set of legacy Scrabble data stored as letters per score",
+    "to a set of data stored score per letter.",
+    "Note:  The expected input data for these tests should have",
+    "integer keys (not stringified numbers as shown in the JSON below",
+    "Unless the language prohibits that, please implement these tests",
+    "such that keys are integers. e.g. in JavaScript, it might look ",
+    "like `transform( { 1: ['A'] } );`"
+  ],
   "cases": [
     {
-      "comments": [
-        "Transforms a set of legacy Scrabble data stored as letters per score",
-        "to a set of data stored score per letter.",
-        "Note:  The expected input data for these tests should have",
-        "integer keys (not stringified numbers as shown in the JSON below",
-        "Unless the language prohibits that, please implement these tests",
-        "such that keys are integers. e.g. in JavaScript, it might look ",
-        "like `transform( { 1: ['A'] } );`"
-      ],
-      "description": "Transform legacy to new",
-      "cases": [
-        {
-          "uuid": "78a7a9f9-4490-4a47-8ee9-5a38bb47d28f",
-          "description": "single letter",
-          "property": "transform",
-          "input": {
-            "legacy": {
-              "1": ["A"]
-            }
-          },
-          "expected": {
-            "a": 1
-          }
-        },
-        {
-          "uuid": "60dbd000-451d-44c7-bdbb-97c73ac1f497",
-          "description": "single score with multiple letters",
-          "property": "transform",
-          "input": {
-            "legacy": {
-              "1": ["A", "E", "I", "O", "U"]
-            }
-          },
-          "expected": {
-            "a": 1,
-            "e": 1,
-            "i": 1,
-            "o": 1,
-            "u": 1
-          }
-        },
-        {
-          "uuid": "f5c5de0c-301f-4fdd-a0e5-df97d4214f54",
-          "description": "multiple scores with multiple letters",
-          "property": "transform",
-          "input": {
-            "legacy": {
-              "1": ["A", "E"],
-              "2": ["D", "G"]
-            }
-          },
-          "expected": {
-            "a": 1,
-            "d": 2,
-            "e": 1,
-            "g": 2
-          }
-        },
-        {
-          "uuid": "5db8ea89-ecb4-4dcd-902f-2b418cc87b9d",
-          "description": "multiple scores with differing numbers of letters",
-          "property": "transform",
-          "input": {
-            "legacy": {
-               "1": ["A", "E", "I", "O", "U", "L", "N", "R", "S", "T"],
-               "2": ["D", "G"],
-               "3": ["B", "C", "M", "P"],
-               "4": ["F", "H", "V", "W", "Y"],
-               "5": ["K"],
-               "8": ["J", "X"],
-              "10": ["Q", "Z"]
-            }
-          },
-          "expected": {
-            "a":  1, "b":  3, "c": 3, "d": 2, "e": 1,
-            "f":  4, "g":  2, "h": 4, "i": 1, "j": 8,
-            "k":  5, "l":  1, "m": 3, "n": 1, "o": 1,
-            "p":  3, "q": 10, "r": 1, "s": 1, "t": 1,
-            "u":  1, "v":  4, "w": 4, "x": 8, "y": 4,
-            "z": 10
-          }
+      "uuid": "78a7a9f9-4490-4a47-8ee9-5a38bb47d28f",
+      "description": "single letter",
+      "property": "transform",
+      "input": {
+        "legacy": {
+          "1": ["A"]
         }
-      ]
+      },
+      "expected": {
+        "a": 1
+      }
+    },
+    {
+      "uuid": "60dbd000-451d-44c7-bdbb-97c73ac1f497",
+      "description": "single score with multiple letters",
+      "property": "transform",
+      "input": {
+        "legacy": {
+          "1": ["A", "E", "I", "O", "U"]
+        }
+      },
+      "expected": {
+        "a": 1,
+        "e": 1,
+        "i": 1,
+        "o": 1,
+        "u": 1
+      }
+    },
+    {
+      "uuid": "f5c5de0c-301f-4fdd-a0e5-df97d4214f54",
+      "description": "multiple scores with multiple letters",
+      "property": "transform",
+      "input": {
+        "legacy": {
+          "1": ["A", "E"],
+          "2": ["D", "G"]
+        }
+      },
+      "expected": {
+        "a": 1,
+        "d": 2,
+        "e": 1,
+        "g": 2
+      }
+    },
+    {
+      "uuid": "5db8ea89-ecb4-4dcd-902f-2b418cc87b9d",
+      "description": "multiple scores with differing numbers of letters",
+      "property": "transform",
+      "input": {
+        "legacy": {
+            "1": ["A", "E", "I", "O", "U", "L", "N", "R", "S", "T"],
+            "2": ["D", "G"],
+            "3": ["B", "C", "M", "P"],
+            "4": ["F", "H", "V", "W", "Y"],
+            "5": ["K"],
+            "8": ["J", "X"],
+          "10": ["Q", "Z"]
+        }
+      },
+      "expected": {
+        "a":  1, "b":  3, "c": 3, "d": 2, "e": 1,
+        "f":  4, "g":  2, "h": 4, "i": 1, "j": 8,
+        "k":  5, "l":  1, "m": 3, "n": 1, "o": 1,
+        "p":  3, "q": 10, "r": 1, "s": 1, "t": 1,
+        "u":  1, "v":  4, "w": 4, "x": 8, "y": 4,
+        "z": 10
+      }
     }
   ]
 }

--- a/exercises/food-chain/canonical-data.json
+++ b/exercises/food-chain/canonical-data.json
@@ -12,224 +12,219 @@
   ],
   "cases": [
     {
-      "description": "Return specified verse or series of verses",
-      "cases": [
-        {
-          "uuid": "751dce68-9412-496e-b6e8-855998c56166",
-          "description": "fly",
-          "property": "recite",
-          "input": {
-            "startVerse": 1,
-            "endVerse": 1
-          },
-          "expected": [
-            "I know an old lady who swallowed a fly.",
-            "I don't know why she swallowed the fly. Perhaps she'll die."
-          ]
-        },
-        {
-          "uuid": "6c56f861-0c5e-4907-9a9d-b2efae389379",
-          "description": "spider",
-          "property": "recite",
-          "input": {
-            "startVerse": 2,
-            "endVerse": 2
-          },
-          "expected": [
-            "I know an old lady who swallowed a spider.",
-            "It wriggled and jiggled and tickled inside her.",
-            "She swallowed the spider to catch the fly.",
-            "I don't know why she swallowed the fly. Perhaps she'll die."
-          ]
-        },
-        {
-          "uuid": "3edf5f33-bef1-4e39-ae67-ca5eb79203fa",
-          "description": "bird",
-          "property": "recite",
-          "input": {
-            "startVerse": 3,
-            "endVerse": 3
-          },
-          "expected": [
-            "I know an old lady who swallowed a bird.",
-            "How absurd to swallow a bird!",
-            "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
-            "She swallowed the spider to catch the fly.",
-            "I don't know why she swallowed the fly. Perhaps she'll die."
-          ]
-        },
-        {
-          "uuid": "e866a758-e1ff-400e-9f35-f27f28cc288f",
-          "description": "cat",
-          "property": "recite",
-          "input": {
-            "startVerse": 4,
-            "endVerse": 4
-          },
-          "expected": [
-            "I know an old lady who swallowed a cat.",
-            "Imagine that, to swallow a cat!",
-            "She swallowed the cat to catch the bird.",
-            "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
-            "She swallowed the spider to catch the fly.",
-            "I don't know why she swallowed the fly. Perhaps she'll die."
-          ]
-        },
-        {
-          "uuid": "3f02c30e-496b-4b2a-8491-bc7e2953cafb",
-          "description": "dog",
-          "property": "recite",
-          "input": {
-            "startVerse": 5,
-            "endVerse": 5
-          },
-          "expected": [
-            "I know an old lady who swallowed a dog.",
-            "What a hog, to swallow a dog!",
-            "She swallowed the dog to catch the cat.",
-            "She swallowed the cat to catch the bird.",
-            "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
-            "She swallowed the spider to catch the fly.",
-            "I don't know why she swallowed the fly. Perhaps she'll die."
-          ]
-        },
-        {
-          "uuid": "4b3fd221-01ea-46e0-825b-5734634fbc59",
-          "description": "goat",
-          "property": "recite",
-          "input": {
-            "startVerse": 6,
-            "endVerse": 6
-          },
-          "expected": [
-            "I know an old lady who swallowed a goat.",
-            "Just opened her throat and swallowed a goat!",
-            "She swallowed the goat to catch the dog.",
-            "She swallowed the dog to catch the cat.",
-            "She swallowed the cat to catch the bird.",
-            "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
-            "She swallowed the spider to catch the fly.",
-            "I don't know why she swallowed the fly. Perhaps she'll die."
-          ]
-        },
-        {
-          "uuid": "1b707da9-7001-4fac-941f-22ad9c7a65d4",
-          "description": "cow",
-          "property": "recite",
-          "input": {
-            "startVerse": 7,
-            "endVerse": 7
-          },
-          "expected": [
-            "I know an old lady who swallowed a cow.",
-            "I don't know how she swallowed a cow!",
-            "She swallowed the cow to catch the goat.",
-            "She swallowed the goat to catch the dog.",
-            "She swallowed the dog to catch the cat.",
-            "She swallowed the cat to catch the bird.",
-            "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
-            "She swallowed the spider to catch the fly.",
-            "I don't know why she swallowed the fly. Perhaps she'll die."
-          ]
-        },
-        {
-          "uuid": "3cb10d46-ae4e-4d2c-9296-83c9ffc04cdc",
-          "description": "horse",
-          "property": "recite",
-          "input": {
-            "startVerse": 8,
-            "endVerse": 8
-          },
-          "expected": [
-            "I know an old lady who swallowed a horse.",
-            "She's dead, of course!"
-          ]
-        },
-        {
-          "uuid": "22b863d5-17e4-4d1e-93e4-617329a5c050",
-          "description": "multiple verses",
-          "property": "recite",
-          "input": {
-            "startVerse": 1,
-            "endVerse": 3
-          },
-          "expected": [
-            "I know an old lady who swallowed a fly.",
-            "I don't know why she swallowed the fly. Perhaps she'll die.",
-            "",
-            "I know an old lady who swallowed a spider.",
-            "It wriggled and jiggled and tickled inside her.",
-            "She swallowed the spider to catch the fly.",
-            "I don't know why she swallowed the fly. Perhaps she'll die.",
-            "",
-            "I know an old lady who swallowed a bird.",
-            "How absurd to swallow a bird!",
-            "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
-            "She swallowed the spider to catch the fly.",
-            "I don't know why she swallowed the fly. Perhaps she'll die."
-          ]
-        },
-        {
-          "uuid": "e626b32b-745c-4101-bcbd-3b13456893db",
-          "description": "full song",
-          "property": "recite",
-          "input": {
-            "startVerse": 1,
-            "endVerse": 8
-          },
-          "expected": [
-            "I know an old lady who swallowed a fly.",
-            "I don't know why she swallowed the fly. Perhaps she'll die.",
-            "",
-            "I know an old lady who swallowed a spider.",
-            "It wriggled and jiggled and tickled inside her.",
-            "She swallowed the spider to catch the fly.",
-            "I don't know why she swallowed the fly. Perhaps she'll die.",
-            "",
-            "I know an old lady who swallowed a bird.",
-            "How absurd to swallow a bird!",
-            "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
-            "She swallowed the spider to catch the fly.",
-            "I don't know why she swallowed the fly. Perhaps she'll die.",
-            "",
-            "I know an old lady who swallowed a cat.",
-            "Imagine that, to swallow a cat!",
-            "She swallowed the cat to catch the bird.",
-            "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
-            "She swallowed the spider to catch the fly.",
-            "I don't know why she swallowed the fly. Perhaps she'll die.",
-            "",
-            "I know an old lady who swallowed a dog.",
-            "What a hog, to swallow a dog!",
-            "She swallowed the dog to catch the cat.",
-            "She swallowed the cat to catch the bird.",
-            "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
-            "She swallowed the spider to catch the fly.",
-            "I don't know why she swallowed the fly. Perhaps she'll die.",
-            "",
-            "I know an old lady who swallowed a goat.",
-            "Just opened her throat and swallowed a goat!",
-            "She swallowed the goat to catch the dog.",
-            "She swallowed the dog to catch the cat.",
-            "She swallowed the cat to catch the bird.",
-            "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
-            "She swallowed the spider to catch the fly.",
-            "I don't know why she swallowed the fly. Perhaps she'll die.",
-            "",
-            "I know an old lady who swallowed a cow.",
-            "I don't know how she swallowed a cow!",
-            "She swallowed the cow to catch the goat.",
-            "She swallowed the goat to catch the dog.",
-            "She swallowed the dog to catch the cat.",
-            "She swallowed the cat to catch the bird.",
-            "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
-            "She swallowed the spider to catch the fly.",
-            "I don't know why she swallowed the fly. Perhaps she'll die.",
-            "",
-            "I know an old lady who swallowed a horse.",
-            "She's dead, of course!"
-          ]
-        }
+      "uuid": "751dce68-9412-496e-b6e8-855998c56166",
+      "description": "fly",
+      "property": "recite",
+      "input": {
+        "startVerse": 1,
+        "endVerse": 1
+      },
+      "expected": [
+        "I know an old lady who swallowed a fly.",
+        "I don't know why she swallowed the fly. Perhaps she'll die."
+      ]
+    },
+    {
+      "uuid": "6c56f861-0c5e-4907-9a9d-b2efae389379",
+      "description": "spider",
+      "property": "recite",
+      "input": {
+        "startVerse": 2,
+        "endVerse": 2
+      },
+      "expected": [
+        "I know an old lady who swallowed a spider.",
+        "It wriggled and jiggled and tickled inside her.",
+        "She swallowed the spider to catch the fly.",
+        "I don't know why she swallowed the fly. Perhaps she'll die."
+      ]
+    },
+    {
+      "uuid": "3edf5f33-bef1-4e39-ae67-ca5eb79203fa",
+      "description": "bird",
+      "property": "recite",
+      "input": {
+        "startVerse": 3,
+        "endVerse": 3
+      },
+      "expected": [
+        "I know an old lady who swallowed a bird.",
+        "How absurd to swallow a bird!",
+        "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+        "She swallowed the spider to catch the fly.",
+        "I don't know why she swallowed the fly. Perhaps she'll die."
+      ]
+    },
+    {
+      "uuid": "e866a758-e1ff-400e-9f35-f27f28cc288f",
+      "description": "cat",
+      "property": "recite",
+      "input": {
+        "startVerse": 4,
+        "endVerse": 4
+      },
+      "expected": [
+        "I know an old lady who swallowed a cat.",
+        "Imagine that, to swallow a cat!",
+        "She swallowed the cat to catch the bird.",
+        "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+        "She swallowed the spider to catch the fly.",
+        "I don't know why she swallowed the fly. Perhaps she'll die."
+      ]
+    },
+    {
+      "uuid": "3f02c30e-496b-4b2a-8491-bc7e2953cafb",
+      "description": "dog",
+      "property": "recite",
+      "input": {
+        "startVerse": 5,
+        "endVerse": 5
+      },
+      "expected": [
+        "I know an old lady who swallowed a dog.",
+        "What a hog, to swallow a dog!",
+        "She swallowed the dog to catch the cat.",
+        "She swallowed the cat to catch the bird.",
+        "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+        "She swallowed the spider to catch the fly.",
+        "I don't know why she swallowed the fly. Perhaps she'll die."
+      ]
+    },
+    {
+      "uuid": "4b3fd221-01ea-46e0-825b-5734634fbc59",
+      "description": "goat",
+      "property": "recite",
+      "input": {
+        "startVerse": 6,
+        "endVerse": 6
+      },
+      "expected": [
+        "I know an old lady who swallowed a goat.",
+        "Just opened her throat and swallowed a goat!",
+        "She swallowed the goat to catch the dog.",
+        "She swallowed the dog to catch the cat.",
+        "She swallowed the cat to catch the bird.",
+        "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+        "She swallowed the spider to catch the fly.",
+        "I don't know why she swallowed the fly. Perhaps she'll die."
+      ]
+    },
+    {
+      "uuid": "1b707da9-7001-4fac-941f-22ad9c7a65d4",
+      "description": "cow",
+      "property": "recite",
+      "input": {
+        "startVerse": 7,
+        "endVerse": 7
+      },
+      "expected": [
+        "I know an old lady who swallowed a cow.",
+        "I don't know how she swallowed a cow!",
+        "She swallowed the cow to catch the goat.",
+        "She swallowed the goat to catch the dog.",
+        "She swallowed the dog to catch the cat.",
+        "She swallowed the cat to catch the bird.",
+        "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+        "She swallowed the spider to catch the fly.",
+        "I don't know why she swallowed the fly. Perhaps she'll die."
+      ]
+    },
+    {
+      "uuid": "3cb10d46-ae4e-4d2c-9296-83c9ffc04cdc",
+      "description": "horse",
+      "property": "recite",
+      "input": {
+        "startVerse": 8,
+        "endVerse": 8
+      },
+      "expected": [
+        "I know an old lady who swallowed a horse.",
+        "She's dead, of course!"
+      ]
+    },
+    {
+      "uuid": "22b863d5-17e4-4d1e-93e4-617329a5c050",
+      "description": "multiple verses",
+      "property": "recite",
+      "input": {
+        "startVerse": 1,
+        "endVerse": 3
+      },
+      "expected": [
+        "I know an old lady who swallowed a fly.",
+        "I don't know why she swallowed the fly. Perhaps she'll die.",
+        "",
+        "I know an old lady who swallowed a spider.",
+        "It wriggled and jiggled and tickled inside her.",
+        "She swallowed the spider to catch the fly.",
+        "I don't know why she swallowed the fly. Perhaps she'll die.",
+        "",
+        "I know an old lady who swallowed a bird.",
+        "How absurd to swallow a bird!",
+        "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+        "She swallowed the spider to catch the fly.",
+        "I don't know why she swallowed the fly. Perhaps she'll die."
+      ]
+    },
+    {
+      "uuid": "e626b32b-745c-4101-bcbd-3b13456893db",
+      "description": "full song",
+      "property": "recite",
+      "input": {
+        "startVerse": 1,
+        "endVerse": 8
+      },
+      "expected": [
+        "I know an old lady who swallowed a fly.",
+        "I don't know why she swallowed the fly. Perhaps she'll die.",
+        "",
+        "I know an old lady who swallowed a spider.",
+        "It wriggled and jiggled and tickled inside her.",
+        "She swallowed the spider to catch the fly.",
+        "I don't know why she swallowed the fly. Perhaps she'll die.",
+        "",
+        "I know an old lady who swallowed a bird.",
+        "How absurd to swallow a bird!",
+        "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+        "She swallowed the spider to catch the fly.",
+        "I don't know why she swallowed the fly. Perhaps she'll die.",
+        "",
+        "I know an old lady who swallowed a cat.",
+        "Imagine that, to swallow a cat!",
+        "She swallowed the cat to catch the bird.",
+        "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+        "She swallowed the spider to catch the fly.",
+        "I don't know why she swallowed the fly. Perhaps she'll die.",
+        "",
+        "I know an old lady who swallowed a dog.",
+        "What a hog, to swallow a dog!",
+        "She swallowed the dog to catch the cat.",
+        "She swallowed the cat to catch the bird.",
+        "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+        "She swallowed the spider to catch the fly.",
+        "I don't know why she swallowed the fly. Perhaps she'll die.",
+        "",
+        "I know an old lady who swallowed a goat.",
+        "Just opened her throat and swallowed a goat!",
+        "She swallowed the goat to catch the dog.",
+        "She swallowed the dog to catch the cat.",
+        "She swallowed the cat to catch the bird.",
+        "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+        "She swallowed the spider to catch the fly.",
+        "I don't know why she swallowed the fly. Perhaps she'll die.",
+        "",
+        "I know an old lady who swallowed a cow.",
+        "I don't know how she swallowed a cow!",
+        "She swallowed the cow to catch the goat.",
+        "She swallowed the goat to catch the dog.",
+        "She swallowed the dog to catch the cat.",
+        "She swallowed the cat to catch the bird.",
+        "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+        "She swallowed the spider to catch the fly.",
+        "I don't know why she swallowed the fly. Perhaps she'll die.",
+        "",
+        "I know an old lady who swallowed a horse.",
+        "She's dead, of course!"
       ]
     }
   ]

--- a/exercises/gigasecond/canonical-data.json
+++ b/exercises/gigasecond/canonical-data.json
@@ -16,54 +16,49 @@
   ],
   "cases": [
     {
-      "description": "Add one gigasecond to the input.",
-      "cases": [
-        {
-          "uuid": "92fbe71c-ea52-4fac-bd77-be38023cacf7",
-          "description": "date only specification of time",
-          "property": "add",
-          "input": {
-            "moment": "2011-04-25"
-          },
-          "expected": "2043-01-01T01:46:40"
-        },
-        {
-          "uuid": "6d86dd16-6f7a-47be-9e58-bb9fb2ae1433",
-          "description": "second test for date only specification of time",
-          "property": "add",
-          "input": {
-            "moment": "1977-06-13"
-          },
-          "expected": "2009-02-19T01:46:40"
-        },
-        {
-          "uuid": "77eb8502-2bca-4d92-89d9-7b39ace28dd5",
-          "description": "third test for date only specification of time",
-          "property": "add",
-          "input": {
-            "moment": "1959-07-19"
-          },
-          "expected": "1991-03-27T01:46:40"
-        },
-        {
-          "uuid": "c9d89a7d-06f8-4e28-a305-64f1b2abc693",
-          "description": "full time specified",
-          "property": "add",
-          "input": {
-            "moment": "2015-01-24T22:00:00"
-          },
-          "expected": "2046-10-02T23:46:40"
-        },
-        {
-          "uuid": "09d4e30e-728a-4b52-9005-be44a58d9eba",
-          "description": "full time with day roll-over",
-          "property": "add",
-          "input": {
-            "moment": "2015-01-24T23:59:59"
-          },
-          "expected": "2046-10-03T01:46:39"
-        }
-      ]
+      "uuid": "92fbe71c-ea52-4fac-bd77-be38023cacf7",
+      "description": "date only specification of time",
+      "property": "add",
+      "input": {
+        "moment": "2011-04-25"
+      },
+      "expected": "2043-01-01T01:46:40"
+    },
+    {
+      "uuid": "6d86dd16-6f7a-47be-9e58-bb9fb2ae1433",
+      "description": "second test for date only specification of time",
+      "property": "add",
+      "input": {
+        "moment": "1977-06-13"
+      },
+      "expected": "2009-02-19T01:46:40"
+    },
+    {
+      "uuid": "77eb8502-2bca-4d92-89d9-7b39ace28dd5",
+      "description": "third test for date only specification of time",
+      "property": "add",
+      "input": {
+        "moment": "1959-07-19"
+      },
+      "expected": "1991-03-27T01:46:40"
+    },
+    {
+      "uuid": "c9d89a7d-06f8-4e28-a305-64f1b2abc693",
+      "description": "full time specified",
+      "property": "add",
+      "input": {
+        "moment": "2015-01-24T22:00:00"
+      },
+      "expected": "2046-10-02T23:46:40"
+    },
+    {
+      "uuid": "09d4e30e-728a-4b52-9005-be44a58d9eba",
+      "description": "full time with day roll-over",
+      "property": "add",
+      "input": {
+        "moment": "2015-01-24T23:59:59"
+      },
+      "expected": "2046-10-03T01:46:39"
     }
   ]
 }

--- a/exercises/house/canonical-data.json
+++ b/exercises/house/canonical-data.json
@@ -12,191 +12,186 @@
   ],
   "cases": [
     {
-      "description": "Return specified verse or series of verses",
-      "cases": [
-        {
-          "uuid": "28a540ff-f765-4348-9d57-ae33f25f41f2",
-          "description": "verse one - the house that jack built",
-          "property": "recite",
-          "input": {
-            "startVerse": 1,
-            "endVerse": 1
-          },
-          "expected": [
-            "This is the house that Jack built."
-          ]
-        },
-        {
-          "uuid": "ebc825ac-6e2b-4a5e-9afd-95732191c8da",
-          "description": "verse two - the malt that lay",
-          "property": "recite",
-          "input": {
-            "startVerse": 2,
-            "endVerse": 2
-          },
-          "expected": [
-            "This is the malt that lay in the house that Jack built."
-          ]
-        },
-        {
-          "uuid": "1ed8bb0f-edb8-4bd1-b6d4-b64754fe4a60",
-          "description": "verse three - the rat that ate",
-          "property": "recite",
-          "input": {
-            "startVerse": 3,
-            "endVerse": 3
-          },
-          "expected": [
-            "This is the rat that ate the malt that lay in the house that Jack built."
-          ]
-        },
-        {
-          "uuid": "64b0954e-8b7d-4d14-aad0-d3f6ce297a30",
-          "description": "verse four - the cat that killed",
-          "property": "recite",
-          "input": {
-            "startVerse": 4,
-            "endVerse": 4
-          },
-          "expected": [
-            "This is the cat that killed the rat that ate the malt that lay in the house that Jack built."
-          ]
-        },
-        {
-          "uuid": "1e8d56bc-fe31-424d-9084-61e6111d2c82",
-          "description": "verse five - the dog that worried",
-          "property": "recite",
-          "input": {
-            "startVerse": 5,
-            "endVerse": 5
-          },
-          "expected": [
-            "This is the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."
-          ]
-        },
-        {
-          "uuid": "6312dc6f-ab0a-40c9-8a55-8d4e582beac4",
-          "description": "verse six - the cow with the crumpled horn",
-          "property": "recite",
-          "input": {
-            "startVerse": 6,
-            "endVerse": 6
-          },
-          "expected": [
-            "This is the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."
-          ]
-        },
-        {
-          "uuid": "68f76d18-6e19-4692-819c-5ff6a7f92feb",
-          "description": "verse seven - the maiden all forlorn",
-          "property": "recite",
-          "input": {
-            "startVerse": 7,
-            "endVerse": 7
-          },
-          "expected": [
-            "This is the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."
-          ]
-        },
-        {
-          "uuid": "73872564-2004-4071-b51d-2e4326096747",
-          "description": "verse eight - the man all tattered and torn",
-          "property": "recite",
-          "input": {
-            "startVerse": 8,
-            "endVerse": 8
-          },
-          "expected": [
-            "This is the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."
-          ]
-        },
-        {
-          "uuid": "0d53d743-66cb-4351-a173-82702f3338c9",
-          "description": "verse nine - the priest all shaven and shorn",
-          "property": "recite",
-          "input": {
-            "startVerse": 9,
-            "endVerse": 9
-          },
-          "expected": [
-            "This is the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."
-          ]
-        },
-        {
-          "uuid": "452f24dc-8fd7-4a82-be1a-3b4839cfeb41",
-          "description": "verse 10 - the rooster that crowed in the morn",
-          "property": "recite",
-          "input": {
-            "startVerse": 10,
-            "endVerse": 10
-          },
-          "expected": [
-            "This is the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."
-          ]
-        },
-        {
-          "uuid": "97176f20-2dd3-4646-ac72-cffced91ea26",
-          "description": "verse 11 - the farmer sowing his corn",
-          "property": "recite",
-          "input": {
-            "startVerse": 11,
-            "endVerse": 11
-          },
-          "expected": [
-            "This is the farmer sowing his corn that kept the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."
-          ]
-        },
-        {
-          "uuid": "09824c29-6aad-4dcd-ac98-f61374a6a8b7",
-          "description": "verse 12 - the horse and the hound and the horn",
-          "property": "recite",
-          "input": {
-            "startVerse": 12,
-            "endVerse": 12
-          },
-          "expected": [
-            "This is the horse and the hound and the horn that belonged to the farmer sowing his corn that kept the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."
-          ]
-        },
-        {
-          "uuid": "d2b980d3-7851-49e1-97ab-1524515ec200",
-          "description": "multiple verses",
-          "property": "recite",
-          "input": {
-            "startVerse": 4,
-            "endVerse": 8
-          },
-          "expected": [
-            "This is the cat that killed the rat that ate the malt that lay in the house that Jack built.",
-            "This is the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.",
-            "This is the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.",
-            "This is the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.",
-            "This is the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."
-          ]
-        },
-        {
-          "uuid": "0311d1d0-e085-4f23-8ae7-92406fb3e803",
-          "description": "full rhyme",
-          "property": "recite",
-          "input": {
-            "startVerse": 1,
-            "endVerse": 12
-          },
-          "expected": [
-            "This is the house that Jack built.",
-            "This is the malt that lay in the house that Jack built.",
-            "This is the rat that ate the malt that lay in the house that Jack built.",
-            "This is the cat that killed the rat that ate the malt that lay in the house that Jack built.",
-            "This is the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.",
-            "This is the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.",
-            "This is the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.",
-            "This is the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.",
-            "This is the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.",
-            "This is the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.",
-            "This is the farmer sowing his corn that kept the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.",
-            "This is the horse and the hound and the horn that belonged to the farmer sowing his corn that kept the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."
-          ]
-        }
+      "uuid": "28a540ff-f765-4348-9d57-ae33f25f41f2",
+      "description": "verse one - the house that jack built",
+      "property": "recite",
+      "input": {
+        "startVerse": 1,
+        "endVerse": 1
+      },
+      "expected": [
+        "This is the house that Jack built."
+      ]
+    },
+    {
+      "uuid": "ebc825ac-6e2b-4a5e-9afd-95732191c8da",
+      "description": "verse two - the malt that lay",
+      "property": "recite",
+      "input": {
+        "startVerse": 2,
+        "endVerse": 2
+      },
+      "expected": [
+        "This is the malt that lay in the house that Jack built."
+      ]
+    },
+    {
+      "uuid": "1ed8bb0f-edb8-4bd1-b6d4-b64754fe4a60",
+      "description": "verse three - the rat that ate",
+      "property": "recite",
+      "input": {
+        "startVerse": 3,
+        "endVerse": 3
+      },
+      "expected": [
+        "This is the rat that ate the malt that lay in the house that Jack built."
+      ]
+    },
+    {
+      "uuid": "64b0954e-8b7d-4d14-aad0-d3f6ce297a30",
+      "description": "verse four - the cat that killed",
+      "property": "recite",
+      "input": {
+        "startVerse": 4,
+        "endVerse": 4
+      },
+      "expected": [
+        "This is the cat that killed the rat that ate the malt that lay in the house that Jack built."
+      ]
+    },
+    {
+      "uuid": "1e8d56bc-fe31-424d-9084-61e6111d2c82",
+      "description": "verse five - the dog that worried",
+      "property": "recite",
+      "input": {
+        "startVerse": 5,
+        "endVerse": 5
+      },
+      "expected": [
+        "This is the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."
+      ]
+    },
+    {
+      "uuid": "6312dc6f-ab0a-40c9-8a55-8d4e582beac4",
+      "description": "verse six - the cow with the crumpled horn",
+      "property": "recite",
+      "input": {
+        "startVerse": 6,
+        "endVerse": 6
+      },
+      "expected": [
+        "This is the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."
+      ]
+    },
+    {
+      "uuid": "68f76d18-6e19-4692-819c-5ff6a7f92feb",
+      "description": "verse seven - the maiden all forlorn",
+      "property": "recite",
+      "input": {
+        "startVerse": 7,
+        "endVerse": 7
+      },
+      "expected": [
+        "This is the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."
+      ]
+    },
+    {
+      "uuid": "73872564-2004-4071-b51d-2e4326096747",
+      "description": "verse eight - the man all tattered and torn",
+      "property": "recite",
+      "input": {
+        "startVerse": 8,
+        "endVerse": 8
+      },
+      "expected": [
+        "This is the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."
+      ]
+    },
+    {
+      "uuid": "0d53d743-66cb-4351-a173-82702f3338c9",
+      "description": "verse nine - the priest all shaven and shorn",
+      "property": "recite",
+      "input": {
+        "startVerse": 9,
+        "endVerse": 9
+      },
+      "expected": [
+        "This is the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."
+      ]
+    },
+    {
+      "uuid": "452f24dc-8fd7-4a82-be1a-3b4839cfeb41",
+      "description": "verse 10 - the rooster that crowed in the morn",
+      "property": "recite",
+      "input": {
+        "startVerse": 10,
+        "endVerse": 10
+      },
+      "expected": [
+        "This is the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."
+      ]
+    },
+    {
+      "uuid": "97176f20-2dd3-4646-ac72-cffced91ea26",
+      "description": "verse 11 - the farmer sowing his corn",
+      "property": "recite",
+      "input": {
+        "startVerse": 11,
+        "endVerse": 11
+      },
+      "expected": [
+        "This is the farmer sowing his corn that kept the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."
+      ]
+    },
+    {
+      "uuid": "09824c29-6aad-4dcd-ac98-f61374a6a8b7",
+      "description": "verse 12 - the horse and the hound and the horn",
+      "property": "recite",
+      "input": {
+        "startVerse": 12,
+        "endVerse": 12
+      },
+      "expected": [
+        "This is the horse and the hound and the horn that belonged to the farmer sowing his corn that kept the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."
+      ]
+    },
+    {
+      "uuid": "d2b980d3-7851-49e1-97ab-1524515ec200",
+      "description": "multiple verses",
+      "property": "recite",
+      "input": {
+        "startVerse": 4,
+        "endVerse": 8
+      },
+      "expected": [
+        "This is the cat that killed the rat that ate the malt that lay in the house that Jack built.",
+        "This is the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.",
+        "This is the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.",
+        "This is the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.",
+        "This is the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."
+      ]
+    },
+    {
+      "uuid": "0311d1d0-e085-4f23-8ae7-92406fb3e803",
+      "description": "full rhyme",
+      "property": "recite",
+      "input": {
+        "startVerse": 1,
+        "endVerse": 12
+      },
+      "expected": [
+        "This is the house that Jack built.",
+        "This is the malt that lay in the house that Jack built.",
+        "This is the rat that ate the malt that lay in the house that Jack built.",
+        "This is the cat that killed the rat that ate the malt that lay in the house that Jack built.",
+        "This is the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.",
+        "This is the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.",
+        "This is the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.",
+        "This is the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.",
+        "This is the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.",
+        "This is the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.",
+        "This is the farmer sowing his corn that kept the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built.",
+        "This is the horse and the hound and the horn that belonged to the farmer sowing his corn that kept the rooster that crowed in the morn that woke the priest all shaven and shorn that married the man all tattered and torn that kissed the maiden all forlorn that milked the cow with the crumpled horn that tossed the dog that worried the cat that killed the rat that ate the malt that lay in the house that Jack built."
       ]
     }
   ]

--- a/exercises/isogram/canonical-data.json
+++ b/exercises/isogram/canonical-data.json
@@ -5,139 +5,131 @@
   ],
   "cases": [
     {
-      "description": "Check if the given string is an isogram",
-      "comments": [
-        "Output should be a boolean denoting if the string is a isogram or not."
-      ],
-      "cases": [
-        {
-          "uuid": "a0e97d2d-669e-47c7-8134-518a1e2c4555",
-          "description": "empty string",
-          "property": "isIsogram",
-          "input": {
-            "phrase": ""
-          },
-          "expected": true
-        },
-        {
-          "uuid": "9a001b50-f194-4143-bc29-2af5ec1ef652",
-          "description": "isogram with only lower case characters",
-          "property": "isIsogram",
-          "input": {
-            "phrase": "isogram"
-          },
-          "expected": true
-        },
-        {
-          "uuid": "8ddb0ca3-276e-4f8b-89da-d95d5bae78a4",
-          "description": "word with one duplicated character",
-          "property": "isIsogram",
-          "input": {
-            "phrase": "eleven"
-          },
-          "expected": false
-        },
-        {
-          "uuid": "6450b333-cbc2-4b24-a723-0b459b34fe18",
-          "description": "word with one duplicated character from the end of the alphabet",
-          "property": "isIsogram",
-          "input": {
-            "phrase": "zzyzx"
-          },
-          "expected": false
-        },
-        {
-          "uuid": "a15ff557-dd04-4764-99e7-02cc1a385863",
-          "description": "longest reported english isogram",
-          "property": "isIsogram",
-          "input": {
-            "phrase": "subdermatoglyphic"
-          },
-          "expected": true
-        },
-        {
-          "uuid": "f1a7f6c7-a42f-4915-91d7-35b2ea11c92e",
-          "description": "word with duplicated character in mixed case",
-          "property": "isIsogram",
-          "input": {
-            "phrase": "Alphabet"
-          },
-          "expected": false
-        },
-        {
-          "uuid": "14a4f3c1-3b47-4695-b645-53d328298942",
-          "description": "word with duplicated character in mixed case, lowercase first",
-          "property": "isIsogram",
-          "input": {
-            "phrase": "alphAbet"
-          },
-          "expected": false
-        },
-        {
-          "uuid": "423b850c-7090-4a8a-b057-97f1cadd7c42",
-          "description": "hypothetical isogrammic word with hyphen",
-          "property": "isIsogram",
-          "input": {
-            "phrase": "thumbscrew-japingly"
-          },
-          "expected": true
-        },
-        {
-          "uuid": "93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2",
-          "description": "hypothetical word with duplicated character following hyphen",
-          "property": "isIsogram",
-          "input": {
-            "phrase": "thumbscrew-jappingly"
-          },
-          "expected": false
-        },
-        {
-          "uuid": "36b30e5c-173f-49c6-a515-93a3e825553f",
-          "description": "isogram with duplicated hyphen",
-          "property": "isIsogram",
-          "input": {
-            "phrase": "six-year-old"
-          },
-          "expected": true
-        },
-        {
-          "uuid": "cdabafa0-c9f4-4c1f-b142-689c6ee17d93",
-          "description": "made-up name that is an isogram",
-          "property": "isIsogram",
-          "input": {
-            "phrase": "Emily Jung Schwartzkopf"
-          },
-          "expected": true
-        },
-        {
-          "uuid": "5fc61048-d74e-48fd-bc34-abfc21552d4d",
-          "description": "duplicated character in the middle",
-          "property": "isIsogram",
-          "input": {
-            "phrase": "accentor"
-          },
-          "expected": false
-        },
-        {
-          "uuid": "310ac53d-8932-47bc-bbb4-b2b94f25a83e",
-          "description": "same first and last characters",
-          "property": "isIsogram",
-          "input": {
-            "phrase": "angola"
-          },
-          "expected": false
-        },
-        {
-          "uuid": "0d0b8644-0a1e-4a31-a432-2b3ee270d847",
-          "description": "word with duplicated character and with two hyphens",
-          "comments": ["This test aims to catch buggy implementations that check for duplicate spaces or hyphens."],
-          "property": "isIsogram",
-          "input": {
-            "phrase": "up-to-date"
-          },
-          "expected": false
-        }
-      ]
+      "uuid": "a0e97d2d-669e-47c7-8134-518a1e2c4555",
+      "description": "empty string",
+      "property": "isIsogram",
+      "input": {
+        "phrase": ""
+      },
+      "expected": true
+    },
+    {
+      "uuid": "9a001b50-f194-4143-bc29-2af5ec1ef652",
+      "description": "isogram with only lower case characters",
+      "property": "isIsogram",
+      "input": {
+        "phrase": "isogram"
+      },
+      "expected": true
+    },
+    {
+      "uuid": "8ddb0ca3-276e-4f8b-89da-d95d5bae78a4",
+      "description": "word with one duplicated character",
+      "property": "isIsogram",
+      "input": {
+        "phrase": "eleven"
+      },
+      "expected": false
+    },
+    {
+      "uuid": "6450b333-cbc2-4b24-a723-0b459b34fe18",
+      "description": "word with one duplicated character from the end of the alphabet",
+      "property": "isIsogram",
+      "input": {
+        "phrase": "zzyzx"
+      },
+      "expected": false
+    },
+    {
+      "uuid": "a15ff557-dd04-4764-99e7-02cc1a385863",
+      "description": "longest reported english isogram",
+      "property": "isIsogram",
+      "input": {
+        "phrase": "subdermatoglyphic"
+      },
+      "expected": true
+    },
+    {
+      "uuid": "f1a7f6c7-a42f-4915-91d7-35b2ea11c92e",
+      "description": "word with duplicated character in mixed case",
+      "property": "isIsogram",
+      "input": {
+        "phrase": "Alphabet"
+      },
+      "expected": false
+    },
+    {
+      "uuid": "14a4f3c1-3b47-4695-b645-53d328298942",
+      "description": "word with duplicated character in mixed case, lowercase first",
+      "property": "isIsogram",
+      "input": {
+        "phrase": "alphAbet"
+      },
+      "expected": false
+    },
+    {
+      "uuid": "423b850c-7090-4a8a-b057-97f1cadd7c42",
+      "description": "hypothetical isogrammic word with hyphen",
+      "property": "isIsogram",
+      "input": {
+        "phrase": "thumbscrew-japingly"
+      },
+      "expected": true
+    },
+    {
+      "uuid": "93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2",
+      "description": "hypothetical word with duplicated character following hyphen",
+      "property": "isIsogram",
+      "input": {
+        "phrase": "thumbscrew-jappingly"
+      },
+      "expected": false
+    },
+    {
+      "uuid": "36b30e5c-173f-49c6-a515-93a3e825553f",
+      "description": "isogram with duplicated hyphen",
+      "property": "isIsogram",
+      "input": {
+        "phrase": "six-year-old"
+      },
+      "expected": true
+    },
+    {
+      "uuid": "cdabafa0-c9f4-4c1f-b142-689c6ee17d93",
+      "description": "made-up name that is an isogram",
+      "property": "isIsogram",
+      "input": {
+        "phrase": "Emily Jung Schwartzkopf"
+      },
+      "expected": true
+    },
+    {
+      "uuid": "5fc61048-d74e-48fd-bc34-abfc21552d4d",
+      "description": "duplicated character in the middle",
+      "property": "isIsogram",
+      "input": {
+        "phrase": "accentor"
+      },
+      "expected": false
+    },
+    {
+      "uuid": "310ac53d-8932-47bc-bbb4-b2b94f25a83e",
+      "description": "same first and last characters",
+      "property": "isIsogram",
+      "input": {
+        "phrase": "angola"
+      },
+      "expected": false
+    },
+    {
+      "uuid": "0d0b8644-0a1e-4a31-a432-2b3ee270d847",
+      "description": "word with duplicated character and with two hyphens",
+      "comments": ["This test aims to catch buggy implementations that check for duplicate spaces or hyphens."],
+      "property": "isIsogram",
+      "input": {
+        "phrase": "up-to-date"
+      },
+      "expected": false
     }
   ]
 }

--- a/exercises/micro-blog/canonical-data.json
+++ b/exercises/micro-blog/canonical-data.json
@@ -20,117 +20,112 @@
   ],
   "cases": [
     {
-      "description": "Truncate a micro blog post",
-      "cases": [
-        {
-          "uuid": "b927b57f-7c98-42fd-8f33-fae091dc1efc",
-          "description": "English language short",
-          "property": "truncate",
-          "input": {
-            "phrase": "Hi"
-          },
-          "expected": "Hi"
-        },
-        {
-          "uuid": "a3fcdc5b-0ed4-4f49-80f5-b1a293eac2a0",
-          "description": "English language long",
-          "property": "truncate",
-          "input": {
-            "phrase": "Hello there"
-          },
-          "expected": "Hello"
-        },
-        {
-          "uuid": "01910864-8e15-4007-9c7c-ac956c686e60",
-          "description": "German language short (broth)",
-          "property": "truncate",
-          "input": {
-            "phrase": "brühe"
-          },
-          "expected": "brühe"
-        },
-        {
-          "uuid": "f263e488-aefb-478f-a671-b6ba99722543",
-          "description": "German language long (bear carpet → beards)",
-          "property": "truncate",
-          "input": {
-            "phrase": "Bärteppich"
-          },
-          "expected": "Bärte"
-        },
-        {
-          "uuid": "0916e8f1-41d7-4402-a110-b08aa000342c",
-          "description": "Bulgarian language short (good)",
-          "property": "truncate",
-          "input": {
-            "phrase": "Добър"
-          },
-          "expected": "Добър"
-        },
-        {
-          "uuid": "bed6b89c-03df-4154-98e6-a61a74f61b7d",
-          "description": "Greek language short (health)",
-          "property": "truncate",
-          "input": {
-            "phrase": "υγειά"
-          },
-          "expected": "υγειά"
-        },
-        {
-          "uuid": "485a6a70-2edb-424d-b999-5529dbc8e002",
-          "description": "Maths short",
-          "property": "truncate",
-          "input": {
-            "phrase": "a=πr²"
-          },
-          "expected": "a=πr²"
-        },
-        {
-          "uuid": "8b4b7b51-8f48-4fbe-964e-6e4e6438be28",
-          "description": "Maths long",
-          "property": "truncate",
-          "input": {
-            "phrase": "∅⊊ℕ⊊ℤ⊊ℚ⊊ℝ⊊ℂ"
-          },
-          "expected": "∅⊊ℕ⊊ℤ"
-        },
-        {
-          "uuid": "71f4a192-0566-4402-a512-fe12878be523",
-          "description": "English and emoji short",
-          "property": "truncate",
-          "input": {
-            "phrase": "Fly 🛫"
-          },
-          "expected": "Fly 🛫"
-        },
-        {
-          "uuid": "6f0f71f3-9806-4759-a844-fa182f7bc203",
-          "description": "Emoji short",
-          "property": "truncate",
-          "input": {
-            "phrase": "💇"
-          },
-          "expected": "💇"
-        },
-        {
-          "uuid": "ce71fb92-5214-46d0-a7f8-d5ba56b4cc6e",
-          "description": "Emoji long",
-          "property": "truncate",
-          "input": {
-            "phrase": "❄🌡🤧🤒🏥🕰😀"
-          },
-          "expected": "❄🌡🤧🤒🏥"
-        },
-        {
-          "uuid": "5dee98d2-d56e-468a-a1f2-121c3f7c5a0b",
-          "description": "Royal Flush?",
-          "property": "truncate",
-          "input": {
-            "phrase": "🃎🂸🃅🃋🃍🃁🃊"
-          },
-          "expected": "🃎🂸🃅🃋🃍"
-        }
-      ]
+      "uuid": "b927b57f-7c98-42fd-8f33-fae091dc1efc",
+      "description": "English language short",
+      "property": "truncate",
+      "input": {
+        "phrase": "Hi"
+      },
+      "expected": "Hi"
+    },
+    {
+      "uuid": "a3fcdc5b-0ed4-4f49-80f5-b1a293eac2a0",
+      "description": "English language long",
+      "property": "truncate",
+      "input": {
+        "phrase": "Hello there"
+      },
+      "expected": "Hello"
+    },
+    {
+      "uuid": "01910864-8e15-4007-9c7c-ac956c686e60",
+      "description": "German language short (broth)",
+      "property": "truncate",
+      "input": {
+        "phrase": "brühe"
+      },
+      "expected": "brühe"
+    },
+    {
+      "uuid": "f263e488-aefb-478f-a671-b6ba99722543",
+      "description": "German language long (bear carpet → beards)",
+      "property": "truncate",
+      "input": {
+        "phrase": "Bärteppich"
+      },
+      "expected": "Bärte"
+    },
+    {
+      "uuid": "0916e8f1-41d7-4402-a110-b08aa000342c",
+      "description": "Bulgarian language short (good)",
+      "property": "truncate",
+      "input": {
+        "phrase": "Добър"
+      },
+      "expected": "Добър"
+    },
+    {
+      "uuid": "bed6b89c-03df-4154-98e6-a61a74f61b7d",
+      "description": "Greek language short (health)",
+      "property": "truncate",
+      "input": {
+        "phrase": "υγειά"
+      },
+      "expected": "υγειά"
+    },
+    {
+      "uuid": "485a6a70-2edb-424d-b999-5529dbc8e002",
+      "description": "Maths short",
+      "property": "truncate",
+      "input": {
+        "phrase": "a=πr²"
+      },
+      "expected": "a=πr²"
+    },
+    {
+      "uuid": "8b4b7b51-8f48-4fbe-964e-6e4e6438be28",
+      "description": "Maths long",
+      "property": "truncate",
+      "input": {
+        "phrase": "∅⊊ℕ⊊ℤ⊊ℚ⊊ℝ⊊ℂ"
+      },
+      "expected": "∅⊊ℕ⊊ℤ"
+    },
+    {
+      "uuid": "71f4a192-0566-4402-a512-fe12878be523",
+      "description": "English and emoji short",
+      "property": "truncate",
+      "input": {
+        "phrase": "Fly 🛫"
+      },
+      "expected": "Fly 🛫"
+    },
+    {
+      "uuid": "6f0f71f3-9806-4759-a844-fa182f7bc203",
+      "description": "Emoji short",
+      "property": "truncate",
+      "input": {
+        "phrase": "💇"
+      },
+      "expected": "💇"
+    },
+    {
+      "uuid": "ce71fb92-5214-46d0-a7f8-d5ba56b4cc6e",
+      "description": "Emoji long",
+      "property": "truncate",
+      "input": {
+        "phrase": "❄🌡🤧🤒🏥🕰😀"
+      },
+      "expected": "❄🌡🤧🤒🏥"
+    },
+    {
+      "uuid": "5dee98d2-d56e-468a-a1f2-121c3f7c5a0b",
+      "description": "Royal Flush?",
+      "property": "truncate",
+      "input": {
+        "phrase": "🃎🂸🃅🃋🃍🃁🃊"
+      },
+      "expected": "🃎🂸🃅🃋🃍"
     }
   ]
 }

--- a/exercises/nucleotide-count/canonical-data.json
+++ b/exercises/nucleotide-count/canonical-data.json
@@ -2,76 +2,71 @@
   "exercise": "nucleotide-count",
   "cases": [
     {
-      "description": "count all nucleotides in a strand",
-      "cases": [
-        {
-          "uuid": "3e5c30a8-87e2-4845-a815-a49671ade970",
-          "description": "empty strand",
-          "property": "nucleotideCounts",
-          "input": {
-            "strand": ""
-          },
-          "expected": {
-            "A": 0,
-            "C": 0,
-            "G": 0,
-            "T": 0
-          }
-        },
-        {
-          "uuid": "a0ea42a6-06d9-4ac6-828c-7ccaccf98fec",
-          "description": "can count one nucleotide in single-character input",
-          "property": "nucleotideCounts",
-          "input": {
-            "strand": "G"
-          },
-          "expected": {
-            "A": 0,
-            "C": 0,
-            "G": 1,
-            "T": 0
-          }
-        },
-        {
-          "uuid": "eca0d565-ed8c-43e7-9033-6cefbf5115b5",
-          "description": "strand with repeated nucleotide",
-          "property": "nucleotideCounts",
-          "input": {
-            "strand": "GGGGGGG"
-          },
-          "expected": {
-            "A": 0,
-            "C": 0,
-            "G": 7,
-            "T": 0
-          }
-        },
-        {
-          "uuid": "40a45eac-c83f-4740-901a-20b22d15a39f",
-          "description": "strand with multiple nucleotides",
-          "property": "nucleotideCounts",
-          "input": {
-            "strand": "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"
-          },
-          "expected": {
-            "A": 20,
-            "C": 12,
-            "G": 17,
-            "T": 21
-          }
-        },
-        {
-          "uuid": "b4c47851-ee9e-4b0a-be70-a86e343bd851",
-          "description": "strand with invalid nucleotides",
-          "property": "nucleotideCounts",
-          "input": {
-            "strand": "AGXXACT"
-          },
-          "expected": {
-            "error": "Invalid nucleotide in strand"
-          }
-        }
-      ]
+      "uuid": "3e5c30a8-87e2-4845-a815-a49671ade970",
+      "description": "empty strand",
+      "property": "nucleotideCounts",
+      "input": {
+        "strand": ""
+      },
+      "expected": {
+        "A": 0,
+        "C": 0,
+        "G": 0,
+        "T": 0
+      }
+    },
+    {
+      "uuid": "a0ea42a6-06d9-4ac6-828c-7ccaccf98fec",
+      "description": "can count one nucleotide in single-character input",
+      "property": "nucleotideCounts",
+      "input": {
+        "strand": "G"
+      },
+      "expected": {
+        "A": 0,
+        "C": 0,
+        "G": 1,
+        "T": 0
+      }
+    },
+    {
+      "uuid": "eca0d565-ed8c-43e7-9033-6cefbf5115b5",
+      "description": "strand with repeated nucleotide",
+      "property": "nucleotideCounts",
+      "input": {
+        "strand": "GGGGGGG"
+      },
+      "expected": {
+        "A": 0,
+        "C": 0,
+        "G": 7,
+        "T": 0
+      }
+    },
+    {
+      "uuid": "40a45eac-c83f-4740-901a-20b22d15a39f",
+      "description": "strand with multiple nucleotides",
+      "property": "nucleotideCounts",
+      "input": {
+        "strand": "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"
+      },
+      "expected": {
+        "A": 20,
+        "C": 12,
+        "G": 17,
+        "T": 21
+      }
+    },
+    {
+      "uuid": "b4c47851-ee9e-4b0a-be70-a86e343bd851",
+      "description": "strand with invalid nucleotides",
+      "property": "nucleotideCounts",
+      "input": {
+        "strand": "AGXXACT"
+      },
+      "expected": {
+        "error": "Invalid nucleotide in strand"
+      }
     }
   ]
 }

--- a/exercises/ocr-numbers/canonical-data.json
+++ b/exercises/ocr-numbers/canonical-data.json
@@ -2,254 +2,249 @@
   "exercise": "ocr-numbers",
   "cases": [
     {
-      "description": "Converts lines of OCR Numbers to a string of integers",
-      "cases": [
-        {
-          "uuid": "5ee54e1a-b554-4bf3-a056-9a7976c3f7e8",
-          "description": "Recognizes 0",
-          "property": "convert",
-          "input": {
-            "rows": [
-              " _ ",
-              "| |",
-              "|_|",
-              "   "
-            ]
-          },
-          "expected": "0"
-        },
-        {
-          "uuid": "027ada25-17fd-4d78-aee6-35a19623639d",
-          "description": "Recognizes 1",
-          "property": "convert",
-          "input": {
-            "rows": [
-              "   ",
-              "  |",
-              "  |",
-              "   "
-            ]
-          },
-          "expected": "1"
-        },
-        {
-          "uuid": "3cce2dbd-01d9-4f94-8fae-419a822e89bb",
-          "description": "Unreadable but correctly sized inputs return ?",
-          "property": "convert",
-          "input": {
-            "rows": [
-              "   ",
-              "  _",
-              "  |",
-              "   "
-            ]
-          },
-          "expected": "?"
-        },
-        {
-          "uuid": "cb19b733-4e36-4cf9-a4a1-6e6aac808b9a",
-          "description": "Input with a number of lines that is not a multiple of four raises an error",
-          "property": "convert",
-          "input": {
-            "rows": [
-              " _ ",
-              "| |",
-              "   "
-            ]
-          },
-          "expected": {"error": "Number of input lines is not a multiple of four"}
-        },
-        {
-          "uuid": "235f7bd1-991b-4587-98d4-84206eec4cc6",
-          "description": "Input with a number of columns that is not a multiple of three raises an error",
-          "property": "convert",
-          "input": {
-            "rows": [
-              "    ",
-              "   |",
-              "   |",
-              "    "
-            ]
-          },
-          "expected": {"error": "Number of input columns is not a multiple of three"}
-        },
-        {
-          "uuid": "4a841794-73c9-4da9-a779-1f9837faff66",
-          "description": "Recognizes 110101100",
-          "property": "convert",
-          "input": {
-            "rows": [
-              "       _     _        _  _ ",
-              "  |  || |  || |  |  || || |",
-              "  |  ||_|  ||_|  |  ||_||_|",
-              "                           "
-            ]
-          },
-          "expected": "110101100"
-        },
-        {
-          "uuid": "70c338f9-85b1-4296-a3a8-122901cdfde8",
-          "description": "Garbled numbers in a string are replaced with ?",
-          "property": "convert",
-          "input": {
-            "rows": [
-              "       _     _           _ ",
-              "  |  || |  || |     || || |",
-              "  |  | _|  ||_|  |  ||_||_|",
-              "                           "
-            ]
-          },
-          "expected": "11?10?1?0"
-        },
-        {
-          "uuid": "ea494ff4-3610-44d7-ab7e-72fdef0e0802",
-          "description": "Recognizes 2",
-          "property": "convert",
-          "input": {
-            "rows": [
-              " _ ",
-              " _|",
-              "|_ ",
-              "   "
-            ]
-          },
-          "expected": "2"
-        },
-        {
-          "uuid": "1acd2c00-412b-4268-93c2-bd7ff8e05a2c",
-          "description": "Recognizes 3",
-          "property": "convert",
-          "input": {
-            "rows": [
-              " _ ",
-              " _|",
-              " _|",
-              "   "
-            ]
-          },
-          "expected": "3"
-        },
-        {
-          "uuid": "eaec6a15-be17-4b6d-b895-596fae5d1329",
-          "description": "Recognizes 4",
-          "property": "convert",
-          "input": {
-            "rows": [
-              "   ",
-              "|_|",
-              "  |",
-              "   "
-            ]
-          },
-          "expected": "4"
-        },
-        {
-          "uuid": "440f397a-f046-4243-a6ca-81ab5406c56e",
-          "description": "Recognizes 5",
-          "property": "convert",
-          "input": {
-            "rows": [
-              " _ ",
-              "|_ ",
-              " _|",
-              "   "
-            ]
-          },
-          "expected": "5"
-        },
-        {
-          "uuid": "f4c9cf6a-f1e2-4878-bfc3-9b85b657caa0",
-          "description": "Recognizes 6",
-          "property": "convert",
-          "input": {
-            "rows": [
-              " _ ",
-              "|_ ",
-              "|_|",
-              "   "
-            ]
-          },
-          "expected": "6"
-        },
-        {
-          "uuid": "e24ebf80-c611-41bb-a25a-ac2c0f232df5",
-          "description": "Recognizes 7",
-          "property": "convert",
-          "input": {
-            "rows": [
-              " _ ",
-              "  |",
-              "  |",
-              "   "
-            ]
-          },
-          "expected": "7"
-        },
-        {
-          "uuid": "b79cad4f-e264-4818-9d9e-77766792e233",
-          "description": "Recognizes 8",
-          "property": "convert",
-          "input": {
-            "rows": [
-              " _ ",
-              "|_|",
-              "|_|",
-              "   "
-            ]
-          },
-          "expected": "8"
-        },
-        {
-          "uuid": "5efc9cfc-9227-4688-b77d-845049299e66",
-          "description": "Recognizes 9",
-          "property": "convert",
-          "input": {
-            "rows": [
-              " _ ",
-              "|_|",
-              " _|",
-              "   "
-            ]
-          },
-          "expected": "9"
-        },
-        {
-          "uuid": "f60cb04a-42be-494e-a535-3451c8e097a4",
-          "description": "Recognizes string of decimal numbers",
-          "property": "convert",
-          "input": {
-            "rows": [
-              "    _  _     _  _  _  _  _  _ ",
-              "  | _| _||_||_ |_   ||_||_|| |",
-              "  ||_  _|  | _||_|  ||_| _||_|",
-              "                              "
-            ]
-          },
-          "expected": "1234567890"
-        },
-        {
-          "uuid": "b73ecf8b-4423-4b36-860d-3710bdb8a491",
-          "description": "Numbers separated by empty lines are recognized. Lines are joined by commas.",
-          "property": "convert",
-          "input": {
-            "rows": [
-              "    _  _ ",
-              "  | _| _|",
-              "  ||_  _|",
-              "         ",
-              "    _  _ ",
-              "|_||_ |_ ",
-              "  | _||_|",
-              "         ",
-              " _  _  _ ",
-              "  ||_||_|",
-              "  ||_| _|",
-              "         "
-            ]
-          },
-          "expected": "123,456,789"
-        }
-      ]
+      "uuid": "5ee54e1a-b554-4bf3-a056-9a7976c3f7e8",
+      "description": "Recognizes 0",
+      "property": "convert",
+      "input": {
+        "rows": [
+          " _ ",
+          "| |",
+          "|_|",
+          "   "
+        ]
+      },
+      "expected": "0"
+    },
+    {
+      "uuid": "027ada25-17fd-4d78-aee6-35a19623639d",
+      "description": "Recognizes 1",
+      "property": "convert",
+      "input": {
+        "rows": [
+          "   ",
+          "  |",
+          "  |",
+          "   "
+        ]
+      },
+      "expected": "1"
+    },
+    {
+      "uuid": "3cce2dbd-01d9-4f94-8fae-419a822e89bb",
+      "description": "Unreadable but correctly sized inputs return ?",
+      "property": "convert",
+      "input": {
+        "rows": [
+          "   ",
+          "  _",
+          "  |",
+          "   "
+        ]
+      },
+      "expected": "?"
+    },
+    {
+      "uuid": "cb19b733-4e36-4cf9-a4a1-6e6aac808b9a",
+      "description": "Input with a number of lines that is not a multiple of four raises an error",
+      "property": "convert",
+      "input": {
+        "rows": [
+          " _ ",
+          "| |",
+          "   "
+        ]
+      },
+      "expected": {"error": "Number of input lines is not a multiple of four"}
+    },
+    {
+      "uuid": "235f7bd1-991b-4587-98d4-84206eec4cc6",
+      "description": "Input with a number of columns that is not a multiple of three raises an error",
+      "property": "convert",
+      "input": {
+        "rows": [
+          "    ",
+          "   |",
+          "   |",
+          "    "
+        ]
+      },
+      "expected": {"error": "Number of input columns is not a multiple of three"}
+    },
+    {
+      "uuid": "4a841794-73c9-4da9-a779-1f9837faff66",
+      "description": "Recognizes 110101100",
+      "property": "convert",
+      "input": {
+        "rows": [
+          "       _     _        _  _ ",
+          "  |  || |  || |  |  || || |",
+          "  |  ||_|  ||_|  |  ||_||_|",
+          "                           "
+        ]
+      },
+      "expected": "110101100"
+    },
+    {
+      "uuid": "70c338f9-85b1-4296-a3a8-122901cdfde8",
+      "description": "Garbled numbers in a string are replaced with ?",
+      "property": "convert",
+      "input": {
+        "rows": [
+          "       _     _           _ ",
+          "  |  || |  || |     || || |",
+          "  |  | _|  ||_|  |  ||_||_|",
+          "                           "
+        ]
+      },
+      "expected": "11?10?1?0"
+    },
+    {
+      "uuid": "ea494ff4-3610-44d7-ab7e-72fdef0e0802",
+      "description": "Recognizes 2",
+      "property": "convert",
+      "input": {
+        "rows": [
+          " _ ",
+          " _|",
+          "|_ ",
+          "   "
+        ]
+      },
+      "expected": "2"
+    },
+    {
+      "uuid": "1acd2c00-412b-4268-93c2-bd7ff8e05a2c",
+      "description": "Recognizes 3",
+      "property": "convert",
+      "input": {
+        "rows": [
+          " _ ",
+          " _|",
+          " _|",
+          "   "
+        ]
+      },
+      "expected": "3"
+    },
+    {
+      "uuid": "eaec6a15-be17-4b6d-b895-596fae5d1329",
+      "description": "Recognizes 4",
+      "property": "convert",
+      "input": {
+        "rows": [
+          "   ",
+          "|_|",
+          "  |",
+          "   "
+        ]
+      },
+      "expected": "4"
+    },
+    {
+      "uuid": "440f397a-f046-4243-a6ca-81ab5406c56e",
+      "description": "Recognizes 5",
+      "property": "convert",
+      "input": {
+        "rows": [
+          " _ ",
+          "|_ ",
+          " _|",
+          "   "
+        ]
+      },
+      "expected": "5"
+    },
+    {
+      "uuid": "f4c9cf6a-f1e2-4878-bfc3-9b85b657caa0",
+      "description": "Recognizes 6",
+      "property": "convert",
+      "input": {
+        "rows": [
+          " _ ",
+          "|_ ",
+          "|_|",
+          "   "
+        ]
+      },
+      "expected": "6"
+    },
+    {
+      "uuid": "e24ebf80-c611-41bb-a25a-ac2c0f232df5",
+      "description": "Recognizes 7",
+      "property": "convert",
+      "input": {
+        "rows": [
+          " _ ",
+          "  |",
+          "  |",
+          "   "
+        ]
+      },
+      "expected": "7"
+    },
+    {
+      "uuid": "b79cad4f-e264-4818-9d9e-77766792e233",
+      "description": "Recognizes 8",
+      "property": "convert",
+      "input": {
+        "rows": [
+          " _ ",
+          "|_|",
+          "|_|",
+          "   "
+        ]
+      },
+      "expected": "8"
+    },
+    {
+      "uuid": "5efc9cfc-9227-4688-b77d-845049299e66",
+      "description": "Recognizes 9",
+      "property": "convert",
+      "input": {
+        "rows": [
+          " _ ",
+          "|_|",
+          " _|",
+          "   "
+        ]
+      },
+      "expected": "9"
+    },
+    {
+      "uuid": "f60cb04a-42be-494e-a535-3451c8e097a4",
+      "description": "Recognizes string of decimal numbers",
+      "property": "convert",
+      "input": {
+        "rows": [
+          "    _  _     _  _  _  _  _  _ ",
+          "  | _| _||_||_ |_   ||_||_|| |",
+          "  ||_  _|  | _||_|  ||_| _||_|",
+          "                              "
+        ]
+      },
+      "expected": "1234567890"
+    },
+    {
+      "uuid": "b73ecf8b-4423-4b36-860d-3710bdb8a491",
+      "description": "Numbers separated by empty lines are recognized. Lines are joined by commas.",
+      "property": "convert",
+      "input": {
+        "rows": [
+          "    _  _ ",
+          "  | _| _|",
+          "  ||_  _|",
+          "         ",
+          "    _  _ ",
+          "|_||_ |_ ",
+          "  | _||_|",
+          "         ",
+          " _  _  _ ",
+          "  ||_||_|",
+          "  ||_| _|",
+          "         "
+        ]
+      },
+      "expected": "123,456,789"
     }
   ]
 }

--- a/exercises/pascals-triangle/canonical-data.json
+++ b/exercises/pascals-triangle/canonical-data.json
@@ -6,81 +6,76 @@
   ],
   "cases": [
     {
-      "description": "Given a count, return a collection of that many rows of pascal's triangle",
-      "cases": [
-        {
-          "uuid": "9920ce55-9629-46d5-85d6-4201f4a4234d",
-          "description": "zero rows",
-          "property": "rows",
-          "input": {
-            "count": 0
-          },
-          "expected": []
-        },
-        {
-          "uuid": "70d643ce-a46d-4e93-af58-12d88dd01f21",
-          "description": "single row",
-          "property": "rows",
-          "input": {
-            "count": 1
-          },
-          "expected": [[1]]
-        },
-        {
-          "uuid": "a6e5a2a2-fc9a-4b47-9f4f-ed9ad9fbe4bd",
-          "description": "two rows",
-          "property": "rows",
-          "input": {
-            "count": 2
-          },
-          "expected": [[1], [1, 1]]
-        },
-        {
-          "uuid": "97206a99-79ba-4b04-b1c5-3c0fa1e16925",
-          "description": "three rows",
-          "property": "rows",
-          "input": {
-            "count": 3
-          },
-          "expected": [[1], [1, 1], [1, 2, 1]]
-        },
-        {
-          "uuid": "565a0431-c797-417c-a2c8-2935e01ce306",
-          "description": "four rows",
-          "property": "rows",
-          "input": {
-            "count": 4
-          },
-          "expected": [[1], [1, 1], [1, 2, 1], [1, 3, 3, 1]]
-        },
-        {
-          "uuid": "06f9ea50-9f51-4eb2-b9a9-c00975686c27",
-          "description": "five rows",
-          "property": "rows",
-          "input": {
-            "count": 5
-          },
-          "expected": [[1], [1, 1], [1, 2, 1], [1, 3, 3, 1], [1, 4, 6, 4, 1]]
-        },
-        {
-          "uuid": "c3912965-ddb4-46a9-848e-3363e6b00b13",
-          "description": "six rows",
-          "property": "rows",
-          "input": {
-            "count": 6
-          },
-          "expected": [[1], [1, 1], [1, 2, 1], [1, 3, 3, 1], [1, 4, 6, 4, 1], [1, 5, 10, 10, 5, 1]]
-        },
-        {
-          "uuid": "6cb26c66-7b57-4161-962c-81ec8c99f16b",
-          "description": "ten rows",
-          "property": "rows",
-          "input": {
-            "count": 10
-          },
-          "expected": [[1], [1, 1], [1, 2, 1], [1, 3, 3, 1], [1, 4, 6, 4, 1], [1, 5, 10, 10, 5, 1], [1, 6, 15, 20, 15, 6, 1], [1, 7, 21, 35, 35, 21, 7, 1], [1, 8, 28, 56, 70, 56, 28, 8, 1], [1, 9, 36, 84, 126, 126, 84, 36, 9, 1]]
-        }
-      ]
+      "uuid": "9920ce55-9629-46d5-85d6-4201f4a4234d",
+      "description": "zero rows",
+      "property": "rows",
+      "input": {
+        "count": 0
+      },
+      "expected": []
+    },
+    {
+      "uuid": "70d643ce-a46d-4e93-af58-12d88dd01f21",
+      "description": "single row",
+      "property": "rows",
+      "input": {
+        "count": 1
+      },
+      "expected": [[1]]
+    },
+    {
+      "uuid": "a6e5a2a2-fc9a-4b47-9f4f-ed9ad9fbe4bd",
+      "description": "two rows",
+      "property": "rows",
+      "input": {
+        "count": 2
+      },
+      "expected": [[1], [1, 1]]
+    },
+    {
+      "uuid": "97206a99-79ba-4b04-b1c5-3c0fa1e16925",
+      "description": "three rows",
+      "property": "rows",
+      "input": {
+        "count": 3
+      },
+      "expected": [[1], [1, 1], [1, 2, 1]]
+    },
+    {
+      "uuid": "565a0431-c797-417c-a2c8-2935e01ce306",
+      "description": "four rows",
+      "property": "rows",
+      "input": {
+        "count": 4
+      },
+      "expected": [[1], [1, 1], [1, 2, 1], [1, 3, 3, 1]]
+    },
+    {
+      "uuid": "06f9ea50-9f51-4eb2-b9a9-c00975686c27",
+      "description": "five rows",
+      "property": "rows",
+      "input": {
+        "count": 5
+      },
+      "expected": [[1], [1, 1], [1, 2, 1], [1, 3, 3, 1], [1, 4, 6, 4, 1]]
+    },
+    {
+      "uuid": "c3912965-ddb4-46a9-848e-3363e6b00b13",
+      "description": "six rows",
+      "property": "rows",
+      "input": {
+        "count": 6
+      },
+      "expected": [[1], [1, 1], [1, 2, 1], [1, 3, 3, 1], [1, 4, 6, 4, 1], [1, 5, 10, 10, 5, 1]]
+    },
+    {
+      "uuid": "6cb26c66-7b57-4161-962c-81ec8c99f16b",
+      "description": "ten rows",
+      "property": "rows",
+      "input": {
+        "count": 10
+      },
+      "expected": [[1], [1, 1], [1, 2, 1], [1, 3, 3, 1], [1, 4, 6, 4, 1], [1, 5, 10, 10, 5, 1], [1, 6, 15, 20, 15, 6, 1], [1, 7, 21, 35, 35, 21, 7, 1], [1, 8, 28, 56, 70, 56, 28, 8, 1], [1, 9, 36, 84, 126, 126, 84, 36, 9, 1]]
     }
   ]
 }

--- a/exercises/phone-number/canonical-data.json
+++ b/exercises/phone-number/canonical-data.json
@@ -1,177 +1,172 @@
 {
   "exercise": "phone-number",
+  "comments": [
+    " Returns the cleaned phone number if given number is valid, "
+  , " else returns error object. Note that number is not formatted,"
+  , " just a 10-digit number is returned.                        "
+  ],
   "cases": [
     {
-      "description": "Cleanup user-entered phone numbers",
-      "comments": [
-        " Returns the cleaned phone number if given number is valid, "
-      , " else returns error object. Note that number is not formatted,"
-      , " just a 10-digit number is returned.                        "
-      ],
-      "cases": [
-        {
-          "uuid": "79666dce-e0f1-46de-95a1-563802913c35",
-          "description": "cleans the number",
-          "property": "clean",
-          "input": {
-            "phrase": "(223) 456-7890"
-          },
-          "expected": "2234567890"
-        },
-        {
-          "uuid": "c360451f-549f-43e4-8aba-fdf6cb0bf83f",
-          "description": "cleans numbers with dots",
-          "property": "clean",
-          "input": {
-            "phrase": "223.456.7890"
-          },
-          "expected": "2234567890"
-        },
-        {
-          "uuid": "08f94c34-9a37-46a2-a123-2a8e9727395d",
-          "description": "cleans numbers with multiple spaces",
-          "property": "clean",
-          "input": {
-            "phrase": "223 456   7890   "
-          },
-          "expected": "2234567890"
-        },
-        {
-          "uuid": "598d8432-0659-4019-a78b-1c6a73691d21",
-          "description": "invalid when 9 digits",
-          "property": "clean",
-          "input": {
-            "phrase": "123456789"
-          },
-          "expected": {"error": "incorrect number of digits"}
-        },
-        {
-          "uuid": "57061c72-07b5-431f-9766-d97da7c4399d",
-          "description": "invalid when 11 digits does not start with a 1",
-          "property": "clean",
-          "input": {
-            "phrase": "22234567890"
-          },
-          "expected": {"error": "11 digits must start with 1"}
-        },
-        {
-          "uuid": "9962cbf3-97bb-4118-ba9b-38ff49c64430",
-          "description": "valid when 11 digits and starting with 1",
-          "property": "clean",
-          "input": {
-            "phrase": "12234567890"
-          },
-          "expected": "2234567890"
-        },
-        {
-          "uuid": "fa724fbf-054c-4d91-95da-f65ab5b6dbca",
-          "description": "valid when 11 digits and starting with 1 even with punctuation",
-          "property": "clean",
-          "input": {
-            "phrase": "+1 (223) 456-7890"
-          },
-          "expected": "2234567890"
-        },
-        {
-          "uuid": "c6a5f007-895a-4fc5-90bc-a7e70f9b5cad",
-          "description": "invalid when more than 11 digits",
-          "property": "clean",
-          "input": {
-            "phrase": "321234567890"
-          },
-          "expected": {"error": "more than 11 digits"}
-        },
-        {
-          "uuid": "63f38f37-53f6-4a5f-bd86-e9b404f10a60",
-          "description": "invalid with letters",
-          "property": "clean",
-          "input": {
-            "phrase": "123-abc-7890"
-          },
-          "expected": {"error": "letters not permitted"}
-        },
-        {
-          "uuid": "4bd97d90-52fd-45d3-b0db-06ab95b1244e",
-          "description": "invalid with punctuations",
-          "property": "clean",
-          "input": {
-            "phrase": "123-@:!-7890"
-          },
-          "expected": {"error": "punctuations not permitted"}
-        },
-        {
-          "uuid": "d77d07f8-873c-4b17-8978-5f66139bf7d7",
-          "description": "invalid if area code starts with 0",
-          "property": "clean",
-          "input": {
-            "phrase": "(023) 456-7890"
-          },
-          "expected": {"error": "area code cannot start with zero"}
-        },
-        {
-          "uuid": "c7485cfb-1e7b-4081-8e96-8cdb3b77f15e",
-          "description": "invalid if area code starts with 1",
-          "property": "clean",
-          "input": {
-            "phrase": "(123) 456-7890"
-          },
-          "expected": {"error": "area code cannot start with one"}
-        },
-        {
-          "uuid": "4d622293-6976-413d-b8bf-dd8a94d4e2ac",
-          "description": "invalid if exchange code starts with 0",
-          "property": "clean",
-          "input": {
-            "phrase": "(223) 056-7890"
-          },
-          "expected": {"error": "exchange code cannot start with zero"}
-        },
-        {
-          "uuid": "4cef57b4-7d8e-43aa-8328-1e1b89001262",
-          "description": "invalid if exchange code starts with 1",
-          "property": "clean",
-          "input": {
-            "phrase": "(223) 156-7890"
-          },
-          "expected": {"error": "exchange code cannot start with one"}
-        },
-        {
-          "uuid": "9925b09c-1a0d-4960-a197-5d163cbe308c",
-          "description": "invalid if area code starts with 0 on valid 11-digit number",
-          "property": "clean",
-          "input": {
-            "phrase": "1 (023) 456-7890"
-          },
-          "expected": {"error": "area code cannot start with zero"}
-        },
-        {
-          "uuid": "3f809d37-40f3-44b5-ad90-535838b1a816",
-          "description": "invalid if area code starts with 1 on valid 11-digit number",
-          "property": "clean",
-          "input": {
-            "phrase": "1 (123) 456-7890"
-          },
-          "expected": {"error": "area code cannot start with one"}
-        },
-        {
-          "uuid": "e08e5532-d621-40d4-b0cc-96c159276b65",
-          "description": "invalid if exchange code starts with 0 on valid 11-digit number",
-          "property": "clean",
-          "input": {
-            "phrase": "1 (223) 056-7890"
-          },
-          "expected": {"error": "exchange code cannot start with zero"}
-        },
-        {
-          "uuid": "57b32f3d-696a-455c-8bf1-137b6d171cdf",
-          "description": "invalid if exchange code starts with 1 on valid 11-digit number",
-          "property": "clean",
-          "input": {
-            "phrase": "1 (223) 156-7890"
-          },
-          "expected": {"error": "exchange code cannot start with one"}
-        }
-      ]
+      "uuid": "79666dce-e0f1-46de-95a1-563802913c35",
+      "description": "cleans the number",
+      "property": "clean",
+      "input": {
+        "phrase": "(223) 456-7890"
+      },
+      "expected": "2234567890"
+    },
+    {
+      "uuid": "c360451f-549f-43e4-8aba-fdf6cb0bf83f",
+      "description": "cleans numbers with dots",
+      "property": "clean",
+      "input": {
+        "phrase": "223.456.7890"
+      },
+      "expected": "2234567890"
+    },
+    {
+      "uuid": "08f94c34-9a37-46a2-a123-2a8e9727395d",
+      "description": "cleans numbers with multiple spaces",
+      "property": "clean",
+      "input": {
+        "phrase": "223 456   7890   "
+      },
+      "expected": "2234567890"
+    },
+    {
+      "uuid": "598d8432-0659-4019-a78b-1c6a73691d21",
+      "description": "invalid when 9 digits",
+      "property": "clean",
+      "input": {
+        "phrase": "123456789"
+      },
+      "expected": {"error": "incorrect number of digits"}
+    },
+    {
+      "uuid": "57061c72-07b5-431f-9766-d97da7c4399d",
+      "description": "invalid when 11 digits does not start with a 1",
+      "property": "clean",
+      "input": {
+        "phrase": "22234567890"
+      },
+      "expected": {"error": "11 digits must start with 1"}
+    },
+    {
+      "uuid": "9962cbf3-97bb-4118-ba9b-38ff49c64430",
+      "description": "valid when 11 digits and starting with 1",
+      "property": "clean",
+      "input": {
+        "phrase": "12234567890"
+      },
+      "expected": "2234567890"
+    },
+    {
+      "uuid": "fa724fbf-054c-4d91-95da-f65ab5b6dbca",
+      "description": "valid when 11 digits and starting with 1 even with punctuation",
+      "property": "clean",
+      "input": {
+        "phrase": "+1 (223) 456-7890"
+      },
+      "expected": "2234567890"
+    },
+    {
+      "uuid": "c6a5f007-895a-4fc5-90bc-a7e70f9b5cad",
+      "description": "invalid when more than 11 digits",
+      "property": "clean",
+      "input": {
+        "phrase": "321234567890"
+      },
+      "expected": {"error": "more than 11 digits"}
+    },
+    {
+      "uuid": "63f38f37-53f6-4a5f-bd86-e9b404f10a60",
+      "description": "invalid with letters",
+      "property": "clean",
+      "input": {
+        "phrase": "123-abc-7890"
+      },
+      "expected": {"error": "letters not permitted"}
+    },
+    {
+      "uuid": "4bd97d90-52fd-45d3-b0db-06ab95b1244e",
+      "description": "invalid with punctuations",
+      "property": "clean",
+      "input": {
+        "phrase": "123-@:!-7890"
+      },
+      "expected": {"error": "punctuations not permitted"}
+    },
+    {
+      "uuid": "d77d07f8-873c-4b17-8978-5f66139bf7d7",
+      "description": "invalid if area code starts with 0",
+      "property": "clean",
+      "input": {
+        "phrase": "(023) 456-7890"
+      },
+      "expected": {"error": "area code cannot start with zero"}
+    },
+    {
+      "uuid": "c7485cfb-1e7b-4081-8e96-8cdb3b77f15e",
+      "description": "invalid if area code starts with 1",
+      "property": "clean",
+      "input": {
+        "phrase": "(123) 456-7890"
+      },
+      "expected": {"error": "area code cannot start with one"}
+    },
+    {
+      "uuid": "4d622293-6976-413d-b8bf-dd8a94d4e2ac",
+      "description": "invalid if exchange code starts with 0",
+      "property": "clean",
+      "input": {
+        "phrase": "(223) 056-7890"
+      },
+      "expected": {"error": "exchange code cannot start with zero"}
+    },
+    {
+      "uuid": "4cef57b4-7d8e-43aa-8328-1e1b89001262",
+      "description": "invalid if exchange code starts with 1",
+      "property": "clean",
+      "input": {
+        "phrase": "(223) 156-7890"
+      },
+      "expected": {"error": "exchange code cannot start with one"}
+    },
+    {
+      "uuid": "9925b09c-1a0d-4960-a197-5d163cbe308c",
+      "description": "invalid if area code starts with 0 on valid 11-digit number",
+      "property": "clean",
+      "input": {
+        "phrase": "1 (023) 456-7890"
+      },
+      "expected": {"error": "area code cannot start with zero"}
+    },
+    {
+      "uuid": "3f809d37-40f3-44b5-ad90-535838b1a816",
+      "description": "invalid if area code starts with 1 on valid 11-digit number",
+      "property": "clean",
+      "input": {
+        "phrase": "1 (123) 456-7890"
+      },
+      "expected": {"error": "area code cannot start with one"}
+    },
+    {
+      "uuid": "e08e5532-d621-40d4-b0cc-96c159276b65",
+      "description": "invalid if exchange code starts with 0 on valid 11-digit number",
+      "property": "clean",
+      "input": {
+        "phrase": "1 (223) 056-7890"
+      },
+      "expected": {"error": "exchange code cannot start with zero"}
+    },
+    {
+      "uuid": "57b32f3d-696a-455c-8bf1-137b6d171cdf",
+      "description": "invalid if exchange code starts with 1 on valid 11-digit number",
+      "property": "clean",
+      "input": {
+        "phrase": "1 (223) 156-7890"
+      },
+      "expected": {"error": "exchange code cannot start with one"}
     }
   ]
 }

--- a/exercises/prime-factors/canonical-data.json
+++ b/exercises/prime-factors/canonical-data.json
@@ -2,155 +2,150 @@
   "exercise": "prime-factors",
   "cases": [
     {
-      "description": "returns prime factors for the given input number",
-      "cases": [
-        {
-          "uuid": "924fc966-a8f5-4288-82f2-6b9224819ccd",
-          "description": "no factors",
-          "property": "factors",
-          "input": {
-            "value": 1
-          },
-          "expected": []
-        },
-        {
-          "uuid": "17e30670-b105-4305-af53-ddde182cb6ad",
-          "description": "prime number",
-          "property": "factors",
-          "input": {
-            "value": 2
-          },
-          "expected": [
-            2
-          ]
-        },
-        {
-          "uuid": "238d57c8-4c12-42ef-af34-ae4929f94789",
-          "description": "another prime number",
-          "property": "factors",
-          "input": {
-            "value": 3
-          },
-          "expected": [
-            3
-          ]
-        },
-        {
-          "uuid": "f59b8350-a180-495a-8fb1-1712fbee1158",
-          "description": "square of a prime",
-          "property": "factors",
-          "input": {
-            "value": 9
-          },
-          "expected": [
-            3,
-            3
-          ]
-        },
-        {
-          "uuid": "756949d3-3158-4e3d-91f2-c4f9f043ee70",
-          "description": "product of first prime",
-          "property": "factors",
-          "input": {
-            "value": 4
-          },
-          "expected": [
-            2,
-            2
-          ]
-        },
-        {
-          "uuid": "bc8c113f-9580-4516-8669-c5fc29512ceb",
-          "description": "cube of a prime",
-          "property": "factors",
-          "input": {
-            "value": 8
-          },
-          "expected": [
-            2,
-            2,
-            2
-          ]
-        },
-        {
-          "uuid": "7d6a3300-a4cb-4065-bd33-0ced1de6cb44",
-          "description": "product of second prime",
-          "property": "factors",
-          "input": {
-            "value": 27
-          },
-          "expected": [
-            3,
-            3,
-            3
-          ]
-        },
-        {
-          "uuid": "073ac0b2-c915-4362-929d-fc45f7b9a9e4",
-          "description": "product of third prime",
-          "property": "factors",
-          "input": {
-            "value": 625
-          },
-          "expected": [
-            5,
-            5,
-            5,
-            5
-          ]
-        },
-        {
-          "uuid": "6e0e4912-7fb6-47f3-a9ad-dbcd79340c75",
-          "description": "product of first and second prime",
-          "property": "factors",
-          "input": {
-            "value": 6
-          },
-          "expected": [
-            2,
-            3
-          ]
-        },
-        {
-          "uuid": "00485cd3-a3fe-4fbe-a64a-a4308fc1f870",
-          "description": "product of primes and non-primes",
-          "property": "factors",
-          "input": {
-            "value": 12
-          },
-          "expected": [
-            2,
-            2,
-            3
-          ]
-        },
-        {
-          "uuid": "02251d54-3ca1-4a9b-85e1-b38f4b0ccb91",
-          "description": "product of primes",
-          "property": "factors",
-          "input": {
-            "value": 901255
-          },
-          "expected": [
-            5,
-            17,
-            23,
-            461
-          ]
-        },
-        {
-          "uuid": "070cf8dc-e202-4285-aa37-8d775c9cd473",
-          "description": "factors include a large prime",
-          "property": "factors",
-          "input": {
-            "value": 93819012551
-          },
-          "expected": [
-            11,
-            9539,
-            894119
-          ]
-        }
+      "uuid": "924fc966-a8f5-4288-82f2-6b9224819ccd",
+      "description": "no factors",
+      "property": "factors",
+      "input": {
+        "value": 1
+      },
+      "expected": []
+    },
+    {
+      "uuid": "17e30670-b105-4305-af53-ddde182cb6ad",
+      "description": "prime number",
+      "property": "factors",
+      "input": {
+        "value": 2
+      },
+      "expected": [
+        2
+      ]
+    },
+    {
+      "uuid": "238d57c8-4c12-42ef-af34-ae4929f94789",
+      "description": "another prime number",
+      "property": "factors",
+      "input": {
+        "value": 3
+      },
+      "expected": [
+        3
+      ]
+    },
+    {
+      "uuid": "f59b8350-a180-495a-8fb1-1712fbee1158",
+      "description": "square of a prime",
+      "property": "factors",
+      "input": {
+        "value": 9
+      },
+      "expected": [
+        3,
+        3
+      ]
+    },
+    {
+      "uuid": "756949d3-3158-4e3d-91f2-c4f9f043ee70",
+      "description": "product of first prime",
+      "property": "factors",
+      "input": {
+        "value": 4
+      },
+      "expected": [
+        2,
+        2
+      ]
+    },
+    {
+      "uuid": "bc8c113f-9580-4516-8669-c5fc29512ceb",
+      "description": "cube of a prime",
+      "property": "factors",
+      "input": {
+        "value": 8
+      },
+      "expected": [
+        2,
+        2,
+        2
+      ]
+    },
+    {
+      "uuid": "7d6a3300-a4cb-4065-bd33-0ced1de6cb44",
+      "description": "product of second prime",
+      "property": "factors",
+      "input": {
+        "value": 27
+      },
+      "expected": [
+        3,
+        3,
+        3
+      ]
+    },
+    {
+      "uuid": "073ac0b2-c915-4362-929d-fc45f7b9a9e4",
+      "description": "product of third prime",
+      "property": "factors",
+      "input": {
+        "value": 625
+      },
+      "expected": [
+        5,
+        5,
+        5,
+        5
+      ]
+    },
+    {
+      "uuid": "6e0e4912-7fb6-47f3-a9ad-dbcd79340c75",
+      "description": "product of first and second prime",
+      "property": "factors",
+      "input": {
+        "value": 6
+      },
+      "expected": [
+        2,
+        3
+      ]
+    },
+    {
+      "uuid": "00485cd3-a3fe-4fbe-a64a-a4308fc1f870",
+      "description": "product of primes and non-primes",
+      "property": "factors",
+      "input": {
+        "value": 12
+      },
+      "expected": [
+        2,
+        2,
+        3
+      ]
+    },
+    {
+      "uuid": "02251d54-3ca1-4a9b-85e1-b38f4b0ccb91",
+      "description": "product of primes",
+      "property": "factors",
+      "input": {
+        "value": 901255
+      },
+      "expected": [
+        5,
+        17,
+        23,
+        461
+      ]
+    },
+    {
+      "uuid": "070cf8dc-e202-4285-aa37-8d775c9cd473",
+      "description": "factors include a large prime",
+      "property": "factors",
+      "input": {
+        "value": 93819012551
+      },
+      "expected": [
+        11,
+        9539,
+        894119
       ]
     }
   ]

--- a/exercises/protein-translation/canonical-data.json
+++ b/exercises/protein-translation/canonical-data.json
@@ -2,216 +2,211 @@
   "exercise": "protein-translation",
   "cases": [
     {
-      "description": "Translate input RNA sequences into proteins",
-      "cases": [
-        {
-          "uuid": "96d3d44f-34a2-4db4-84cd-fff523e069be",
-          "description": "Methionine RNA sequence",
-          "property": "proteins",
-          "input": {
-            "strand": "AUG"
-          },
-          "expected": ["Methionine"]
-        },
-        {
-          "uuid": "1b4c56d8-d69f-44eb-be0e-7b17546143d9",
-          "description": "Phenylalanine RNA sequence 1",
-          "property": "proteins",
-          "input": {
-            "strand": "UUU"
-          },
-          "expected": ["Phenylalanine"]
-        },
-        {
-          "uuid": "81b53646-bd57-4732-b2cb-6b1880e36d11",
-          "description": "Phenylalanine RNA sequence 2",
-          "property": "proteins",
-          "input": {
-            "strand": "UUC"
-          },
-          "expected": ["Phenylalanine"]
-        },
-        {
-          "uuid": "42f69d4f-19d2-4d2c-a8b0-f0ae9ee1b6b4",
-          "description": "Leucine RNA sequence 1",
-          "property": "proteins",
-          "input": {
-            "strand": "UUA"
-          },
-          "expected": ["Leucine"]
-        },
-        {
-          "uuid": "ac5edadd-08ed-40a3-b2b9-d82bb50424c4",
-          "description": "Leucine RNA sequence 2",
-          "property": "proteins",
-          "input": {
-            "strand": "UUG"
-          },
-          "expected": ["Leucine"]
-        },
-        {
-          "uuid": "8bc36e22-f984-44c3-9f6b-ee5d4e73f120",
-          "description": "Serine RNA sequence 1",
-          "property": "proteins",
-          "input": {
-            "strand": "UCU"
-          },
-          "expected": ["Serine"]
-        },
-        {
-          "uuid": "5c3fa5da-4268-44e5-9f4b-f016ccf90131",
-          "description": "Serine RNA sequence 2",
-          "property": "proteins",
-          "input": {
-            "strand": "UCC"
-          },
-          "expected": ["Serine"]
-        },
-        {
-          "uuid": "00579891-b594-42b4-96dc-7ff8bf519606",
-          "description": "Serine RNA sequence 3",
-          "property": "proteins",
-          "input": {
-            "strand": "UCA"
-          },
-          "expected": ["Serine"]
-        },
-        {
-          "uuid": "08c61c3b-fa34-4950-8c4a-133945570ef6",
-          "description": "Serine RNA sequence 4",
-          "property": "proteins",
-          "input": {
-            "strand": "UCG"
-          },
-          "expected": ["Serine"]
-        },
-        {
-          "uuid": "54e1e7d8-63c0-456d-91d2-062c72f8eef5",
-          "description": "Tyrosine RNA sequence 1",
-          "property": "proteins",
-          "input": {
-            "strand": "UAU"
-          },
-          "expected": ["Tyrosine"]
-        },
-        {
-          "uuid": "47bcfba2-9d72-46ad-bbce-22f7666b7eb1",
-          "description": "Tyrosine RNA sequence 2",
-          "property": "proteins",
-          "input": {
-            "strand": "UAC"
-          },
-          "expected": ["Tyrosine"]
-        },
-        {
-          "uuid": "3a691829-fe72-43a7-8c8e-1bd083163f72",
-          "description": "Cysteine RNA sequence 1",
-          "property": "proteins",
-          "input": {
-            "strand": "UGU"
-          },
-          "expected": ["Cysteine"]
-        },
-        {
-          "uuid": "1b6f8a26-ca2f-43b8-8262-3ee446021767",
-          "description": "Cysteine RNA sequence 2",
-          "property": "proteins",
-          "input": {
-            "strand": "UGC"
-          },
-          "expected": ["Cysteine"]
-        },
-        {
-          "uuid": "1e91c1eb-02c0-48a0-9e35-168ad0cb5f39",
-          "description": "Tryptophan RNA sequence",
-          "property": "proteins",
-          "input": {
-            "strand": "UGG"
-          },
-          "expected": ["Tryptophan"]
-        },
-        {
-          "uuid": "e547af0b-aeab-49c7-9f13-801773a73557",
-          "description": "STOP codon RNA sequence 1",
-          "property": "proteins",
-          "input": {
-            "strand": "UAA"
-          },
-          "expected": []
-        },
-        {
-          "uuid": "67640947-ff02-4f23-a2ef-816f8a2ba72e",
-          "description": "STOP codon RNA sequence 2",
-          "property": "proteins",
-          "input": {
-            "strand": "UAG"
-          },
-          "expected": []
-        },
-        {
-          "uuid": "9c2ad527-ebc9-4ace-808b-2b6447cb54cb",
-          "description": "STOP codon RNA sequence 3",
-          "property": "proteins",
-          "input": {
-            "strand": "UGA"
-          },
-          "expected": []
-        },
-        {
-          "uuid": "d0f295df-fb70-425c-946c-ec2ec185388e",
-          "description": "Translate RNA strand into correct protein list",
-          "property": "proteins",
-          "input": {
-            "strand": "AUGUUUUGG"
-          },
-          "expected": ["Methionine","Phenylalanine","Tryptophan"]
-        },
-        {
-          "uuid": "e30e8505-97ec-4e5f-a73e-5726a1faa1f4",
-          "description": "Translation stops if STOP codon at beginning of sequence",
-          "property": "proteins",
-          "input": {
-            "strand": "UAGUGG"
-          },
-          "expected": []
-        },
-        {
-          "uuid": "5358a20b-6f4c-4893-bce4-f929001710f3",
-          "description": "Translation stops if STOP codon at end of two-codon sequence",
-          "property": "proteins",
-          "input": {
-            "strand": "UGGUAG"
-          },
-          "expected": ["Tryptophan"]
-        },
-        {
-          "uuid": "ba16703a-1a55-482f-bb07-b21eef5093a3",
-          "description": "Translation stops if STOP codon at end of three-codon sequence",
-          "property": "proteins",
-          "input": {
-            "strand": "AUGUUUUAA"
-          },
-          "expected": ["Methionine","Phenylalanine"]
-        },
-        {
-          "uuid": "4089bb5a-d5b4-4e71-b79e-b8d1f14a2911",
-          "description": "Translation stops if STOP codon in middle of three-codon sequence",
-          "property": "proteins",
-          "input": {
-            "strand": "UGGUAGUGG"
-          },
-          "expected": ["Tryptophan"]
-        },
-        {
-          "uuid": "2c2a2a60-401f-4a80-b977-e0715b23b93d",
-          "description": "Translation stops if STOP codon in middle of six-codon sequence",
-          "property": "proteins",
-          "input": {
-            "strand": "UGGUGUUAUUAAUGGUUU"
-          },
-          "expected": ["Tryptophan","Cysteine","Tyrosine"]
-        }
-      ]
+      "uuid": "96d3d44f-34a2-4db4-84cd-fff523e069be",
+      "description": "Methionine RNA sequence",
+      "property": "proteins",
+      "input": {
+        "strand": "AUG"
+      },
+      "expected": ["Methionine"]
+    },
+    {
+      "uuid": "1b4c56d8-d69f-44eb-be0e-7b17546143d9",
+      "description": "Phenylalanine RNA sequence 1",
+      "property": "proteins",
+      "input": {
+        "strand": "UUU"
+      },
+      "expected": ["Phenylalanine"]
+    },
+    {
+      "uuid": "81b53646-bd57-4732-b2cb-6b1880e36d11",
+      "description": "Phenylalanine RNA sequence 2",
+      "property": "proteins",
+      "input": {
+        "strand": "UUC"
+      },
+      "expected": ["Phenylalanine"]
+    },
+    {
+      "uuid": "42f69d4f-19d2-4d2c-a8b0-f0ae9ee1b6b4",
+      "description": "Leucine RNA sequence 1",
+      "property": "proteins",
+      "input": {
+        "strand": "UUA"
+      },
+      "expected": ["Leucine"]
+    },
+    {
+      "uuid": "ac5edadd-08ed-40a3-b2b9-d82bb50424c4",
+      "description": "Leucine RNA sequence 2",
+      "property": "proteins",
+      "input": {
+        "strand": "UUG"
+      },
+      "expected": ["Leucine"]
+    },
+    {
+      "uuid": "8bc36e22-f984-44c3-9f6b-ee5d4e73f120",
+      "description": "Serine RNA sequence 1",
+      "property": "proteins",
+      "input": {
+        "strand": "UCU"
+      },
+      "expected": ["Serine"]
+    },
+    {
+      "uuid": "5c3fa5da-4268-44e5-9f4b-f016ccf90131",
+      "description": "Serine RNA sequence 2",
+      "property": "proteins",
+      "input": {
+        "strand": "UCC"
+      },
+      "expected": ["Serine"]
+    },
+    {
+      "uuid": "00579891-b594-42b4-96dc-7ff8bf519606",
+      "description": "Serine RNA sequence 3",
+      "property": "proteins",
+      "input": {
+        "strand": "UCA"
+      },
+      "expected": ["Serine"]
+    },
+    {
+      "uuid": "08c61c3b-fa34-4950-8c4a-133945570ef6",
+      "description": "Serine RNA sequence 4",
+      "property": "proteins",
+      "input": {
+        "strand": "UCG"
+      },
+      "expected": ["Serine"]
+    },
+    {
+      "uuid": "54e1e7d8-63c0-456d-91d2-062c72f8eef5",
+      "description": "Tyrosine RNA sequence 1",
+      "property": "proteins",
+      "input": {
+        "strand": "UAU"
+      },
+      "expected": ["Tyrosine"]
+    },
+    {
+      "uuid": "47bcfba2-9d72-46ad-bbce-22f7666b7eb1",
+      "description": "Tyrosine RNA sequence 2",
+      "property": "proteins",
+      "input": {
+        "strand": "UAC"
+      },
+      "expected": ["Tyrosine"]
+    },
+    {
+      "uuid": "3a691829-fe72-43a7-8c8e-1bd083163f72",
+      "description": "Cysteine RNA sequence 1",
+      "property": "proteins",
+      "input": {
+        "strand": "UGU"
+      },
+      "expected": ["Cysteine"]
+    },
+    {
+      "uuid": "1b6f8a26-ca2f-43b8-8262-3ee446021767",
+      "description": "Cysteine RNA sequence 2",
+      "property": "proteins",
+      "input": {
+        "strand": "UGC"
+      },
+      "expected": ["Cysteine"]
+    },
+    {
+      "uuid": "1e91c1eb-02c0-48a0-9e35-168ad0cb5f39",
+      "description": "Tryptophan RNA sequence",
+      "property": "proteins",
+      "input": {
+        "strand": "UGG"
+      },
+      "expected": ["Tryptophan"]
+    },
+    {
+      "uuid": "e547af0b-aeab-49c7-9f13-801773a73557",
+      "description": "STOP codon RNA sequence 1",
+      "property": "proteins",
+      "input": {
+        "strand": "UAA"
+      },
+      "expected": []
+    },
+    {
+      "uuid": "67640947-ff02-4f23-a2ef-816f8a2ba72e",
+      "description": "STOP codon RNA sequence 2",
+      "property": "proteins",
+      "input": {
+        "strand": "UAG"
+      },
+      "expected": []
+    },
+    {
+      "uuid": "9c2ad527-ebc9-4ace-808b-2b6447cb54cb",
+      "description": "STOP codon RNA sequence 3",
+      "property": "proteins",
+      "input": {
+        "strand": "UGA"
+      },
+      "expected": []
+    },
+    {
+      "uuid": "d0f295df-fb70-425c-946c-ec2ec185388e",
+      "description": "Translate RNA strand into correct protein list",
+      "property": "proteins",
+      "input": {
+        "strand": "AUGUUUUGG"
+      },
+      "expected": ["Methionine","Phenylalanine","Tryptophan"]
+    },
+    {
+      "uuid": "e30e8505-97ec-4e5f-a73e-5726a1faa1f4",
+      "description": "Translation stops if STOP codon at beginning of sequence",
+      "property": "proteins",
+      "input": {
+        "strand": "UAGUGG"
+      },
+      "expected": []
+    },
+    {
+      "uuid": "5358a20b-6f4c-4893-bce4-f929001710f3",
+      "description": "Translation stops if STOP codon at end of two-codon sequence",
+      "property": "proteins",
+      "input": {
+        "strand": "UGGUAG"
+      },
+      "expected": ["Tryptophan"]
+    },
+    {
+      "uuid": "ba16703a-1a55-482f-bb07-b21eef5093a3",
+      "description": "Translation stops if STOP codon at end of three-codon sequence",
+      "property": "proteins",
+      "input": {
+        "strand": "AUGUUUUAA"
+      },
+      "expected": ["Methionine","Phenylalanine"]
+    },
+    {
+      "uuid": "4089bb5a-d5b4-4e71-b79e-b8d1f14a2911",
+      "description": "Translation stops if STOP codon in middle of three-codon sequence",
+      "property": "proteins",
+      "input": {
+        "strand": "UGGUAGUGG"
+      },
+      "expected": ["Tryptophan"]
+    },
+    {
+      "uuid": "2c2a2a60-401f-4a80-b977-e0715b23b93d",
+      "description": "Translation stops if STOP codon in middle of six-codon sequence",
+      "property": "proteins",
+      "input": {
+        "strand": "UGGUGUUAUUAAUGGUUU"
+      },
+      "expected": ["Tryptophan","Cysteine","Tyrosine"]
     }
   ]
 }

--- a/exercises/rotational-cipher/canonical-data.json
+++ b/exercises/rotational-cipher/canonical-data.json
@@ -5,109 +5,104 @@
   ],
   "cases": [
     {
-      "description": "Test rotation from English to ROTn",
-      "cases": [
-        {
-          "uuid": "74e58a38-e484-43f1-9466-877a7515e10f",
-          "description": "rotate a by 0, same output as input",
-          "property": "rotate",
-          "input": {
-            "text": "a",
-            "shiftKey": 0
-          },
-          "expected": "a"
-        },
-        {
-          "uuid": "7ee352c6-e6b0-4930-b903-d09943ecb8f5",
-          "description": "rotate a by 1",
-          "property": "rotate",
-          "input": {
-            "text": "a",
-            "shiftKey": 1
-          },
-          "expected": "b"
-        },
-        {
-          "uuid": "edf0a733-4231-4594-a5ee-46a4009ad764",
-          "description": "rotate a by 26, same output as input",
-          "property": "rotate",
-          "input": {
-            "text": "a",
-            "shiftKey": 26
-          },
-          "expected": "a"
-        },
-        {
-          "uuid": "e3e82cb9-2a5b-403f-9931-e43213879300",
-          "description": "rotate m by 13",
-          "property": "rotate",
-          "input": {
-            "text": "m",
-            "shiftKey": 13
-          },
-          "expected": "z"
-        },
-        {
-          "uuid": "19f9eb78-e2ad-4da4-8fe3-9291d47c1709",
-          "description": "rotate n by 13 with wrap around alphabet",
-          "property": "rotate",
-          "input": {
-            "text": "n",
-            "shiftKey": 13
-          },
-          "expected": "a"
-        },
-        {
-          "uuid": "a116aef4-225b-4da9-884f-e8023ca6408a",
-          "description": "rotate capital letters",
-          "property": "rotate",
-          "input": {
-            "text": "OMG",
-            "shiftKey": 5
-          },
-          "expected": "TRL"
-        },
-        {
-          "uuid": "71b541bb-819c-4dc6-a9c3-132ef9bb737b",
-          "description": "rotate spaces",
-          "property": "rotate",
-          "input": {
-            "text": "O M G",
-            "shiftKey": 5
-          },
-          "expected": "T R L"
-        },
-        {
-          "uuid": "ef32601d-e9ef-4b29-b2b5-8971392282e6",
-          "description": "rotate numbers",
-          "property": "rotate",
-          "input": {
-            "text": "Testing 1 2 3 testing",
-            "shiftKey": 4
-          },
-          "expected": "Xiwxmrk 1 2 3 xiwxmrk"
-        },
-        {
-          "uuid": "32dd74f6-db2b-41a6-b02c-82eb4f93e549",
-          "description": "rotate punctuation",
-          "property": "rotate",
-          "input": {
-            "text": "Let's eat, Grandma!",
-            "shiftKey": 21
-          },
-          "expected": "Gzo'n zvo, Bmviyhv!"
-        },
-        {
-          "uuid": "9fb93fe6-42b0-46e6-9ec1-0bf0a062d8c9",
-          "description": "rotate all letters",
-          "property": "rotate",
-          "input": {
-            "text": "The quick brown fox jumps over the lazy dog.",
-            "shiftKey": 13
-          },
-          "expected": "Gur dhvpx oebja sbk whzcf bire gur ynml qbt."
-        }
-      ]
+      "uuid": "74e58a38-e484-43f1-9466-877a7515e10f",
+      "description": "rotate a by 0, same output as input",
+      "property": "rotate",
+      "input": {
+        "text": "a",
+        "shiftKey": 0
+      },
+      "expected": "a"
+    },
+    {
+      "uuid": "7ee352c6-e6b0-4930-b903-d09943ecb8f5",
+      "description": "rotate a by 1",
+      "property": "rotate",
+      "input": {
+        "text": "a",
+        "shiftKey": 1
+      },
+      "expected": "b"
+    },
+    {
+      "uuid": "edf0a733-4231-4594-a5ee-46a4009ad764",
+      "description": "rotate a by 26, same output as input",
+      "property": "rotate",
+      "input": {
+        "text": "a",
+        "shiftKey": 26
+      },
+      "expected": "a"
+    },
+    {
+      "uuid": "e3e82cb9-2a5b-403f-9931-e43213879300",
+      "description": "rotate m by 13",
+      "property": "rotate",
+      "input": {
+        "text": "m",
+        "shiftKey": 13
+      },
+      "expected": "z"
+    },
+    {
+      "uuid": "19f9eb78-e2ad-4da4-8fe3-9291d47c1709",
+      "description": "rotate n by 13 with wrap around alphabet",
+      "property": "rotate",
+      "input": {
+        "text": "n",
+        "shiftKey": 13
+      },
+      "expected": "a"
+    },
+    {
+      "uuid": "a116aef4-225b-4da9-884f-e8023ca6408a",
+      "description": "rotate capital letters",
+      "property": "rotate",
+      "input": {
+        "text": "OMG",
+        "shiftKey": 5
+      },
+      "expected": "TRL"
+    },
+    {
+      "uuid": "71b541bb-819c-4dc6-a9c3-132ef9bb737b",
+      "description": "rotate spaces",
+      "property": "rotate",
+      "input": {
+        "text": "O M G",
+        "shiftKey": 5
+      },
+      "expected": "T R L"
+    },
+    {
+      "uuid": "ef32601d-e9ef-4b29-b2b5-8971392282e6",
+      "description": "rotate numbers",
+      "property": "rotate",
+      "input": {
+        "text": "Testing 1 2 3 testing",
+        "shiftKey": 4
+      },
+      "expected": "Xiwxmrk 1 2 3 xiwxmrk"
+    },
+    {
+      "uuid": "32dd74f6-db2b-41a6-b02c-82eb4f93e549",
+      "description": "rotate punctuation",
+      "property": "rotate",
+      "input": {
+        "text": "Let's eat, Grandma!",
+        "shiftKey": 21
+      },
+      "expected": "Gzo'n zvo, Bmviyhv!"
+    },
+    {
+      "uuid": "9fb93fe6-42b0-46e6-9ec1-0bf0a062d8c9",
+      "description": "rotate all letters",
+      "property": "rotate",
+      "input": {
+        "text": "The quick brown fox jumps over the lazy dog.",
+        "shiftKey": 13
+      },
+      "expected": "Gur dhvpx oebja sbk whzcf bire gur ynml qbt."
     }
   ]
 }

--- a/exercises/secret-handshake/canonical-data.json
+++ b/exercises/secret-handshake/canonical-data.json
@@ -15,108 +15,103 @@
   ],
   "cases": [
     {
-      "description": "Create a handshake for a number",
-      "cases": [
-        {
-          "uuid": "b8496fbd-6778-468c-8054-648d03c4bb23",
-          "description": "wink for 1",
-          "property": "commands",
-          "input": {
-            "number": 1
-          },
-          "expected": ["wink"]
-        },
-        {
-          "uuid": "83ec6c58-81a9-4fd1-bfaf-0160514fc0e3",
-          "description": "double blink for 10",
-          "property": "commands",
-          "input": {
-            "number": 2
-          },
-          "expected": ["double blink"]
-        },
-        {
-          "uuid": "0e20e466-3519-4134-8082-5639d85fef71",
-          "description": "close your eyes for 100",
-          "property": "commands",
-          "input": {
-            "number": 4
-          },
-          "expected": ["close your eyes"]
-        },
-        {
-          "uuid": "b339ddbb-88b7-4b7d-9b19-4134030d9ac0",
-          "description": "jump for 1000",
-          "property": "commands",
-          "input": {
-            "number": 8
-          },
-          "expected": ["jump"]
-        },
-        {
-          "uuid": "40499fb4-e60c-43d7-8b98-0de3ca44e0eb",
-          "description": "combine two actions",
-          "property": "commands",
-          "input": {
-            "number": 3
-          },
-          "expected": ["wink", "double blink"]
-        },
-        {
-          "uuid": "9730cdd5-ef27-494b-afd3-5c91ad6c3d9d",
-          "description": "reverse two actions",
-          "property": "commands",
-          "input": {
-            "number": 19
-          },
-          "expected": ["double blink", "wink"]
-        },
-        {
-          "uuid": "0b828205-51ca-45cd-90d5-f2506013f25f",
-          "description": "reversing one action gives the same action",
-          "property": "commands",
-          "input": {
-            "number": 24
-          },
-          "expected": ["jump"]
-        },
-        {
-          "uuid": "9949e2ac-6c9c-4330-b685-2089ab28b05f",
-          "description": "reversing no actions still gives no actions",
-          "property": "commands",
-          "input": {
-            "number": 16
-          },
-          "expected": []
-        },
-        {
-          "uuid": "23fdca98-676b-4848-970d-cfed7be39f81",
-          "description": "all possible actions",
-          "property": "commands",
-          "input": {
-            "number": 15
-          },
-          "expected": ["wink", "double blink", "close your eyes", "jump"]
-        },
-        {
-          "uuid": "ae8fe006-d910-4d6f-be00-54b7c3799e79",
-          "description": "reverse all possible actions",
-          "property": "commands",
-          "input": {
-            "number": 31
-          },
-          "expected": ["jump", "close your eyes", "double blink", "wink"]
-        },
-        {
-          "uuid": "3d36da37-b31f-4cdb-a396-d93a2ee1c4a5",
-          "description": "do nothing for zero",
-          "property": "commands",
-          "input": {
-            "number": 0
-          },
-          "expected": []
-        }
-      ]
+      "uuid": "b8496fbd-6778-468c-8054-648d03c4bb23",
+      "description": "wink for 1",
+      "property": "commands",
+      "input": {
+        "number": 1
+      },
+      "expected": ["wink"]
+    },
+    {
+      "uuid": "83ec6c58-81a9-4fd1-bfaf-0160514fc0e3",
+      "description": "double blink for 10",
+      "property": "commands",
+      "input": {
+        "number": 2
+      },
+      "expected": ["double blink"]
+    },
+    {
+      "uuid": "0e20e466-3519-4134-8082-5639d85fef71",
+      "description": "close your eyes for 100",
+      "property": "commands",
+      "input": {
+        "number": 4
+      },
+      "expected": ["close your eyes"]
+    },
+    {
+      "uuid": "b339ddbb-88b7-4b7d-9b19-4134030d9ac0",
+      "description": "jump for 1000",
+      "property": "commands",
+      "input": {
+        "number": 8
+      },
+      "expected": ["jump"]
+    },
+    {
+      "uuid": "40499fb4-e60c-43d7-8b98-0de3ca44e0eb",
+      "description": "combine two actions",
+      "property": "commands",
+      "input": {
+        "number": 3
+      },
+      "expected": ["wink", "double blink"]
+    },
+    {
+      "uuid": "9730cdd5-ef27-494b-afd3-5c91ad6c3d9d",
+      "description": "reverse two actions",
+      "property": "commands",
+      "input": {
+        "number": 19
+      },
+      "expected": ["double blink", "wink"]
+    },
+    {
+      "uuid": "0b828205-51ca-45cd-90d5-f2506013f25f",
+      "description": "reversing one action gives the same action",
+      "property": "commands",
+      "input": {
+        "number": 24
+      },
+      "expected": ["jump"]
+    },
+    {
+      "uuid": "9949e2ac-6c9c-4330-b685-2089ab28b05f",
+      "description": "reversing no actions still gives no actions",
+      "property": "commands",
+      "input": {
+        "number": 16
+      },
+      "expected": []
+    },
+    {
+      "uuid": "23fdca98-676b-4848-970d-cfed7be39f81",
+      "description": "all possible actions",
+      "property": "commands",
+      "input": {
+        "number": 15
+      },
+      "expected": ["wink", "double blink", "close your eyes", "jump"]
+    },
+    {
+      "uuid": "ae8fe006-d910-4d6f-be00-54b7c3799e79",
+      "description": "reverse all possible actions",
+      "property": "commands",
+      "input": {
+        "number": 31
+      },
+      "expected": ["jump", "close your eyes", "double blink", "wink"]
+    },
+    {
+      "uuid": "3d36da37-b31f-4cdb-a396-d93a2ee1c4a5",
+      "description": "do nothing for zero",
+      "property": "commands",
+      "input": {
+        "number": 0
+      },
+      "expected": []
     }
   ]
 }

--- a/exercises/trinary/canonical-data.json
+++ b/exercises/trinary/canonical-data.json
@@ -2,108 +2,103 @@
   "exercise": "trinary",
   "cases": [
     {
-      "description": "returns the decimal representation of the input trinary value",
-      "cases": [
-        {
-          "uuid": "a7a79a9e-5606-454c-9cdb-4f3c0ca46931",
-          "description": "trinary 1 is decimal 1",
-          "property": "toDecimal",
-          "input": {
-            "trinary": 1
-          },
-          "expected": 1
-        },
-        {
-          "uuid": "39240078-13e2-4eb8-87c4-aeffa7d64130",
-          "description": "trinary 2 is decimal 2",
-          "property": "toDecimal",
-          "input": {
-            "trinary": 2
-          },
-          "expected": 2
-        },
-        {
-          "uuid": "81900d67-7e07-4d41-a71e-86f1cd72ce1f",
-          "description": "trinary 10 is decimal 3",
-          "property": "toDecimal",
-          "input": {
-            "trinary": 10
-          },
-          "expected": 3
-        },
-        {
-          "uuid": "7a8d5341-f88a-4c60-9048-4d5e017fa701",
-          "description": "trinary 11 is decimal 4",
-          "property": "toDecimal",
-          "input": {
-            "trinary": 11
-          },
-          "expected": 4
-        },
-        {
-          "uuid": "6b3c37f6-d6b3-4575-85c0-19f48dd101af",
-          "description": "trinary 100 is decimal 9",
-          "property": "toDecimal",
-          "input": {
-            "trinary": 100
-          },
-          "expected": 9
-        },
-        {
-          "uuid": "a210b2b8-d333-4e19-9e59-87cabdd2a0ba",
-          "description": "trinary 112 is decimal 14",
-          "property": "toDecimal",
-          "input": {
-            "trinary": 112
-          },
-          "expected": 14
-        },
-        {
-          "uuid": "5ae03472-b942-42ce-ba00-e84a7dc86dd8",
-          "description": "trinary 222 is decimal 26",
-          "property": "toDecimal",
-          "input": {
-            "trinary": 222
-          },
-          "expected": 26
-        },
-        {
-          "uuid": "d4fabf94-6149-4d1e-b42f-b34dc3ddef8f",
-          "description": "trinary 1122000120 is decimal 32091",
-          "property": "toDecimal",
-          "input": {
-            "trinary": 1122000120
-          },
-          "expected": 32091
-        },
-        {
-          "uuid": "34be152d-38f3-4dcf-b5ab-9e14fe2f7161",
-          "description": "invalid trinary digits returns 0",
-          "property": "toDecimal",
-          "input": {
-            "trinary": "1234"
-          },
-          "expected": 0
-        },
-        {
-          "uuid": "b57aa24d-3da2-4787-9429-5bc94d3112d6",
-          "description": "invalid word as input returns 0",
-          "property": "toDecimal",
-          "input": {
-            "trinary": "carrot"
-          },
-          "expected": 0
-        },
-        {
-          "uuid": "673c2057-5d89-483c-87fa-139da6927b90",
-          "description": "invalid numbers with letters as input returns 0",
-          "property": "toDecimal",
-          "input": {
-            "trinary": "0a1b2c"
-          },
-          "expected": 0
-        }
-      ]
+      "uuid": "a7a79a9e-5606-454c-9cdb-4f3c0ca46931",
+      "description": "trinary 1 is decimal 1",
+      "property": "toDecimal",
+      "input": {
+        "trinary": 1
+      },
+      "expected": 1
+    },
+    {
+      "uuid": "39240078-13e2-4eb8-87c4-aeffa7d64130",
+      "description": "trinary 2 is decimal 2",
+      "property": "toDecimal",
+      "input": {
+        "trinary": 2
+      },
+      "expected": 2
+    },
+    {
+      "uuid": "81900d67-7e07-4d41-a71e-86f1cd72ce1f",
+      "description": "trinary 10 is decimal 3",
+      "property": "toDecimal",
+      "input": {
+        "trinary": 10
+      },
+      "expected": 3
+    },
+    {
+      "uuid": "7a8d5341-f88a-4c60-9048-4d5e017fa701",
+      "description": "trinary 11 is decimal 4",
+      "property": "toDecimal",
+      "input": {
+        "trinary": 11
+      },
+      "expected": 4
+    },
+    {
+      "uuid": "6b3c37f6-d6b3-4575-85c0-19f48dd101af",
+      "description": "trinary 100 is decimal 9",
+      "property": "toDecimal",
+      "input": {
+        "trinary": 100
+      },
+      "expected": 9
+    },
+    {
+      "uuid": "a210b2b8-d333-4e19-9e59-87cabdd2a0ba",
+      "description": "trinary 112 is decimal 14",
+      "property": "toDecimal",
+      "input": {
+        "trinary": 112
+      },
+      "expected": 14
+    },
+    {
+      "uuid": "5ae03472-b942-42ce-ba00-e84a7dc86dd8",
+      "description": "trinary 222 is decimal 26",
+      "property": "toDecimal",
+      "input": {
+        "trinary": 222
+      },
+      "expected": 26
+    },
+    {
+      "uuid": "d4fabf94-6149-4d1e-b42f-b34dc3ddef8f",
+      "description": "trinary 1122000120 is decimal 32091",
+      "property": "toDecimal",
+      "input": {
+        "trinary": 1122000120
+      },
+      "expected": 32091
+    },
+    {
+      "uuid": "34be152d-38f3-4dcf-b5ab-9e14fe2f7161",
+      "description": "invalid trinary digits returns 0",
+      "property": "toDecimal",
+      "input": {
+        "trinary": "1234"
+      },
+      "expected": 0
+    },
+    {
+      "uuid": "b57aa24d-3da2-4787-9429-5bc94d3112d6",
+      "description": "invalid word as input returns 0",
+      "property": "toDecimal",
+      "input": {
+        "trinary": "carrot"
+      },
+      "expected": 0
+    },
+    {
+      "uuid": "673c2057-5d89-483c-87fa-139da6927b90",
+      "description": "invalid numbers with letters as input returns 0",
+      "property": "toDecimal",
+      "input": {
+        "trinary": "0a1b2c"
+      },
+      "expected": 0
     }
   ]
 }


### PR DESCRIPTION
The canonical data for `isogram` and `prime-factors` contain nesting, but as there is only one level of nesting, this does not add any value.﻿

This can break test generators, but as everything is still in flux anyway, I think this is a good time to do this.

Note: please don't squash merge to retain the individual commits