### PR TITLE
Update sync documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ or the short form `configlet sync -e foo -u -mi`.
 The `sync` command operates on Practice Exercises that are in the track-level `config.json` file.
 If you are adding an exercise that has canonical data to a track, first add that exercise to the track-level `config.json`, and then run a `configlet sync` command to create the corresponding `tests.toml` file.
 
-To download the latest version of the `configlet` tool, please run the [`fetch-configlet`](https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet) script or the [`fetch-configlet.ps1`](https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.ps1) script. At least one of these scripts should already exist in every track repo's `bin` directory - the script will also download `configlet` to this location. You can then sync the tests by running `./bin/configlet sync` (on Linux or macOS) or `.\bin\configlet.exe sync` (on Windows).
+To download the latest version of the `configlet` tool, please run the [`fetch-configlet`](https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet) bash script or the [`fetch-configlet.ps1`](https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.ps1) PowerShell script (Windows only). At least one of these scripts should already exist in every track repo's `bin` directory - the script will also download `configlet` to this location. You can then sync the tests by running `./bin/configlet sync` (on macOS/Linux/similar) or `.\bin\configlet.exe sync` (on Windows).
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,17 @@ A plain `configlet sync` performs no changes, and just compares the tests specif
 To interactively update the `tests.toml` files, use `configlet sync --update`.
 For each missing test, this prompts the user to choose whether to include/exclude/skip it, and updates the corresponding `tests.toml` file accordingly.
 
+To non-interactively include every missing test for an exercise `foo`, use:
+
+```
+configlet sync --exercise foo --update --mode include
+```
+
+or the short form `configlet sync -e foo -u -mi`.
+
+The `sync` command operates on Practice Exercises that are in the track-level `config.json` file.
+If you are adding an exercise that has canonical data to a track, first add that exercise to the track-level `config.json`, and then run a `configlet sync` command to create the corresponding `tests.toml` file.
+
 To download the latest version of the `configlet` tool, please run the [`fetch-configlet`](https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet) script or the [`fetch-configlet.ps1`](https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.ps1) script. At least one of these scripts should already exist in every track repo's `bin` directory - the script will also download `configlet` to this location. You can then sync the tests by running `./bin/configlet sync` (on Linux or macOS) or `.\bin\configlet.exe sync` (on Windows).
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -190,27 +190,26 @@ If a track implements an exercise for which test data exists, the exercise _must
 A `tests.toml` file for a track's `two-fer` exercise looks like this:
 
 ```toml
-[canonical-tests]
+[19709124-b82e-4e86-a722-9e5c5ebf3952]
+description = "no name given"
 
-# no name given
-"19709124-b82e-4e86-a722-9e5c5ebf3952" = true
+[3451eebd-123f-4256-b667-7b109affce32]
+description = "a name given"
+include = false
 
-# a name given
-"3451eebd-123f-4256-b667-7b109affce32" = true
-
-# another name given
-"653611c6-be9f-4935-ab42-978e25fe9a10" = false
+[653611c6-be9f-4935-ab42-978e25fe9a10]
+description = "another name given"
 ```
 
-In this case, the track has chosen to implement two of the three available tests.
+In this case, the track has chosen to implement two of the three available tests (`include = true` is the default and is omitted).
 
 If a track uses a _test generator_ to generate an exercise's test suite, it _must_ use the contents of the `tests.toml` file to determine which tests to include in the generated test suite.
 
 ### Track Test Data Tooling
 
-To make it easy to keep the `tests.toml` up to date, tracks can use the [`canonical_data_syncer` application](https://github.com/exercism/canonical-data-syncer). This application is a small, standalone binary that will compare the tests specified in the `tests.toml` files against the tests that are defined in the exercise's canonical data. It then interactively gives the maintainer the option to include or exclude test cases that are currently missing, updating the `tests.toml` file accordingly.
+To make it easy to keep the `tests.toml` up to date, tracks can use the [`configlet` application](https://github.com/exercism/configlet)'s `sync` command. This command will compare the tests specified in the `tests.toml` files against the tests that are defined in the exercise's canonical data. It then interactively gives the maintainer the option to include or exclude test cases that are currently missing, updating the `tests.toml` file accordingly.
 
-To use the canonical data syncer tool, tracks should copying the [`fetch-canonical_data_syncer`](https://github.com/exercism/canonical-data-syncer/blob/main/scripts/fetch-canonical_data_syncer) and/or [`fetch-canonical_data_syncer.ps1`](https://github.com/exercism/canonical-data-syncer/blob/main/scripts/fetch-canonical_data_syncer.ps1) scripts into their repository. Then, running either of these scripts will download the latest version of the tool to the track's `bin` directory. The tool can be run using `./bin/canonical_data_syncer` or `.\bin\canonical_data_syncer.exe`, depending on your operating system.
+To use the configlet tool, tracks should copy the [`fetch-configlet`](https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet) and/or [`fetch-configlet.ps1`](https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.ps1) scripts into their repository's `bin` directory. Then, running either of these scripts will download the latest version of the tool to the same `bin` directory. The tool can then be run using `./bin/configlet sync` or `.\bin\configlet.exe sync`, depending on your operating system.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ This is an example of what a re-implementation looks like:
 
 If a track implements an exercise for which test data exists, the exercise _must_ contain a `.meta/tests.toml` file. The goal of this file is to keep track of which tests are implemented by the exercise. Tests in this file are identified by their UUID and each test has a boolean value that indicates if it is implemented by that exercise.
 
-A `tests.toml` file for a track's `two-fer` exercise looks like this:
+A `tests.toml` file for a track's `two-fer` exercise might contain:
 
 ```toml
 [19709124-b82e-4e86-a722-9e5c5ebf3952]

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ include = false
 
 [653611c6-be9f-4935-ab42-978e25fe9a10]
 description = "another name given"
+comment = "comments like this will persist across syncs"
 ```
 
 In this case, the track has chosen to implement two of the three available tests (`include = true` is the default and is omitted).

--- a/README.md
+++ b/README.md
@@ -207,7 +207,11 @@ If a track uses a _test generator_ to generate an exercise's test suite, it _mus
 
 ### Track Test Data Tooling
 
-To make it easy to keep the `tests.toml` up to date, tracks can use the [`configlet` application](https://github.com/exercism/configlet)'s `sync` command. This command will compare the tests specified in the `tests.toml` files against the tests that are defined in the exercise's canonical data. It then interactively gives the maintainer the option to include or exclude test cases that are currently missing, updating the `tests.toml` file accordingly.
+To make it easy to keep the `tests.toml` up to date, tracks can use the [`configlet` application](https://github.com/exercism/configlet)'s `sync` command.
+A plain `configlet sync` performs no changes, and just compares the tests specified in the `tests.toml` files against the tests that are defined in the exercise's canonical data - if there are tests defined only in the latter, it prints a summary and exits with a non-zero exit code.
+
+To interactively update the `tests.toml` files, use `configlet sync --update`.
+For each missing test, this prompts the user to choose whether to include/exclude/skip it, and updates the corresponding `tests.toml` file accordingly.
 
 To download the latest version of the `configlet` tool, please run the [`fetch-configlet`](https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet) script or the [`fetch-configlet.ps1`](https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.ps1) script. At least one of these scripts should already exist in every track repo's `bin` directory - the script will also download `configlet` to this location. You can then sync the tests by running `./bin/configlet sync` (on Linux or macOS) or `.\bin\configlet.exe sync` (on Windows).
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ If a track uses a _test generator_ to generate an exercise's test suite, it _mus
 
 To make it easy to keep the `tests.toml` up to date, tracks can use the [`configlet` application](https://github.com/exercism/configlet)'s `sync` command. This command will compare the tests specified in the `tests.toml` files against the tests that are defined in the exercise's canonical data. It then interactively gives the maintainer the option to include or exclude test cases that are currently missing, updating the `tests.toml` file accordingly.
 
-To use the configlet tool, tracks should copy the [`fetch-configlet`](https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet) and/or [`fetch-configlet.ps1`](https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.ps1) scripts into their repository's `bin` directory. Then, running either of these scripts will download the latest version of the tool to the same `bin` directory. The tool can then be run using `./bin/configlet sync` or `.\bin\configlet.exe sync`, depending on your operating system.
+To download the latest version of the `configlet` tool, please run the [`fetch-configlet`](https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet) script or the [`fetch-configlet.ps1`](https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.ps1) script. At least one of these scripts should already exist in every track repo's `bin` directory - the script will also download `configlet` to this location. You can then sync the tests by running `./bin/configlet sync` (on Linux or macOS) or `.\bin\configlet.exe sync` (on Windows).
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ If a track uses a _test generator_ to generate an exercise's test suite, it _mus
 
 ### Track Test Data Tooling
 
-To make it easy to keep the `tests.toml` up to date, tracks can use the [`configlet` application](https://github.com/exercism/configlet)'s `sync` command.
+To make it easy to keep the `tests.toml` up to date, tracks should use the [`configlet` application](https://github.com/exercism/configlet)'s `sync` command.
 A plain `configlet sync` performs no changes, and just compares the tests specified in the `tests.toml` files against the tests that are defined in the exercise's canonical data - if there are tests defined only in the latter, it prints a summary and exits with a non-zero exit code.
 
 To interactively update the `tests.toml` files, use `configlet sync --update`.


### PR DESCRIPTION
The current documentation for `tests.toml` files was still referring to the obsolete canonical data syncer. This PR updates the documentation to use configlet's `sync` command instead. It also updates the contents of the example `tests.toml` file to the latest spec.

Closes https://github.com/exercism/configlet/issues/124
