### PR TITLE
Two-fer: add title to metadata

### DIFF
--- a/exercises/two-fer/metadata.toml
+++ b/exercises/two-fer/metadata.toml
@@ -1,2 +1,3 @@
+title = "Two-fer"
 blurb = "Create a sentence of the form \"One for X, one for me.\"."
 source_url = "https://github.com/exercism/problem-specifications/issues/757"

--- a/exercises/two-fer/metadata.yml
+++ b/exercises/two-fer/metadata.yml
@@ -1,3 +1,4 @@
 ---
+title: "Two-fer"
 blurb: 'Create a sentence of the form "One for X, one for me.".'
 source_url: "https://github.com/exercism/problem-specifications/issues/757"


### PR DESCRIPTION
Because it would be possible otherwise to generate title "Two Fer" by automatic exercise generator. Proper title punctuation is taken from description.md.