### PR TITLE
pythagorean-triplets: Fix maths notation in instructions

### DIFF
--- a/exercises/pythagorean-triplet/description.md
+++ b/exercises/pythagorean-triplet/description.md
@@ -4,7 +4,7 @@ A Pythagorean triplet is a set of three natural numbers, {a, b, c}, for
 which,
 
 ```text
-a**2 + b**2 = c**2
+a² + b² = c²
 ```
 
 and such that,
@@ -16,7 +16,7 @@ a < b < c
 For example,
 
 ```text
-3**2 + 4**2 = 9 + 16 = 25 = 5**2.
+3² + 4² = 9 + 16 = 25 = 5².
 ```
 
 Given an input integer N, find all Pythagorean triplets for which `a + b + c = N`.


### PR DESCRIPTION
`**` is not commonly used for exponentiation. I went with `²` but `^` would also be a more common choice than `**`. In v3, this should probably be updated to use Mathjax/KaTeX notation instead. (see https://github.com/exercism/website/issues/476)