### PR TITLE
Collatz Conjecture: test for non-integers

### DIFF
--- a/exercises/collatz-conjecture/canonical-data.json
+++ b/exercises/collatz-conjecture/canonical-data.json
@@ -44,7 +44,7 @@
       "input": {
         "number": 0
       },
-      "expected": { "error": "Only positive numbers are allowed" }
+      "expected": { "error": "Only positive integers are allowed" }
     },
     {
       "uuid": "c6c795bf-a288-45e9-86a1-841359ad426d",
@@ -53,7 +53,16 @@
       "input": {
         "number": -15
       },
-      "expected": { "error": "Only positive numbers are allowed" }
+      "expected": { "error": "Only positive integers are allowed" }
+    },
+    {
+      "uuid": "f7176864-e35d-11eb-ba80-0242ac130004",
+      "description": "non-integer value is an error",
+      "property": "steps",
+      "input": {
+        "number": 3.1415
+      },
+      "expected": { "error": "Only positive integers are allowed" }
     }
   ]
 }

--- a/exercises/collatz-conjecture/canonical-data.json
+++ b/exercises/collatz-conjecture/canonical-data.json
@@ -44,11 +44,33 @@
       "input": {
         "number": 0
       },
+      "expected": { "error": "Only positive numbers are allowed" }
+    },
+    {
+      "uuid": "2187673d-77d6-4543-975e-66df6c50e2da",
+      "description": "zero is an error",
+      "property": "steps",
+      "comments": ["Collatz Conjecture holds only for positive integers"],
+      "reimplements": "7d4750e6-def9-4b86-aec7-9f7eb44f95a3",
+      "input": {
+        "number": 0
+      },
       "expected": { "error": "Only positive integers are allowed" }
     },
     {
       "uuid": "c6c795bf-a288-45e9-86a1-841359ad426d",
       "description": "negative value is an error",
+      "property": "steps",
+      "input": {
+        "number": -15
+      },
+      "expected": { "error": "Only positive numbers are allowed" }
+    },
+    {
+      "uuid": "ec11f479-56bc-47fd-a434-bcd7a31a7a2e",
+      "description": "negative value is an error",
+      "comments": ["Collatz Conjecture holds only for positive integers"],
+      "reimplements": "c6c795bf-a288-45e9-86a1-841359ad426d",
       "property": "steps",
       "input": {
         "number": -15

--- a/exercises/collatz-conjecture/canonical-data.json
+++ b/exercises/collatz-conjecture/canonical-data.json
@@ -76,15 +76,6 @@
         "number": -15
       },
       "expected": { "error": "Only positive integers are allowed" }
-    },
-    {
-      "uuid": "f7176864-e35d-41eb-ba80-0242ac130004",
-      "description": "non-integer value is an error",
-      "property": "steps",
-      "input": {
-        "number": 3.1415
-      },
-      "expected": { "error": "Only positive integers are allowed" }
     }
   ]
 }

--- a/exercises/collatz-conjecture/canonical-data.json
+++ b/exercises/collatz-conjecture/canonical-data.json
@@ -78,7 +78,7 @@
       "expected": { "error": "Only positive integers are allowed" }
     },
     {
-      "uuid": "f7176864-e35d-11eb-ba80-0242ac130004",
+      "uuid": "f7176864-e35d-41eb-ba80-0242ac130004",
       "description": "non-integer value is an error",
       "property": "steps",
       "input": {


### PR DESCRIPTION
The Collatz Conjecture holds only for positive integers. Whilst for strongly-typed languages such as Rust, the compiler ensures that the input must be an integer, for dynamically-typed languages (e.g. Python) or languages in which there is no integer type (e.g. TypeScript), the input must be explicitly tested. This commit adds a test case for a positive non-integer and modifies the expected error message from 'Only positive numbers are allowed' to 'Only positive integers are allowed' so that the student can test the input using a single if statement.