### PR TITLE
affine-cipher: Updates to the exercise instructions file

### DIFF
--- a/exercises/affine-cipher/description.md
+++ b/exercises/affine-cipher/description.md
@@ -10,61 +10,54 @@ its new numeric value. Although all mono-alphabetic ciphers are weak,
 the affine cipher is much stronger than the atbash cipher,
 because it has many more keys.
 
+## Encryption
+
 The encryption function is:
 
-  `E(x) = (ax + b) mod m`
-  -  where `x` is the letter's index from 0 - length of alphabet - 1
-  -  `m` is the length of the alphabet. For the roman alphabet `m == 26`.
-  -  and `a` and `b` make the key
+  `E(x) = (ai + b) mod m`
+  -  where `i` is the letter's index from `0` to the length of the alphabet - 1
+  -  `m` is the length of the alphabet. For the roman alphabet `m` is `26`.
+  -  `a` and `b` are integers which make the encryption key
+
+Values `a` and `m` must be *coprime* (or, *relatively prime*) for automatic decryption to succeed,
+ie. they have number `1` as their only common factor (more information about coprime numbers
+can be found [here](https://en.wikipedia.org/wiki/Coprime_integers)). In case `a` is not coprime to `m` your
+program should return status `1` and `"Error: a and m must be coprime."`. Otherwise it should encrypt or
+decrypt with the provided key.
+
+For the purpose of this exercise, digits are valid input but they are not encrypted. Spaces and punctuation
+characters are excluded. Ciphertext is written out in groups of fixed length separated by space,
+the traditional group size being `5` letters. This is to make it harder to guess encrypted text based
+on word boundaries.
+
+## Decryption
 
 The decryption function is:
 
-  `D(y) = a^-1(y - b) mod m`
+  `D(y) = (a^-1)(y - b) mod m`
   -  where `y` is the numeric value of an encrypted letter, ie. `y = E(x)`
-  -  it is important to note that `a^-1` is the modular multiplicative inverse
+  -  it is important to note that `a^-1` is the modular multiplicative inverse (MMI)
      of `a mod m`
-  -  the modular multiplicative inverse of `a` only exists if `a` and `m` are
-     coprime.
+  -  the modular multiplicative inverse only exists if `a` and `m` are coprime.
 
-To find the MMI of `a`:
+The MMI of `a` is `x` such that the remainder after dividing `ax` by `m` is `1`:
 
-  `an mod m = 1`
-  -  where `n` is the modular multiplicative inverse of `a mod m`
+  `ax mod m = 1`
 
 More information regarding how to find a Modular Multiplicative Inverse
 and what it means can be found [here.](https://en.wikipedia.org/wiki/Modular_multiplicative_inverse)
 
-Because automatic decryption fails if `a` is not coprime to `m` your
-program should return status 1 and `"Error: a and m must be coprime."`
-if they are not.  Otherwise it should encode or decode with the
-provided key.
-
-The Caesar (shift) cipher is a simple affine cipher where `a` is 1 and
-`b` as the magnitude results in a static displacement of the letters.
-This is much less secure than a full implementation of the affine cipher.
-
-Ciphertext is written out in groups of fixed length, the traditional group
-size being 5 letters, and punctuation is excluded. This is to make it
-harder to guess things based on word boundaries.
-
 ## General Examples
 
- - Encoding `test` gives `ybty` with the key a=5 b=7
- - Decoding `ybty` gives `test` with the key a=5 b=7
- - Decoding `ybty` gives `lqul` with the wrong key a=11 b=7
- - Decoding `kqlfd jzvgy tpaet icdhm rtwly kqlon ubstx`
-   - gives `thequickbrownfoxjumpsoverthelazydog` with the key a=19 b=13
- - Encoding `test` with the key a=18 b=13
-   - gives `Error: a and m must be coprime.`
-   - because a and m are not relatively prime
+ - Encrypting `"test"` gives `"ybty"` with the key `a = 5`, `b = 7`
+ - Decrypting `"ybty"` gives `"test"` with the key `a = 5`, `b = 7`
+ - Decrypting `"ybty"` gives `"lqul"` with the wrong key `a = 11`, `b = 7`
+ - Decrypting `"kqlfd jzvgy tpaet icdhm rtwly kqlon ubstx"` gives `"thequickbrownfoxjumpsoverthelazydog"` with the key `a = 19`, `b = 13`
+ - Encrypting `"test"` with the key `a = 18`, `b = 13` gives `Error: a and m must be coprime.` because `18` and `26` are not coprime
 
-## Examples of finding a Modular Multiplicative Inverse (MMI)
+## Example of finding a Modular Multiplicative Inverse (MMI)
 
-  - simple example:
-    - `9 mod 26 = 9`
-    - `9 * 3 mod 26 = 27 mod 26 = 1`
-    - `3` is the MMI of `9 mod 26`
-  - a more complicated example:
-    - `15 mod 26 = 15`
-    - `15 * 7 mod 26 = 105 mod 26 = 1`
-    - `7` is the MMI of `15 mod 26`
+Finding MMI for `a = 15`:
+  - `(15 * x) mod 26 = 1`
+  - `(15 * 7) mod 26 = 1`, ie. `105 mod 26 = 1`
+  - `7` is the MMI of `15 mod 26`

--- a/exercises/affine-cipher/description.md
+++ b/exercises/affine-cipher/description.md
@@ -53,7 +53,7 @@ and what it means can be found in the [related Wikipedia article](https://en.wik
  - Decrypting `"ybty"` gives `"test"` with the key `a = 5`, `b = 7`
  - Decrypting `"ybty"` gives `"lqul"` with the wrong key `a = 11`, `b = 7`
  - Decrypting `"kqlfd jzvgy tpaet icdhm rtwly kqlon ubstx"` gives `"thequickbrownfoxjumpsoverthelazydog"` with the key `a = 19`, `b = 13`
- - Encrypting `"test"` with the key `a = 18`, `b = 13` gives `"Error: a and m must be coprime."` because `18` and `26` are not coprime
+ - Encrypting `"test"` with the key `a = 18`, `b = 13` is an error because `18` and `26` are not coprime
 
 ## Example of finding a Modular Multiplicative Inverse (MMI)
 

--- a/exercises/affine-cipher/description.md
+++ b/exercises/affine-cipher/description.md
@@ -20,7 +20,7 @@ The encryption function is:
   -  `a` and `b` are integers which make the encryption key
 
 Values `a` and `m` must be *coprime* (or, *relatively prime*) for automatic decryption to succeed,
-ie. they have number `1` as their only common factor (more information can be found
+ie. they have number `1` as their only common factor (more information can be found in the
 [Wikipedia article about coprime integers](https://en.wikipedia.org/wiki/Coprime_integers)). In case `a` is
 not coprime to `m`, your program should return `"Error: a and m must be coprime."`. Otherwise it should
 encrypt or decrypt with the provided key.

--- a/exercises/affine-cipher/description.md
+++ b/exercises/affine-cipher/description.md
@@ -22,7 +22,7 @@ The encryption function is:
 Values `a` and `m` must be *coprime* (or, *relatively prime*) for automatic decryption to succeed,
 ie. they have number `1` as their only common factor (more information can be found
 [Wikipedia article about coprime integers](https://en.wikipedia.org/wiki/Coprime_integers)). In case `a` is
-not coprime to `m` your program should return `"Error: a and m must be coprime."`. Otherwise it should
+not coprime to `m`, your program should return `"Error: a and m must be coprime."`. Otherwise it should
 encrypt or decrypt with the provided key.
 
 For the purpose of this exercise, digits are valid input but they are not encrypted. Spaces and punctuation

--- a/exercises/affine-cipher/description.md
+++ b/exercises/affine-cipher/description.md
@@ -22,7 +22,7 @@ The encryption function is:
 Values `a` and `m` must be *coprime* (or, *relatively prime*) for automatic decryption to succeed,
 ie. they have number `1` as their only common factor (more information can be found in the
 [Wikipedia article about coprime integers](https://en.wikipedia.org/wiki/Coprime_integers)). In case `a` is
-not coprime to `m`, your program should return `"Error: a and m must be coprime."`. Otherwise it should
+not coprime to `m`, your program should indicate that this is an error. Otherwise it should
 encrypt or decrypt with the provided key.
 
 For the purpose of this exercise, digits are valid input but they are not encrypted. Spaces and punctuation

--- a/exercises/affine-cipher/description.md
+++ b/exercises/affine-cipher/description.md
@@ -16,14 +16,14 @@ The encryption function is:
 
   `E(x) = (ai + b) mod m`
   -  where `i` is the letter's index from `0` to the length of the alphabet - 1
-  -  `m` is the length of the alphabet. For the roman alphabet `m` is `26`.
+  -  `m` is the length of the alphabet. For the Roman alphabet `m` is `26`.
   -  `a` and `b` are integers which make the encryption key
 
 Values `a` and `m` must be *coprime* (or, *relatively prime*) for automatic decryption to succeed,
-ie. they have number `1` as their only common factor (more information about coprime numbers
-can be found [here](https://en.wikipedia.org/wiki/Coprime_integers)). In case `a` is not coprime to `m` your
-program should return status `1` and `"Error: a and m must be coprime."`. Otherwise it should encrypt or
-decrypt with the provided key.
+ie. they have number `1` as their only common factor (more information can be found
+[Wikipedia article about coprime integers](https://en.wikipedia.org/wiki/Coprime_integers)). In case `a` is
+not coprime to `m` your program should return `"Error: a and m must be coprime."`. Otherwise it should
+encrypt or decrypt with the provided key.
 
 For the purpose of this exercise, digits are valid input but they are not encrypted. Spaces and punctuation
 characters are excluded. Ciphertext is written out in groups of fixed length separated by space,
@@ -45,7 +45,7 @@ The MMI of `a` is `x` such that the remainder after dividing `ax` by `m` is `1`:
   `ax mod m = 1`
 
 More information regarding how to find a Modular Multiplicative Inverse
-and what it means can be found [here.](https://en.wikipedia.org/wiki/Modular_multiplicative_inverse)
+and what it means can be found in the [related Wikipedia article](https://en.wikipedia.org/wiki/Modular_multiplicative_inverse).
 
 ## General Examples
 
@@ -53,7 +53,7 @@ and what it means can be found [here.](https://en.wikipedia.org/wiki/Modular_mul
  - Decrypting `"ybty"` gives `"test"` with the key `a = 5`, `b = 7`
  - Decrypting `"ybty"` gives `"lqul"` with the wrong key `a = 11`, `b = 7`
  - Decrypting `"kqlfd jzvgy tpaet icdhm rtwly kqlon ubstx"` gives `"thequickbrownfoxjumpsoverthelazydog"` with the key `a = 19`, `b = 13`
- - Encrypting `"test"` with the key `a = 18`, `b = 13` gives `Error: a and m must be coprime.` because `18` and `26` are not coprime
+ - Encrypting `"test"` with the key `a = 18`, `b = 13` gives `"Error: a and m must be coprime."` because `18` and `26` are not coprime
 
 ## Example of finding a Modular Multiplicative Inverse (MMI)
 


### PR DESCRIPTION
Hi, I have tried to clean up the instructions to this exercise a bit and possibly make them a bit more informative by:
* Changing the markdown text from plain to `code` for important values to let them stand out
* Adding the Encryption and Decryption section headers for improved clarity
* Adding guidance about digits and spaces as inputs to match the test cases
* Updating the Decryption formula to avoid exponent ambiguity
* Updated the MMI property formula to be more consistent with the resource (Wiki), and subjectively easier to grasp
* Adding a hint about what coprimes (or relative primes) are for improved clarity
* Removing one example of MMI which seemed to be redundant

Please review the proposed updates and let me know what you think - they are subjective so it's perfectly fine if only some / none of them will be accepted. Thank you for your time!