### PR TITLE
Update canonical-schema.json with "timeout" property

### DIFF
--- a/canonical-schema.json
+++ b/canonical-schema.json
@@ -86,6 +86,7 @@
                 , "property"    : { "$ref": "#/definitions/property"    }
                 , "input"       : { "$ref": "#/definitions/input"       }
                 , "expected"    : { "$ref": "#/definitions/expected"    }
+                , "timeout"     : { "$ref": "#/definitions/timeout"     }
                 }
           , "additionalProperties": false
           },


### PR DESCRIPTION
Added non-required `timeout` (in milliseconds) property to `labeledTest.properties` to support tests with timeouts, such as for `alphametics` and `palindrome-products` exercises. This would support automatic generation/update of the tests rather than specific track manually modification of the relevant exercise's test file.