### PR TITLE
exercises/markdown: add extensive header parsing tests

### DIFF
--- a/exercises/markdown/canonical-data.json
+++ b/exercises/markdown/canonical-data.json
@@ -59,13 +59,49 @@
       "expected": "<h2>This will be an h2</h2>"
     },
     {
-      "uuid": "13b5f410-33f5-44f0-a6a7-cfd4ab74b5d5",
-      "description": "with h6 header level",
-      "property": "parse",
-      "input": {
-        "markdown": "###### This will be an h6"
-      },
-      "expected": "<h6>This will be an h6</h6>"
+       "uuid": "9df3f500-0622-4696-81a7-d5babd9b5f49",
+       "description": "with h3 header level",
+       "property": "parse",
+       "input": {
+         "markdown": "### This will be an h3"
+       },
+       "expected": "<h3>This will be an h3</h3>"
+    },
+    {
+       "uuid": "50862777-a5e8-42e9-a3b8-4ba6fcd0ed03",
+       "description": "with h4 header level",
+       "property": "parse",
+       "input": {
+         "markdown": "#### This will be an h4"
+       },
+       "expected": "<h4>This will be an h4</h4>"
+    },
+    {
+       "uuid": "ee1c23ac-4c86-4f2a-8b9c-403548d4ab82",
+       "description": "with h5 header level",
+       "property": "parse",
+       "input": {
+         "markdown": "##### This will be an h5"
+       },
+       "expected": "<h5>This will be an h5</h5>"
+    },
+    {
+       "uuid": "13b5f410-33f5-44f0-a6a7-cfd4ab74b5d5",
+       "description": "with h6 header level",
+       "property": "parse",
+       "input": {
+         "markdown": "###### This will be an h6"
+       },
+       "expected": "<h6>This will be an h6</h6>"
+    },
+    {
+       "uuid": "6dca5d10-5c22-4e2a-ac2b-bd6f21e61939",
+       "description": "with h7 header level",
+       "property": "parse",
+       "input": {
+         "markdown": "####### This will not be an h7"
+       },
+       "expected": "####### This will not be an h7"
     },
     {
       "uuid": "25288a2b-8edc-45db-84cf-0b6c6ee034d6",
@@ -86,40 +122,40 @@
       "expected": "<h1>Header!</h1><ul><li><strong>Bold Item</strong></li><li><em>Italic Item</em></li></ul>"
     },
     {
-        "uuid": "0b3ed1ec-3991-4b8b-8518-5cb73d4a64fe",
-        "description": "with markdown symbols in the header text that should not be interpreted",
-        "property": "parse",
-        "input": {
-            "markdown": "# This is a header with # and * in the text"
-        },
-        "expected": "<h1>This is a header with # and * in the text</h1>"
+      "uuid": "0b3ed1ec-3991-4b8b-8518-5cb73d4a64fe",
+      "description": "with markdown symbols in the header text that should not be interpreted",
+      "property": "parse",
+      "input": {
+        "markdown": "# This is a header with # and * in the text"
+      },
+      "expected": "<h1>This is a header with # and * in the text</h1>"
     },
     {
-        "uuid": "113a2e58-78de-4efa-90e9-20972224d759",
-        "description": "with markdown symbols in the list item text that should not be interpreted",
-        "property": "parse",
-        "input": {
-            "markdown": "* Item 1 with a # in the text\n* Item 2 with * in the text"
-        },
-        "expected": "<ul><li>Item 1 with a # in the text</li><li>Item 2 with * in the text</li></ul>"
+      "uuid": "113a2e58-78de-4efa-90e9-20972224d759",
+      "description": "with markdown symbols in the list item text that should not be interpreted",
+      "property": "parse",
+      "input": {
+        "markdown": "* Item 1 with a # in the text\n* Item 2 with * in the text"
+      },
+      "expected": "<ul><li>Item 1 with a # in the text</li><li>Item 2 with * in the text</li></ul>"
     },
     {
-        "uuid": "e65e46e2-17b7-4216-b3ac-f44a1b9bcdb4",
-        "description": "with markdown symbols in the paragraph text that should not be interpreted",
-        "property": "parse",
-        "input": {
-            "markdown": "This is a paragraph with # and * in the text"
-        },
-        "expected": "<p>This is a paragraph with # and * in the text</p>"
+      "uuid": "e65e46e2-17b7-4216-b3ac-f44a1b9bcdb4",
+      "description": "with markdown symbols in the paragraph text that should not be interpreted",
+      "property": "parse",
+      "input": {
+        "markdown": "This is a paragraph with # and * in the text"
+      },
+      "expected": "<p>This is a paragraph with # and * in the text</p>"
     },
     {
-        "uuid": "f0bbbbde-0f52-4c0c-99ec-be4c60126dd4",
-        "description": "unordered lists close properly with preceding and following lines",
-        "property": "parse",
-        "input": {
-            "markdown": "# Start a list\n* Item 1\n* Item 2\nEnd a list"
-        },
-        "expected": "<h1>Start a list</h1><ul><li>Item 1</li><li>Item 2</li></ul><p>End a list</p>"
+      "uuid": "f0bbbbde-0f52-4c0c-99ec-be4c60126dd4",
+      "description": "unordered lists close properly with preceding and following lines",
+      "property": "parse",
+      "input": {
+        "markdown": "# Start a list\n* Item 1\n* Item 2\nEnd a list"
+      },
+      "expected": "<h1>Start a list</h1><ul><li>Item 1</li><li>Item 2</li></ul><p>End a list</p>"
     }
   ]
 }


### PR DESCRIPTION
As discussed in issue #1812, markdown exercise would benefit with more
extensive tests to ensure learners write dynamic code, capable of
handling all header depths there is.
To ensure their code is not too dynamic, I added the h7 level. It does
not exist in the HTML specification and therefore should be equal to the
input.

Resolves #1812.