### PR TITLE
yacht: Make top-level header consistent

### DIFF
--- a/exercises/yacht/description.md
+++ b/exercises/yacht/description.md
@@ -1,4 +1,4 @@
-# Score a single throw of dice in *Yacht*
+# Description
 
 The dice game [Yacht](https://en.wikipedia.org/wiki/Yacht_(dice_game)) is from
 the same family as Poker Dice, Generala and particularly Yahtzee, of which it


### PR DESCRIPTION
This was the only `description.md` file that did not begin with
`# Description`.

---

@ErikSchierboom do we want this change? 

PR #1782 added `# Description` to the `description.md` of every exercise in `problem-specifications` apart from `yacht`, which already had a top-level header.

On `main`:
```
$ cd problem-specifications/exercises
$ find -name 'description.md' | wc -l
135
$ rg --glob 'description.md' '# Description' --files-with-matches | wc -l
134
$ rg --glob 'description.md' '# Description' --files-without-match
yacht/description.md
```

