### PR TITLE
Add left, right, up, up case to zipper canon

### DIFF
--- a/exercises/zipper/canonical-data.json
+++ b/exercises/zipper/canonical-data.json
@@ -281,7 +281,7 @@
     },
     {
       "uuid": "b9aa8d54-07b7-4bfd-ab6b-7ff7f35930b6",
-      "description": "left, right, up, and up",
+      "description": "test ability to descend multiple levels and return",
       "property": "expectedValue",
       "input": {
         "initialTree": {

--- a/exercises/zipper/canonical-data.json
+++ b/exercises/zipper/canonical-data.json
@@ -280,6 +280,51 @@
       }
     },
     {
+      "uuid": "b9aa8d54-07b7-4bfd-ab6b-7ff7f35930b6",
+      "description": "left, right, up, and up",
+      "property": "expectedValue",
+      "input": {
+        "initialTree": {
+          "value": 1,
+          "left": {
+            "value": 2,
+            "left": null,
+            "right": {
+              "value": 3,
+              "left": null,
+              "right": null
+            }
+          },
+          "right": {
+            "value": 4,
+            "left": null,
+            "right": null
+          }
+        },
+        "operations": [
+          {
+            "operation": "left"
+          },
+          {
+            "operation": "right"
+          },
+          {
+            "operation": "up"
+          },
+          {
+            "operation": "up"
+          },
+          {
+            "operation": "value"
+          }
+        ]
+      },
+      "expected": {
+        "type": "int",
+        "value": 1
+      }
+    },
+    {
       "uuid": "47df1a27-b709-496e-b381-63a03b82ea5f",
       "description": "set_value",
       "property": "expectedValue",


### PR DESCRIPTION
This PR adds a case to the Zipper canonical data. The new case checks whether the zipper implementation can find its way back to the top node from deep within the tree.

Resolves #1872 