### PR TITLE
largest-series-product: Describe window size 0

### DIFF
--- a/exercises/largest-series-product/description.md
+++ b/exercises/largest-series-product/description.md
@@ -12,3 +12,7 @@ in the input; the digits need not be *numerically consecutive*.
 
 For the input `'73167176531330624919225119674426574742355349194934'`,
 the largest product for a series of 6 digits is 23520.
+
+For a series of zero digits, the largest product is 1 because 1 is the multiplicative identity.
+(You don't need to know what a multiplicative identity is to solve this problem;
+it just means that multiplying a number by 1 gives you the same number.)


### PR DESCRIPTION
Closes https://github.com/exercism/problem-specifications/issues/1910

We established the tests for window size 0 via
https://github.com/exercism/problem-specifications/pull/170

Window size 0 has caused questions in the past, including but not
limited to:

* https://github.com/exercism/problem-specifications/issues/1638
* https://github.com/exercism/go/issues/349

We have comments on the test cases, but it's not necessarily the case
that everyone will see those comments.

Let's try adding the reasoning to the description.