### PR TITLE
Remove mean comment from sgf-parsing description

### DIFF
--- a/exercises/sgf-parsing/description.md
+++ b/exercises/sgf-parsing/description.md
@@ -24,7 +24,7 @@ This is a tree with three nodes:
   comment and SZ is the size of the board.)
   - The top level node has a single child which has a single property:
     B\[aa\].  (Black plays on the point encoded as "aa", which is the
-    1-1 point (which is a stupid place to play)).
+    1-1 point).
     - The B\[aa\] node has a single child which has a single property:
       W\[ab\].
 


### PR DESCRIPTION
We were adding this exercise to Elixir (finally) and we noticed that the description is a bit... mean? condescending? I'm not sure if this comment is necessary for the understanding of the exercise. If it is, I guess it could be said a bit nice: "which is not an optimal place to play"?