### PR TITLE
Add test to `rational-numbers`: reduce places minus sign on denominator

### DIFF
--- a/exercises/rational-numbers/canonical-data.json
+++ b/exercises/rational-numbers/canonical-data.json
@@ -420,6 +420,15 @@
             "r": [13, 13]
           },
           "expected": [1, 1]
+        },
+        {
+          "uuid": "5ed6f248-ad8d-4d4e-a545-9146c6727f33",
+          "description": "Reduce places the minus sign on the numerator",
+          "property": "reduce",
+          "input": {
+            "r": [3, -4]
+          },
+          "expected": [-3, 4]
         }
       ]
     }


### PR DESCRIPTION
Closes #1833. There were no comment except for a thumbs up from @glennj (please review 💟), so I'm moving forward.

We received a [nice contribution](https://github.com/exercism/elixir/pull/892) on the Elixir track adding this test, so I thought other tracks should benefit as well.

This test makes explicit a standard behavior of `reduce`: the minus sign should end up on top. 

This is already implied by other tests, in particular, the test "Divide a positive rational number by a negative rational number" produces a minus sign on the denominator when the instructions are followed to the letter and the test expects the minus sign on top. Therefore implementations shouldn't need to change.

Happy to hear your opinions.