### PR TITLE
queen-attack: Add test case to catch an incomplete diagonal check

### DIFF
--- a/exercises/queen-attack/canonical-data.json
+++ b/exercises/queen-attack/canonical-data.json
@@ -242,7 +242,7 @@
           "expected": true
         },
         {
-          "uuid": "33ae4113-d237-42ee-bac1-e1e699c0c007",
+          "uuid": "543f8fd4-2597-4aad-8d77-cbdab63619f8",
           "description": "cannot attack with equal difference",
           "property": "canAttack",
           "input": {

--- a/exercises/queen-attack/canonical-data.json
+++ b/exercises/queen-attack/canonical-data.json
@@ -243,7 +243,7 @@
         },
         {
           "uuid": "543f8fd4-2597-4aad-8d77-cbdab63619f8",
-          "description": "cannot attack with equal difference",
+          "description": "cannot attack if falling diagonals are only the same when reflected across the longest falling diagonal",
           "property": "canAttack",
           "input": {
             "white_queen": {

--- a/exercises/queen-attack/canonical-data.json
+++ b/exercises/queen-attack/canonical-data.json
@@ -240,6 +240,26 @@
             }
           },
           "expected": true
+        },
+        {
+          "uuid": "33ae4113-d237-42ee-bac1-e1e699c0c007",
+          "description": "cannot attack with equal difference",
+          "property": "canAttack",
+          "input": {
+            "white_queen": {
+              "position": {
+                "row": 4,
+                "column": 1
+              }
+            },
+            "black_queen": {
+              "position": {
+                "row": 2,
+                "column": 5
+              }
+            }
+          },
+          "expected": false
         }
       ]
     }


### PR DESCRIPTION
# TL;DR
This is an extra test case for the queen attack exercise. It catches an issue with an erroneous diagonal check that the existing tests do not catch.

The PR I submitted to the Rust track was already merged (https://github.com/exercism/rust/pull/1398). The maintainer suggested I should add this test case here as well.

This is my first PR to this particular project, and my second PR on Github ever, so I appreciate constructive feedback on how to improve.

### Details about why I think this test case might be useful
I started with a condition of
```rust
self.row + self.column == other.row + other.column
```
for the `/` diagonal check, and
```rust
self.row - self.column == other.row - other.column
```
for the `\` diagonal check.

The latter obviously fails when column > row [edit: because I chose unsigned integers as row and column, and Rust will panic on subtract with overflow]. So the code might become something like this:
```rust
if self.row >= self.column && other.row >= other.column
	self.row - self.column == other.row - other.column
else if self.row >= self.column && other.row < other.column
	self.row - self.column == other.column - other.row
else if self.row < self.column && other.row >= other.column
	self.column - self.row == other.row - other.column
else // self.row < self.column && other.row < other.column
	self.column - self.row == other.column - other.row
```

(BTW I didn't use match here on purpose, because everybody understands if/else)

Because this is … inelegant at best, one might come up with something like this:
```rust
max(self.row, self.column) - min(self.column, self.row)
	== max(other.row, other.column) - min(other.column, other.row)    
```

While It's more concise, and did solve all the previous test cases, it's still wrong. It's easy to notice on paper so I created a test case for it. :)