### PR TITLE
scale-generator: Require N+1 notes from N intervals

### DIFF
--- a/exercises/scale-generator/canonical-data.json
+++ b/exercises/scale-generator/canonical-data.json
@@ -36,6 +36,177 @@
       "description": "Scales with specified intervals",
       "cases": [
         {
+          "uuid": "7195998a-7be7-40c9-8877-a1d7949e061b",
+          "reimplements": "6f5b1410-1dd7-4c6c-b410-6b7e986f6f1e",
+          "description": "Simple major scale",
+          "comments": [
+            "The simplest major scale, with no sharps or flats."
+          ],
+          "property": "interval",
+          "input": {
+            "tonic": "C",
+            "intervals": "MMmMMMm"
+          },
+          "expected": [ "C", "D", "E", "F", "G", "A", "B", "C" ]
+        },
+        {
+          "uuid": "fe853b97-1878-4090-b218-4029246abb91",
+          "reimplements": "13a92f89-a83e-40b5-b9d4-01136931ba02",
+          "description": "Major scale with sharps",
+          "property": "interval",
+          "input": {
+            "tonic": "G",
+            "intervals": "MMmMMMm"
+          },
+          "expected": [ "G", "A", "B", "C", "D", "E", "F#", "G" ]
+        },
+        {
+          "uuid": "d60cb414-cc02-4fcb-ad7a-fc7ef0a9eead",
+          "reimplements": "aa3320f6-a761-49a1-bcf6-978e0c81080a",
+          "description": "Major scale with flats",
+          "property": "interval",
+          "input": {
+            "tonic": "F",
+            "intervals": "MMmMMMm"
+          },
+          "expected": [ "F", "G", "A", "Bb", "C", "D", "E", "F" ]
+        },
+        {
+          "uuid": "77dab9b3-1bbc-4f9a-afd8-06da693bcc67",
+          "reimplements": "63daeb2f-c3f9-4c45-92be-5bf97f61ff94",
+          "description": "Minor scale with sharps",
+          "property": "interval",
+          "input": {
+            "tonic": "f#",
+            "intervals": "MmMMmMM"
+          },
+          "expected": [ "F#", "G#", "A", "B", "C#", "D", "E", "F#" ]
+        },
+        {
+          "uuid": "5fa1728f-5b66-4b43-9b7c-84359b7069d4",
+          "reimplements": "616594d0-9c48-4301-949e-af1d4fad16fd",
+          "description": "Minor scale with flats",
+          "property": "interval",
+          "input": {
+            "tonic": "bb",
+            "intervals": "MmMMmMM"
+          },
+          "expected": [ "Bb", "C", "Db", "Eb", "F", "Gb", "Ab", "Bb" ]
+        },
+        {
+          "uuid": "f3f1c353-8f7b-4a85-a5b5-ae06c2645823",
+          "reimplements": "390bd12c-5ac7-4ec7-bdde-4e58d5c78b0a",
+          "description": "Dorian mode",
+          "property": "interval",
+          "input": {
+            "tonic": "d",
+            "intervals": "MmMMMmM"
+          },
+          "expected": [ "D", "E", "F", "G", "A", "B", "C", "D" ]
+        },
+        {
+          "uuid": "5fe14e5a-3ddc-4202-a158-2c1158beb5d0",
+          "reimplements": "846d0862-0f3e-4f3b-8a2d-9cc74f017848",
+          "description": "Mixolydian mode",
+          "property": "interval",
+          "input": {
+            "tonic": "Eb",
+            "intervals": "MMmMMmM"
+          },
+          "expected": [ "Eb", "F", "G", "Ab", "Bb", "C", "Db", "Eb" ]
+        },
+        {
+          "uuid": "e6307799-b7f6-43fc-a6d8-a4834d6e2bdb",
+          "reimplements": "7d49a8bb-b5f7-46ad-a207-83bd5032291a",
+          "description": "Lydian mode",
+          "property": "interval",
+          "input": {
+            "tonic": "a",
+            "intervals": "MMMmMMm"
+          },
+          "expected": [ "A", "B", "C#", "D#", "E", "F#", "G#", "A" ]
+        },
+        {
+          "uuid": "7c4a95cd-ecf4-448d-99bc-dbbca51856e0",
+          "reimplements": "a4e4dac5-1891-4160-a19f-bb06d653d4d0",
+          "description": "Phrygian mode",
+          "property": "interval",
+          "input": {
+            "tonic": "e",
+            "intervals": "mMMMmMM"
+          },
+          "expected": [ "E", "F", "G", "A", "B", "C", "D", "E" ]
+        },
+        {
+          "uuid": "f476f9c9-5a13-473d-bb6c-f884cf8fd9f2",
+          "reimplements": "ef3650af-90f8-4ad9-9ef6-fdbeae07dcaa",
+          "description": "Locrian mode",
+          "property": "interval",
+          "input": {
+            "tonic": "g",
+            "intervals": "mMMmMMM"
+          },
+          "expected": [ "G", "Ab", "Bb", "C", "Db", "Eb", "F", "G" ]
+        },
+        {
+          "comments": [
+            "Note that this case introduces the augmented second interval (A)"
+          ],
+          "uuid": "87fdbcca-d3dd-46d5-9c56-ec79e25b19f4",
+          "reimplements": "70517400-12b7-4530-b861-fa940ae69ee8",
+          "description": "Harmonic minor",
+          "property": "interval",
+          "input": {
+            "tonic": "d",
+            "intervals": "MmMMmAm"
+          },
+          "expected": [ "D", "E", "F", "G", "A", "Bb", "Db", "D" ]
+        },
+        {
+          "uuid": "b28ecc18-88db-4fd5-a973-cfe6361e2b24",
+          "reimplements": "37114c0b-c54d-45da-9f4b-3848201470b0",
+          "description": "Octatonic",
+          "property": "interval",
+          "input": {
+            "tonic": "C",
+            "intervals": "MmMmMmMm"
+          },
+          "expected": [ "C", "D", "D#", "F", "F#", "G#", "A", "B", "C" ]
+        },
+        {
+          "uuid": "a1c7d333-6fb3-4f3b-9178-8a0cbe043134",
+          "reimplements": "496466e7-aa45-4bbd-a64d-f41030feed9c",
+          "description": "Hexatonic",
+          "property": "interval",
+          "input": {
+            "tonic": "Db",
+            "intervals": "MMMMMM"
+          },
+          "expected": [ "Db", "Eb", "F", "G", "A", "B", "Db" ]
+        },
+        {
+          "uuid": "9acfd139-0781-4926-8273-66a478c3b287",
+          "reimplements": "bee5d9ec-e226-47b6-b62b-847a9241f3cc",
+          "description": "Pentatonic",
+          "property": "interval",
+          "input": {
+            "tonic": "A",
+            "intervals": "MMAMA"
+          },
+          "expected": [ "A", "B", "C#", "E", "F#", "A" ]
+        },
+        {
+          "uuid": "31c933ca-2251-4a5b-92dd-9d5831bc84ad",
+          "reimplements": "dbee06a6-7535-4ab7-98e8-d8a36c8402d1",
+          "description": "Enigmatic",
+          "property": "interval",
+          "input": {
+            "tonic": "G",
+            "intervals": "mAMMMmm"
+          },
+          "expected": [ "G", "G#", "B", "C#", "D#", "F", "F#", "G" ]
+        },
+        {
           "uuid": "6f5b1410-1dd7-4c6c-b410-6b7e986f6f1e",
           "description": "Simple major scale",
           "comments": [

--- a/exercises/scale-generator/description.md
+++ b/exercises/scale-generator/description.md
@@ -65,5 +65,19 @@ Given a tonic and a set of intervals, generate the musical scale starting with
 the tonic and following the specified interval pattern.
 
 This is similar to generating chromatic scales except that instead of returning
-12 notes you need to return one note for each interval in the given pattern by
-skipping the number of notes indicated by each interval in the pattern.
+12 notes, you will return N+1 notes for N intervals.
+The first note is always the given tonic.
+Then, for each interval in the pattern, the next note is determined by starting from the previous note and skipping the number of notes indicated by the interval.
+
+For example, starting with G and using the seven intervals MMmMMMm, there would be the following eight notes:
+
+Note | Reason
+--|--
+G | Tonic
+A | M indicates a whole step from G, skipping G#
+B | M indicates a whole step from A, skipping A#
+C | m indicates a half step from B, skipping nothing
+D | M indicates a whole step from C, skipping C#
+E | M indicates a whole step from D, skipping D#
+F# | M indicates a whole step from E, skipping F
+G | m indicates a half step from F#, skipping nothing


### PR DESCRIPTION
The problem has been explained in
https://github.com/exercism/problem-specifications/issues/1640:

All previous cases only required N notes from N intervals, but that
meant the last interval was completely ignored.
That causes confusion (what is the last interval there for?).

To fix this, all tests with the `interval` property have to be
reimplemented.

The `tonic` and `intervals` inputs are the same as the original.
The `expected` is the same as the original, except with an additional
last note indicated by the last interval, which was previously
ignored.

In conjunction with https://github.com/exercism/problem-specifications/pull/1884,
closes https://github.com/exercism/problem-specifications/issues/1640