### PR TITLE
Convert exercise metadata from yaml to json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,7 +219,7 @@ A problem must have a unique slug. This slug is used as
 
 ### In exercism/problem-specifications
 
-* Create `exercises/<slug>/description.md` and `exercises/<slug>/metadata.yml`.
+* Create `exercises/<slug>/description.md` and `exercises/<slug>/metadata.toml`.
 * Bonus: `exercises/<slug>/canonical-data.json` with inputs/outputs for the test suite.
 * Submit a pull request.
 
@@ -230,7 +230,7 @@ A problem must have a unique slug. This slug is used as
   Reference the PR in problem-specifications.
   It's suggested, but not required, to wait until the problem-specifications PR is merged before merging the track-specific PR, for the following reasons:
     * If changes are suggested to the problem-specifications PR, it is likely that they will be applicable to the track-specific PR as well.
-    * Only applicable if the exercise needs a custom `title` in metadata.yml (as described in https://github.com/exercism/docs/blob/main/you-can-help/make-up-new-exercises.md#problem-specification): The title of the exercise as displayed on the website will use the default algorithm instead of the correct title until the problem-specifications PR is merged.
+    * Only applicable if the exercise needs a custom `title` in metadata.toml (as described in https://github.com/exercism/docs/blob/main/you-can-help/make-up-new-exercises.md#problem-specification): The title of the exercise as displayed on the website will use the default algorithm instead of the correct title until the problem-specifications PR is merged.
     * Only applicable to tracks that have specific tools that depend on exercises being present in problem-specifications (see the track-specific documentation for whether any such tools exist): Such tools may operate unexpectedly if the exercise does not yet exist in problem-specifications. Try checking out the branch on a local copy of problem-specifications or rerunning the tool after the problem-specifications PR is merged if applicable.
 
 ## Track Anatomy

--- a/README.md
+++ b/README.md
@@ -14,22 +14,22 @@ Each exercise's metadata lives in a directory under `exercises/`.
 exercises/
 ├── accumulate
 │   ├── description.md
-│   └── metadata.yml
+│   └── metadata.toml
 ├── ...
 ├── minesweeper
 │   ├── canonical-data.json
 │   ├── description.md
-│   └── metadata.yml
+│   └── metadata.toml
 ├── ...
 └── zipper
     ├── description.md
-    └── metadata.yml
+    └── metadata.toml
 ```
 
 There are three metadata files per exercise:
 
 - `description.md` - the basic problem description
-- `metadata.yml` - additional information about the exercise, such as where it came from
+- `metadata.toml` - additional information about the exercise, such as where it came from
 - `canonical-data.json` (optional) - standardized test inputs and outputs that can be used to implement the exercise
 
 ## Test Data (canonical-data.json)

--- a/bin/check_required_files_present
+++ b/bin/check_required_files_present
@@ -26,7 +26,7 @@ function check_directory {
 	for exercise_directory in $directory/* ; do
 		show_progress
 		require_file "$exercise_directory/description.md"
-		require_file "$exercise_directory/metadata.yml"
+		require_file "$exercise_directory/metadata.toml"
 	done
 
 }

--- a/bin/transfer_blurb_to_description.rb
+++ b/bin/transfer_blurb_to_description.rb
@@ -33,6 +33,7 @@ class Exercise
   end
 
   def metadata
+    # TODO: Update to parse TOML instead
     metadata_filename = File.join(path, 'metadata.yml')
     YAML.load_file(metadata_filename)
   end

--- a/exercises/accumulate/metadata.toml
+++ b/exercises/accumulate/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection."
+source = "Conversation with James Edward Gray II"
+source_url = "https://twitter.com/jeg2"

--- a/exercises/acronym/metadata.toml
+++ b/exercises/acronym/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Convert a long phrase to its acronym."
+source = "Julien Vanier"
+source_url = "https://github.com/monkbroc"

--- a/exercises/affine-cipher/metadata.toml
+++ b/exercises/affine-cipher/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Create an implementation of the Affine cipher, an ancient encryption algorithm from the Middle East."
+source = "Wikipedia"
+source_url = "http://en.wikipedia.org/wiki/Affine_cipher"

--- a/exercises/all-your-base/metadata.toml
+++ b/exercises/all-your-base/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Convert a number, represented as a sequence of digits in one base, to any other base."

--- a/exercises/allergies/metadata.toml
+++ b/exercises/allergies/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies."
+source = "Jumpstart Lab Warm-up"
+source_url = "http://jumpstartlab.com"

--- a/exercises/alphametics/metadata.toml
+++ b/exercises/alphametics/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Write a function to solve alphametics puzzles."

--- a/exercises/anagram/metadata.toml
+++ b/exercises/anagram/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given a word and a list of possible anagrams, select the correct sublist."
+source = "Inspired by the Extreme Startup game"
+source_url = "https://github.com/rchatley/extreme_startup"

--- a/exercises/armstrong-numbers/metadata.toml
+++ b/exercises/armstrong-numbers/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Determine if a number is an Armstrong number."
+source = "Wikipedia"
+source_url = "https://en.wikipedia.org/wiki/Narcissistic_number"

--- a/exercises/atbash-cipher/metadata.toml
+++ b/exercises/atbash-cipher/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East."
+source = "Wikipedia"
+source_url = "http://en.wikipedia.org/wiki/Atbash"

--- a/exercises/bank-account/metadata.toml
+++ b/exercises/bank-account/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Simulate a bank account supporting opening/closing, withdraws, and deposits of money. Watch out for concurrent transactions!"

--- a/exercises/beer-song/metadata.toml
+++ b/exercises/beer-song/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall."
+source = "Learn to Program by Chris Pine"
+source_url = "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/binary-search-tree/metadata.toml
+++ b/exercises/binary-search-tree/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Insert and search for numbers in a binary tree."
+source = "Josh Cheek"
+source_url = "https://twitter.com/josh_cheek"

--- a/exercises/binary-search/metadata.toml
+++ b/exercises/binary-search/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Implement a binary search algorithm."
+source = "Wikipedia"
+source_url = "http://en.wikipedia.org/wiki/Binary_search_algorithm"

--- a/exercises/binary/metadata.toml
+++ b/exercises/binary/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles."
+source = "All of Computer Science"
+source_url = "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"

--- a/exercises/bob/metadata.toml
+++ b/exercises/bob/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Bob is a lackadaisical teenager. In conversation, his responses are very limited."
+source = "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial."
+source_url = "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/book-store/metadata.toml
+++ b/exercises/book-store/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "To try and encourage more sales of different books from a popular 5 book series, a bookshop has decided to offer discounts of multiple-book purchases."
+source = "Inspired by the harry potter kata from Cyber-Dojo."
+source_url = "http://cyber-dojo.org"

--- a/exercises/bowling/metadata.toml
+++ b/exercises/bowling/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Score a bowling game."
+source = "The Bowling Game Kata at but UncleBob"
+source_url = "http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata"

--- a/exercises/change/metadata.toml
+++ b/exercises/change/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Correctly determine change to be given using the least number of coins."
+source = "Software Craftsmanship - Coin Change Kata"
+source_url = "https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata"

--- a/exercises/circular-buffer/metadata.toml
+++ b/exercises/circular-buffer/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "A data structure that uses a single, fixed-size buffer as if it were connected end-to-end."
+source = "Wikipedia"
+source_url = "http://en.wikipedia.org/wiki/Circular_buffer"

--- a/exercises/clock/metadata.toml
+++ b/exercises/clock/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Implement a clock that handles times without dates."
+source = "Pairing session with Erin Drummond"
+source_url = "https://twitter.com/ebdrummond"

--- a/exercises/collatz-conjecture/metadata.toml
+++ b/exercises/collatz-conjecture/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Calculate the number of steps to reach 1 using the Collatz conjecture."
+source = "An unsolved problem in mathematics named after mathematician Lothar Collatz"
+source_url = "https://en.wikipedia.org/wiki/3x_%2B_1_problem"

--- a/exercises/complex-numbers/metadata.toml
+++ b/exercises/complex-numbers/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Implement complex numbers."
+source = "Wikipedia"
+source_url = "https://en.wikipedia.org/wiki/Complex_number"

--- a/exercises/connect/metadata.toml
+++ b/exercises/connect/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Compute the result for a game of Hex / Polygon."

--- a/exercises/counter/metadata.toml
+++ b/exercises/counter/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Design a test suite for a line/letter/character counter tool."

--- a/exercises/crypto-square/metadata.toml
+++ b/exercises/crypto-square/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Implement the classic method for composing secret messages called a square code."
+source = "J Dalbey's Programming Practice problems"
+source_url = "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/custom-set/metadata.toml
+++ b/exercises/custom-set/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Create a custom set type."

--- a/exercises/darts/metadata.toml
+++ b/exercises/darts/metadata.toml
@@ -1,0 +1,2 @@
+blurb = "Write a function that returns the earned points in a single toss of a Darts game."
+source = "Inspired by an exercise created by a professor Della Paolera in Argentina"

--- a/exercises/diamond/metadata.toml
+++ b/exercises/diamond/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given a letter, print a diamond starting with 'A' with the supplied letter at the widest point."
+source = "Seb Rose"
+source_url = "http://claysnow.co.uk/recycling-tests-in-tdd/"

--- a/exercises/difference-of-squares/metadata.toml
+++ b/exercises/difference-of-squares/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers."
+source = "Problem 6 at Project Euler"
+source_url = "http://projecteuler.net/problem=6"

--- a/exercises/diffie-hellman/metadata.toml
+++ b/exercises/diffie-hellman/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Diffie-Hellman key exchange."
+source = "Wikipedia, 1024 bit key from www.cryptopp.com/wiki."
+source_url = "http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange"

--- a/exercises/dnd-character/metadata.toml
+++ b/exercises/dnd-character/metadata.toml
@@ -1,0 +1,4 @@
+blurb = "Randomly generate Dungeons & Dragons characters."
+source = "Simon Shine, Erik Schierboom"
+source_url = "https://github.com/exercism/problem-specifications/issues/616#issuecomment-437358945"
+title = "D&D Character"

--- a/exercises/dominoes/metadata.toml
+++ b/exercises/dominoes/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Make a chain of dominoes."

--- a/exercises/dot-dsl/metadata.toml
+++ b/exercises/dot-dsl/metadata.toml
@@ -1,0 +1,4 @@
+title = "DOT DSL"
+blurb = "Write a Domain Specific Language similar to the Graphviz dot language."
+source = "Wikipedia"
+source_url = "https://en.wikipedia.org/wiki/DOT_(graph_description_language)"

--- a/exercises/error-handling/metadata.toml
+++ b/exercises/error-handling/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Implement various kinds of error handling and resource management."

--- a/exercises/etl/metadata.toml
+++ b/exercises/etl/metadata.toml
@@ -1,0 +1,4 @@
+title = "ETL"
+blurb = "We are going to do the `Transform` step of an Extract-Transform-Load."
+source = "The Jumpstart Lab team"
+source_url = "http://jumpstartlab.com"

--- a/exercises/flatten-array/metadata.toml
+++ b/exercises/flatten-array/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Take a nested list and return a single list with all values except nil/null."
+source = "Interview Question"
+source_url = "https://reference.wolfram.com/language/ref/Flatten.html"

--- a/exercises/food-chain/metadata.toml
+++ b/exercises/food-chain/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'."
+source = "Wikipedia"
+source_url = "http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly"

--- a/exercises/forth/metadata.toml
+++ b/exercises/forth/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Implement an evaluator for a very simple subset of Forth."

--- a/exercises/gigasecond/metadata.toml
+++ b/exercises/gigasecond/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given a moment, determine the moment that would be after a gigasecond has passed."
+source = "Chapter 9 in Chris Pine's online Learn to Program tutorial."
+source_url = "http://pine.fm/LearnToProgram/?Chapter=09"

--- a/exercises/go-counting/metadata.toml
+++ b/exercises/go-counting/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Count the scored points on a Go board."

--- a/exercises/grade-school/metadata.toml
+++ b/exercises/grade-school/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given students' names along with the grade that they are in, create a roster for the school."
+source = "A pairing session with Phil Battos at gSchool"
+source_url = "http://gschool.it"

--- a/exercises/grains/metadata.toml
+++ b/exercises/grains/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles."
+source = "JavaRanch Cattle Drive, exercise 6"
+source_url = "http://www.javaranch.com/grains.jsp"

--- a/exercises/grep/metadata.toml
+++ b/exercises/grep/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Search a file for lines matching a regular expression pattern. Return the line number and contents of each matching line."
+source = "Conversation with Nate Foster."
+source_url = "http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf"

--- a/exercises/hamming/metadata.toml
+++ b/exercises/hamming/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Calculate the Hamming difference between two DNA strands."
+source = "The Calculating Point Mutations problem at Rosalind"
+source_url = "http://rosalind.info/problems/hamm/"

--- a/exercises/hangman/metadata.toml
+++ b/exercises/hangman/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Implement the logic of the hangman game using functional reactive programming."

--- a/exercises/hello-world/metadata.toml
+++ b/exercises/hello-world/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "The classical introductory exercise. Just say \"Hello, World!\"."
+source = "This is an exercise to introduce users to using Exercism"
+source_url = "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"

--- a/exercises/hexadecimal/metadata.toml
+++ b/exercises/hexadecimal/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Convert a hexadecimal number, represented as a string (e.g. \"10af8c\"), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion)."
+source = "All of Computer Science"
+source_url = "http://www.wolframalpha.com/examples/NumberBases.html"

--- a/exercises/high-scores/metadata.toml
+++ b/exercises/high-scores/metadata.toml
@@ -1,0 +1,2 @@
+blurb = "Manage a player's High Score list."
+source = "Tribute to the eighties' arcade game Frogger"

--- a/exercises/house/metadata.toml
+++ b/exercises/house/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Output the nursery rhyme 'This is the House that Jack Built'."
+source = "British nursery rhyme"
+source_url = "http://en.wikipedia.org/wiki/This_Is_The_House_That_Jack_Built"

--- a/exercises/isbn-verifier/metadata.toml
+++ b/exercises/isbn-verifier/metadata.toml
@@ -1,0 +1,4 @@
+title = "ISBN Verifier"
+blurb = "Check if a given string is a valid ISBN-10 number."
+source = "Converting a string into a number and some basic processing utilizing a relatable real world example."
+source_url = "https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation"

--- a/exercises/isogram/metadata.toml
+++ b/exercises/isogram/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Determine if a word or phrase is an isogram."
+source = "Wikipedia"
+source_url = "https://en.wikipedia.org/wiki/Isogram"

--- a/exercises/kindergarten-garden/metadata.toml
+++ b/exercises/kindergarten-garden/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given a diagram, determine which plants each child in the kindergarten class is responsible for."
+source = "Random musings during airplane trip."
+source_url = "http://jumpstartlab.com"

--- a/exercises/knapsack/metadata.toml
+++ b/exercises/knapsack/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given a knapsack that can only carry a certain weight, determine which items to put in the knapsack in order to maximize their combined value."
+source = "Wikipedia"
+source_url = "https://en.wikipedia.org/wiki/Knapsack_problem"

--- a/exercises/largest-series-product/metadata.toml
+++ b/exercises/largest-series-product/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given a string of digits, calculate the largest product for a contiguous substring of digits of length n."
+source = "A variation on Problem 8 at Project Euler"
+source_url = "http://projecteuler.net/problem=8"

--- a/exercises/leap/metadata.toml
+++ b/exercises/leap/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given a year, report if it is a leap year."
+source = "JavaRanch Cattle Drive, exercise 3"
+source_url = "http://www.javaranch.com/leap.jsp"

--- a/exercises/ledger/metadata.toml
+++ b/exercises/ledger/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Refactor a ledger printer."

--- a/exercises/lens-person/metadata.toml
+++ b/exercises/lens-person/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Use lenses to update nested records (specific to languages with immutable data)."

--- a/exercises/linked-list/metadata.toml
+++ b/exercises/linked-list/metadata.toml
@@ -1,0 +1,2 @@
+blurb = "Implement a doubly linked list."
+source = "Classic computer science topic"

--- a/exercises/list-ops/metadata.toml
+++ b/exercises/list-ops/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Implement basic list operations."

--- a/exercises/luhn/metadata.toml
+++ b/exercises/luhn/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given a number determine whether or not it is valid per the Luhn formula."
+source = "The Luhn Algorithm on Wikipedia"
+source_url = "http://en.wikipedia.org/wiki/Luhn_algorithm"

--- a/exercises/markdown/metadata.toml
+++ b/exercises/markdown/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Refactor a Markdown parser."

--- a/exercises/matching-brackets/metadata.toml
+++ b/exercises/matching-brackets/metadata.toml
@@ -1,0 +1,2 @@
+blurb = "Make sure the brackets and braces all match."
+source = "Ginna Baker"

--- a/exercises/matrix/metadata.toml
+++ b/exercises/matrix/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given a string representing a matrix of numbers, return the rows and columns of that matrix."
+source = "Warmup to the `saddle-points` warmup."
+source_url = "http://jumpstartlab.com"

--- a/exercises/meetup/metadata.toml
+++ b/exercises/meetup/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Calculate the date of meetups."
+source = "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month"
+source_url = "https://twitter.com/copiousfreetime"

--- a/exercises/micro-blog/metadata.toml
+++ b/exercises/micro-blog/metadata.toml
@@ -1,0 +1,2 @@
+title = "Micro Blog"
+blurb = "Given an input string, truncate it to 5 characters."

--- a/exercises/minesweeper/metadata.toml
+++ b/exercises/minesweeper/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Add the numbers to a minesweeper board."

--- a/exercises/nth-prime/metadata.toml
+++ b/exercises/nth-prime/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given a number n, determine what the nth prime is."
+source = "A variation on Problem 7 at Project Euler"
+source_url = "http://projecteuler.net/problem=7"

--- a/exercises/nucleotide-codons/metadata.toml
+++ b/exercises/nucleotide-codons/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Write a function that returns the name of an amino acid a particular codon, possibly using shorthand, encodes for."

--- a/exercises/nucleotide-count/metadata.toml
+++ b/exercises/nucleotide-count/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given a DNA string, compute how many times each nucleotide occurs in the string."
+source = "The Calculating DNA Nucleotides_problem at Rosalind"
+source_url = "http://rosalind.info/problems/dna/"

--- a/exercises/ocr-numbers/metadata.toml
+++ b/exercises/ocr-numbers/metadata.toml
@@ -1,0 +1,4 @@
+title = "OCR Numbers"
+blurb = "Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is represented, or whether it is garbled."
+source = "Inspired by the Bank OCR kata"
+source_url = "http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR"

--- a/exercises/octal/metadata.toml
+++ b/exercises/octal/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Convert a octal number, represented as a string (e.g. '1735263'), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion)."
+source = "All of Computer Science"
+source_url = "http://www.wolframalpha.com/input/?i=base+8"

--- a/exercises/paasio/metadata.toml
+++ b/exercises/paasio/metadata.toml
@@ -1,0 +1,4 @@
+title = "PaaS I/O"
+blurb = "Report network IO statistics."
+source = "Brian Matsuo"
+source_url = "https://github.com/bmatsuo"

--- a/exercises/palindrome-products/metadata.toml
+++ b/exercises/palindrome-products/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Detect palindrome products in a given range."
+source = "Problem 4 at Project Euler"
+source_url = "http://projecteuler.net/problem=4"

--- a/exercises/pangram/metadata.toml
+++ b/exercises/pangram/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Determine if a sentence is a pangram."
+source = "Wikipedia"
+source_url = "https://en.wikipedia.org/wiki/Pangram"

--- a/exercises/parallel-letter-frequency/metadata.toml
+++ b/exercises/parallel-letter-frequency/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Count the frequency of letters in texts using parallel computation."

--- a/exercises/pascals-triangle/metadata.toml
+++ b/exercises/pascals-triangle/metadata.toml
@@ -1,0 +1,4 @@
+title = "Pascal's Triangle"
+blurb = "Compute Pascal's triangle up to a given number of rows."
+source = "Pascal's Triangle at Wolfram Math World"
+source_url = "http://mathworld.wolfram.com/PascalsTriangle.html"

--- a/exercises/perfect-numbers/metadata.toml
+++ b/exercises/perfect-numbers/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers."
+source = "Taken from Chapter 2 of Functional Thinking by Neal Ford."
+source_url = "http://shop.oreilly.com/product/0636920029687.do"

--- a/exercises/phone-number/metadata.toml
+++ b/exercises/phone-number/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Clean up user-entered phone numbers so that they can be sent SMS messages."
+source = "Event Manager by JumpstartLab"
+source_url = "http://tutorials.jumpstartlab.com/projects/eventmanager.html"

--- a/exercises/pig-latin/metadata.toml
+++ b/exercises/pig-latin/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Implement a program that translates from English to Pig Latin."
+source = "The Pig Latin exercise at Test First Teaching by Ultrasaurus"
+source_url = "https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/"

--- a/exercises/point-mutations/metadata.toml
+++ b/exercises/point-mutations/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Calculate the Hamming difference between two DNA strands."
+source = "The Calculating Point Mutations problem at Rosalind"
+source_url = "http://rosalind.info/problems/hamm/"

--- a/exercises/poker/metadata.toml
+++ b/exercises/poker/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Pick the best hand(s) from a list of poker hands."
+source = "Inspired by the training course from Udacity."
+source_url = "https://www.udacity.com/course/viewer#!/c-cs212/"

--- a/exercises/pov/metadata.toml
+++ b/exercises/pov/metadata.toml
@@ -1,0 +1,4 @@
+title = "POV"
+blurb = "Reparent a graph on a selected node."
+source = "Adaptation of exercise from 4clojure"
+source_url = "https://www.4clojure.com/"

--- a/exercises/prime-factors/metadata.toml
+++ b/exercises/prime-factors/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Compute the prime factors of a given natural number."
+source = "The Prime Factors Kata by Uncle Bob"
+source_url = "http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata"

--- a/exercises/protein-translation/metadata.toml
+++ b/exercises/protein-translation/metadata.toml
@@ -1,0 +1,2 @@
+blurb = "Translate RNA sequences into proteins."
+source = "Tyler Long"

--- a/exercises/proverb/metadata.toml
+++ b/exercises/proverb/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output the full text of this proverbial rhyme."
+source = "Wikipedia"
+source_url = "http://en.wikipedia.org/wiki/For_Want_of_a_Nail"

--- a/exercises/pythagorean-triplet/metadata.toml
+++ b/exercises/pythagorean-triplet/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "There exists exactly one Pythagorean triplet for which a + b + c = 1000. Find the product a * b * c."
+source = "Problem 9 at Project Euler"
+source_url = "http://projecteuler.net/problem=9"

--- a/exercises/queen-attack/metadata.toml
+++ b/exercises/queen-attack/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other."
+source = "J Dalbey's Programming Practice problems"
+source_url = "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/rail-fence-cipher/metadata.toml
+++ b/exercises/rail-fence-cipher/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Implement encoding and decoding for the rail fence cipher."
+source = "Wikipedia"
+source_url = "https://en.wikipedia.org/wiki/Transposition_cipher#Rail_Fence_cipher"

--- a/exercises/raindrops/metadata.toml
+++ b/exercises/raindrops/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Convert a number to a string, the content of which depends on the number's factors."
+source = "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division."
+source_url = "https://en.wikipedia.org/wiki/Fizz_buzz"

--- a/exercises/rational-numbers/metadata.toml
+++ b/exercises/rational-numbers/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Implement rational numbers."
+source = "Wikipedia"
+source_url = "https://en.wikipedia.org/wiki/Rational_number"

--- a/exercises/react/metadata.toml
+++ b/exercises/react/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Implement a basic reactive system."

--- a/exercises/rectangles/metadata.toml
+++ b/exercises/rectangles/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Count the rectangles in an ASCII diagram."

--- a/exercises/resistor-color-duo/metadata.toml
+++ b/exercises/resistor-color-duo/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Convert color codes, as used on resistors, to a numeric value."
+source = "Maud de Vries, Erik Schierboom"
+source_url = "https://github.com/exercism/problem-specifications/issues/1464"

--- a/exercises/resistor-color-trio/metadata.toml
+++ b/exercises/resistor-color-trio/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Convert color codes, as used on resistors, to a human-readable label."
+source = "Maud de Vries, Erik Schierboom"
+source_url = "https://github.com/exercism/problem-specifications/issues/1549"

--- a/exercises/resistor-color/metadata.toml
+++ b/exercises/resistor-color/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Convert a resistor band's color to its numeric representation."
+source = "Maud de Vries, Erik Schierboom"
+source_url = "https://github.com/exercism/problem-specifications/issues/1458"

--- a/exercises/rest-api/metadata.toml
+++ b/exercises/rest-api/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Implement a RESTful API for tracking IOUs."

--- a/exercises/reverse-string/metadata.toml
+++ b/exercises/reverse-string/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Reverse a string."
+source = "Introductory challenge to reverse an input string"
+source_url = "https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb"

--- a/exercises/rna-transcription/metadata.toml
+++ b/exercises/rna-transcription/metadata.toml
@@ -1,0 +1,4 @@
+title = "RNA Transcription"
+blurb = "Given a DNA strand, return its RNA Complement Transcription."
+source = "Hyperphysics"
+source_url = "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html"

--- a/exercises/robot-name/metadata.toml
+++ b/exercises/robot-name/metadata.toml
@@ -1,0 +1,2 @@
+blurb = "Manage robot factory settings."
+source = "A debugging session with Paul Blackwell at gSchool."

--- a/exercises/robot-simulator/metadata.toml
+++ b/exercises/robot-simulator/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Write a robot simulator."
+source = "Inspired by an interview question at a famous company."
+source_url = ""

--- a/exercises/robot-simulator/metadata.toml
+++ b/exercises/robot-simulator/metadata.toml
@@ -1,3 +1,2 @@
 blurb = "Write a robot simulator."
 source = "Inspired by an interview question at a famous company."
-source_url = ""

--- a/exercises/robot-simulator/metadata.yml
+++ b/exercises/robot-simulator/metadata.yml
@@ -1,4 +1,3 @@
 ---
 blurb: "Write a robot simulator."
 source: "Inspired by an interview question at a famous company."
-source_url: ""

--- a/exercises/roman-numerals/metadata.toml
+++ b/exercises/roman-numerals/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Write a function to convert from normal numbers to Roman Numerals."
+source = "The Roman Numeral Kata"
+source_url = "http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals"

--- a/exercises/rotational-cipher/metadata.toml
+++ b/exercises/rotational-cipher/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Create an implementation of the rotational cipher, also sometimes called the Caesar cipher."
+source = "Wikipedia"
+source_url = "https://en.wikipedia.org/wiki/Caesar_cipher"

--- a/exercises/run-length-encoding/metadata.toml
+++ b/exercises/run-length-encoding/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Implement run-length encoding and decoding."
+source = "Wikipedia"
+source_url = "https://en.wikipedia.org/wiki/Run-length_encoding"

--- a/exercises/saddle-points/metadata.toml
+++ b/exercises/saddle-points/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Detect saddle points in a matrix."
+source = "J Dalbey's Programming Practice problems"
+source_url = "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/satellite/metadata.toml
+++ b/exercises/satellite/metadata.toml
@@ -1,0 +1,2 @@
+title = "Satellite"
+blurb = "Rebuild binary trees from pre-order and in-order traversals."

--- a/exercises/say/metadata.toml
+++ b/exercises/say/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given a number from 0 to 999,999,999,999, spell out that number in English."
+source = "A variation on JavaRanch CattleDrive, exercise 4a"
+source_url = "http://www.javaranch.com/say.jsp"

--- a/exercises/scale-generator/metadata.toml
+++ b/exercises/scale-generator/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Generate musical scales, given a starting note and a set of intervals."

--- a/exercises/scrabble-score/metadata.toml
+++ b/exercises/scrabble-score/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given a word, compute the Scrabble score for that word."
+source = "Inspired by the Extreme Startup game"
+source_url = "https://github.com/rchatley/extreme_startup"

--- a/exercises/secret-handshake/metadata.toml
+++ b/exercises/secret-handshake/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given a decimal number, convert it to the appropriate sequence of events for a secret handshake."
+source = "Bert, in Mary Poppins"
+source_url = "http://www.imdb.com/title/tt0058331/quotes/qt0437047"

--- a/exercises/series/metadata.toml
+++ b/exercises/series/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given a string of digits, output all the contiguous substrings of length `n` in that string."
+source = "A subset of the Problem 8 at Project Euler"
+source_url = "http://projecteuler.net/problem=8"

--- a/exercises/sgf-parsing/metadata.toml
+++ b/exercises/sgf-parsing/metadata.toml
@@ -1,0 +1,2 @@
+title = "SGF Parsing"
+blurb = "Parsing a Smart Game Format string."

--- a/exercises/sieve/metadata.toml
+++ b/exercises/sieve/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number."
+source = "Sieve of Eratosthenes at Wikipedia"
+source_url = "http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes"

--- a/exercises/simple-cipher/metadata.toml
+++ b/exercises/simple-cipher/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Implement a simple shift cipher like Caesar and a more secure substitution cipher."
+source = "Substitution Cipher at Wikipedia"
+source_url = "http://en.wikipedia.org/wiki/Substitution_cipher"

--- a/exercises/simple-linked-list/metadata.toml
+++ b/exercises/simple-linked-list/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Write a simple linked list implementation that uses Elements and a List."
+source = "Inspired by 'Data Structures and Algorithms with Object-Oriented Design Patterns in Ruby', singly linked-lists."
+source_url = "https://web.archive.org/web/20160731005714/http://brpreiss.com/books/opus8/html/page96.html"

--- a/exercises/space-age/metadata.toml
+++ b/exercises/space-age/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years."
+source = "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial."
+source_url = "http://pine.fm/LearnToProgram/?Chapter=01"

--- a/exercises/spiral-matrix/metadata.toml
+++ b/exercises/spiral-matrix/metadata.toml
@@ -1,0 +1,3 @@
+blurb = " Given the size, return a square matrix of numbers in spiral order."
+source = "Reddit r/dailyprogrammer challenge #320 [Easy] Spiral Ascension."
+source_url = "https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/"

--- a/exercises/square-root/metadata.toml
+++ b/exercises/square-root/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given a natural radicand, return its square root."
+source = "wolf99"
+source_url = "https://github.com/exercism/problem-specifications/pull/1582"

--- a/exercises/strain/metadata.toml
+++ b/exercises/strain/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false."
+source = "Conversation with James Edward Gray II"
+source_url = "https://twitter.com/jeg2"

--- a/exercises/sublist/metadata.toml
+++ b/exercises/sublist/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Write a function to determine if a list is a sublist of another list."

--- a/exercises/sum-of-multiples/metadata.toml
+++ b/exercises/sum-of-multiples/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given a number, find the sum of all the multiples of particular numbers up to but not including that number."
+source = "A variation on Problem 1 at Project Euler"
+source_url = "http://projecteuler.net/problem=1"

--- a/exercises/tournament/metadata.toml
+++ b/exercises/tournament/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Tally the results of a small football competition."

--- a/exercises/transpose/metadata.toml
+++ b/exercises/transpose/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Take input text and output it transposed."
+source = "Reddit r/dailyprogrammer challenge #270 [Easy]."
+source_url = "https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text"

--- a/exercises/tree-building/metadata.toml
+++ b/exercises/tree-building/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Refactor a tree building algorithm."

--- a/exercises/triangle/metadata.toml
+++ b/exercises/triangle/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Determine if a triangle is equilateral, isosceles, or scalene."
+source = "The Ruby Koans triangle project, parts 1 & 2"
+source_url = "http://rubykoans.com"

--- a/exercises/trinary/metadata.toml
+++ b/exercises/trinary/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Convert a trinary number, represented as a string (e.g. '102012'), to its decimal equivalent using first principles."
+source = "All of Computer Science"
+source_url = "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"

--- a/exercises/twelve-days/metadata.toml
+++ b/exercises/twelve-days/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Output the lyrics to 'The Twelve Days of Christmas'."
+source = "Wikipedia"
+source_url = "http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)"

--- a/exercises/two-bucket/metadata.toml
+++ b/exercises/two-bucket/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Given two buckets of different size, demonstrate how to measure an exact number of liters."
+source = "Water Pouring Problem"
+source_url = "http://demonstrations.wolfram.com/WaterPouringProblem/"

--- a/exercises/two-fer/metadata.toml
+++ b/exercises/two-fer/metadata.toml
@@ -1,0 +1,2 @@
+blurb = "Create a sentence of the form \"One for X, one for me.\"."
+source_url = "https://github.com/exercism/problem-specifications/issues/757"

--- a/exercises/variable-length-quantity/metadata.toml
+++ b/exercises/variable-length-quantity/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Implement variable length quantity encoding and decoding."
+source = "A poor Splice developer having to implement MIDI encoding/decoding."
+source_url = "https://splice.com"

--- a/exercises/word-count/metadata.toml
+++ b/exercises/word-count/metadata.toml
@@ -1,0 +1,2 @@
+blurb = "Given a phrase, count the occurrences of each word in that phrase."
+source = "This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour."

--- a/exercises/word-search/metadata.toml
+++ b/exercises/word-search/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Create a program to solve a word search puzzle."

--- a/exercises/wordy/metadata.toml
+++ b/exercises/wordy/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Parse and evaluate simple math word problems returning the answer as an integer."
+source = "Inspired by one of the generated questions in the Extreme Startup game."
+source_url = "https://github.com/rchatley/extreme_startup"

--- a/exercises/yacht/metadata.toml
+++ b/exercises/yacht/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Score a single throw of dice in the game Yacht."
+source = "James Kilfiger, using wikipedia"
+source_url = "https://en.wikipedia.org/wiki/Yacht_(dice_game)"

--- a/exercises/zebra-puzzle/metadata.toml
+++ b/exercises/zebra-puzzle/metadata.toml
@@ -1,0 +1,3 @@
+blurb = "Solve the zebra puzzle."
+source = "Wikipedia"
+source_url = "https://en.wikipedia.org/wiki/Zebra_Puzzle"

--- a/exercises/zipper/metadata.toml
+++ b/exercises/zipper/metadata.toml
@@ -1,0 +1,1 @@
+blurb = "Creating a zipper for a binary tree."


### PR DESCRIPTION
The general use of this `metadata.yml file` is in creating an exercise's `.meta/config.json`, so... it seems reasonable to convert at least the format before track maintainers do?

This came up in [a slack conversation](https://exercism-team.slack.com/archives/CAQP7JL3T/p1622371616051000) where it's noted that there's also a project convention of using json for human-generated data, and using toml for machine-generated data.

Changes:

- Updated README/CONTRIBUTING files
- Updated bin/[etc] ruby files
- Updated exercises from yaml to json
    - No funny business, I just ran a recursive `yaml2json < metadata.yml | jq > metadata.json`
    - No glaring issues when I ran through the diff

(Open to tweaking files, within reason, along the way if anyone with eagle eyes sees a pre-existing typo or something)

---

### Edit: This is now a conversion to TOML

If anyone wants to do something like this in the future, check out [`yaml2toml`](https://github.com/hiljusti/yaml2toml)