### PR TITLE
Docs(style-guide): Fix broken link to style-guide.md

### DIFF
--- a/STYLE-GUIDE.md
+++ b/STYLE-GUIDE.md
@@ -1,3 +1,3 @@
 # Moved
 
-This file has now moved to the [docs repository](https://github.com/exercism/docs/blob/main/contributing/standards/style-guide.md).
+This file has now moved to the [docs repository](https://github.com/exercism/docs/blob/main/building/markdown/style-guide.md).


### PR DESCRIPTION
The style guide "redirect" link seems to be broken. Linked to what I assume is the correct file in the docs repo

Old link: https://github.com/exercism/docs/blob/main/contributing/standards/style-guide.md
New link: https://github.com/exercism/docs/blob/main/building/markdown/style-guide.md