### PR TITLE
Luhn: A new test case with odd number of digits

### DIFF
--- a/exercises/luhn/canonical-data.json
+++ b/exercises/luhn/canonical-data.json
@@ -146,6 +146,15 @@
       "expected": true
     },
     {
+      "uuid": "ab56fa80-5de8-4735-8a4a-14dae588663e",
+      "description": "valid luhn with an odd number of digits and non zero first digit",
+      "property": "valid",
+      "input": {
+        "value": "109"
+      },
+      "expected": true
+    },
+    {
       "comments": [
         "Convert non-digits to their ascii values and then offset them by 48 sometimes accidentally declare an invalid string to be valid.",
         "This test is designed to avoid that solution."

--- a/exercises/luhn/canonical-data.json
+++ b/exercises/luhn/canonical-data.json
@@ -146,7 +146,7 @@
       "expected": true
     },
     {
-      "uuid": "ab56fa80-5de8-4735-8a4a-14dae588663e",
+      "uuid": "8a7c0e24-85ea-4154-9cf1-c2db90eabc08",
       "description": "valid luhn with an odd number of digits and non zero first digit",
       "property": "valid",
       "input": {


### PR DESCRIPTION
A new positive test case with odd number of digits and non-zero first digit.
I have seen a solution in Golang which passes all the tests for Luhn containing odd number of digits and never reads the first digit.
It happens because in all such cases the first digit is zero . This test case will fix the problem.