### PR TITLE
isbn-verifier: Enhance invalid characters test

### DIFF
--- a/exercises/isbn-verifier/canonical-data.json
+++ b/exercises/isbn-verifier/canonical-data.json
@@ -150,6 +150,17 @@
             "expected": false
         },
         {
+            "uuid": "daad3e58-ce00-4395-8a8e-e3eded1cdc86",
+            "description": "invalid characters are not ignored",
+            "comments": ["Catch invalid characters in an otherwise valid isbn"],
+            "reimplements": "ed6e8d1b-382c-4081-8326-8b772c581fec",
+            "property": "isValid",
+            "input": {
+                "isbn": "3598P215088"
+            },
+            "expected": false
+        },
+        {
             "uuid": "fb5e48d8-7c03-4bfb-a088-b101df16fdc3",
             "description": "input is too long but contains a valid isbn",
             "property": "isValid",


### PR DESCRIPTION
Add a test case to cover the scenario where an invalid character is
nested inside an otherwise valid ISBN.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>