### PR TITLE
Amend unclear hyphen use

### DIFF
--- a/exercises/affine-cipher/description.md
+++ b/exercises/affine-cipher/description.md
@@ -13,7 +13,7 @@ because it has many more keys.
 The encryption function is:
 
   `E(x) = (ax + b) mod m`
-  -  where `x` is the letter's index from 0 - length of alphabet - 1
+  -  where `x` is the letter's index from 0 to (length of alphabet - 1)
   -  `m` is the length of the alphabet. For the roman alphabet `m == 26`.
   -  and `a` and `b` make the key
 


### PR DESCRIPTION
Two hyphens in a row, one acting as a dash and one as a minus sign, was confusing. Amend to use English word 'to' and parens to make the subtraction clearer.