### PR TITLE
isbn-verifier: Distinguish two different invalid character tests

### DIFF
--- a/exercises/isbn-verifier/canonical-data.json
+++ b/exercises/isbn-verifier/canonical-data.json
@@ -142,7 +142,7 @@
         },
         {
             "uuid": "ed6e8d1b-382c-4081-8326-8b772c581fec",
-            "description": "invalid characters are not ignored",
+            "description": "invalid characters are not ignored after checking length",
             "property": "isValid",
             "input": {
                 "isbn": "3132P34035"
@@ -151,9 +151,8 @@
         },
         {
             "uuid": "daad3e58-ce00-4395-8a8e-e3eded1cdc86",
-            "description": "invalid characters are not ignored",
+            "description": "invalid characters are not ignored before checking length",
             "comments": ["Catch invalid characters in an otherwise valid isbn"],
-            "reimplements": "ed6e8d1b-382c-4081-8326-8b772c581fec",
             "property": "isValid",
             "input": {
                 "isbn": "3598P215088"

--- a/exercises/isbn-verifier/canonical-data.json
+++ b/exercises/isbn-verifier/canonical-data.json
@@ -43,7 +43,7 @@
         },
         {
             "uuid": "c19ba0c4-014f-4dc3-a63f-ff9aefc9b5ec",
-            "description": "invalid character in isbn",
+            "description": "invalid character in isbn is not treated as zero",
             "property": "isValid",
             "input": {
               "isbn": "3-598-P1581-X"


### PR DESCRIPTION
One (3132P34035) tests what happens if the invalid character is ignored
after checking length, the other (3598P215088) tests what happens if the
invalid character is ignored before checking length.

These are two different incorrect implementations, and they get the
correct answer on the other tests. So only including one of the two
would fail to reject the other, and tracks would lose coverage.

Therefore, my recommendation is that tracks include both tests.

I have delivered the full recommendation in
https://github.com/exercism/problem-specifications/pull/1898#issuecomment-1002061905

Instead of having one reimplement the other, distinguish the two by
description.