### PR TITLE
Resistor-color-duo: one-digit solution

### DIFF
--- a/exercises/resistor-color-duo/canonical-data.json
+++ b/exercises/resistor-color-duo/canonical-data.json
@@ -45,6 +45,15 @@
         "colors": ["green", "brown", "orange"]
       },
       "expected": 51
+    },
+    {
+      "uuid": "4a8ceec5-0ab4-4904-88a4-daf953a5e818",
+      "description": "Black and brown, one-digit",
+      "property": "value",
+      "input": {
+        "colors": ["black", "brown"]
+      },
+      "expected": 1
     }
   ]
 }


### PR DESCRIPTION
With "black" as first band.

Perhaps instructions should also be updated, as not every output is two-digit?