### PR TITLE
Atbash Cipher: Refine the exercise description

### DIFF
--- a/exercises/atbash-cipher/description.md
+++ b/exercises/atbash-cipher/description.md
@@ -19,11 +19,12 @@ a simple mono-alphabetic substitution cipher. However, this may not have
 been an issue in the cipher's time.
 
 Ciphertext is written out in groups of fixed length, the traditional group size
-being 5 letters, and punctuation is excluded. This is to make it harder to guess
-things based on word boundaries.
+being 5 letters, leaving numbers unchanged, and punctuation is excluded.
+This is to make it harder to guess things based on word boundaries.
 
 ## Examples
 
 - Encoding `test` gives `gvhg`
+- Encoding `x123 yes` gives `c123b vh`
 - Decoding `gvhg` gives `test`
 - Decoding `gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt` gives `thequickbrownfoxjumpsoverthelazydog`


### PR DESCRIPTION
In the canonical-data.json, there are some test cases with numbers.
However, it is not clearly described how to deal with them in the description.md content.
So I made some changes for it. Hopefully it could help to refine the description.