### PR TITLE
grep: Specify prefix with multiple files

### DIFF
--- a/exercises/grep/description.md
+++ b/exercises/grep/description.md
@@ -48,7 +48,8 @@ If given just one file, this prefix is not present.
 
 As said earlier, the `grep` command should also support the following flags:
 
-- `-n` Print the line numbers of each matching line.
+- `-n` Prefix each matching line with its line number within its file.
+  When multiple files are present, this prefix goes *after* the filename prefix.
 - `-l` Print only the names of files that contain at least one matching line.
 - `-i` Match line using a case-insensitive comparison.
 - `-v` Invert the program -- collect all lines that fail to match the pattern.

--- a/exercises/grep/description.md
+++ b/exercises/grep/description.md
@@ -33,6 +33,17 @@ hello
 hello again
 ```
 
+If given multiple files, `grep` should prefix each found line with the file it was found in.
+As an example:
+
+```text
+input.txt:hello
+input.txt:hello again
+greeting.txt:hello world
+```
+
+If given just one file, this prefix is not present.
+
 ## Flags
 
 As said earlier, the `grep` command should also support the following flags:


### PR DESCRIPTION
Notice that our [canonical-data.json](https://github.com/exercism/problem-specifications/blob/main/exercises/grep/canonical-data.json) already has tests matching this
requirement, as it is part of the Unix `grep`'s behaviour; this is
simply documenting the existing requirement.

This was mentioned in
https://github.com/exercism/problem-specifications/issues/1873, though
it is not the main thrust of that issue, so this doesn't close that
issue.

I do not want to make a habit of splitting up two PRs to the same exercise (this and #1876) so granularly and using more of reviewers' valuable time in doing so, but my specific reason for that here is that the two changes are actually quite independent of one another and I actually believe one of them will need far more revision than the other, and no reason to hold up one change just because of revisions to the other.