### PR TITLE
fix typo for bash raindrops exercise

### DIFF
--- a/exercises/raindrops/description.md
+++ b/exercises/raindrops/description.md
@@ -1,6 +1,6 @@
 # Description
 
-Your task is to convert a number into a string that contains raindrop sounds corresponding to certain potential factors. A factor is a number that evenly divides into another number, leaving no remainder. The simplest way to test if a one number is a factor of another is to use the [modulo operation](https://en.wikipedia.org/wiki/Modulo_operation).
+Your task is to convert a number into a string that contains raindrop sounds corresponding to certain potential factors. A factor is a number that evenly divides into another number, leaving no remainder. The simplest way to test if one number is a factor of another is to use the [modulo operation](https://en.wikipedia.org/wiki/Modulo_operation).
 
 The rules of `raindrops` are that if a given number:
 


### PR DESCRIPTION
I saw this little error while doing the exercise. I am hoping this reads a bit easier!

Going from:
`The simplest way to test if a one number is a factor of another is`

to 

`The simplest way to test if one number is a factor of another is`