### PR TITLE
anagram: reimplement cases where `candidates` isn't a set

### DIFF
--- a/exercises/anagram/canonical-data.json
+++ b/exercises/anagram/canonical-data.json
@@ -153,12 +153,56 @@
       "expected": []
     },
     {
+      "uuid": "68934ed0-010b-4ef9-857a-20c9012d1ebf",
+      "reimplements": "85757361-4535-45fd-ac0e-3810d40debc1",
+      "description": "words are not anagrams of themselves",
+      "property": "findAnagrams",
+      "input": {
+        "subject": "BANANA",
+        "candidates": ["BANANA"]
+      },
+      "expected": []
+    },
+    {
+      "uuid": "589384f3-4c8a-4e7d-9edc-51c3e5f0c90e",
+      "reimplements": "85757361-4535-45fd-ac0e-3810d40debc1",
+      "description": "words are not anagrams of themselves even if letter case is partially different",
+      "property": "findAnagrams",
+      "input": {
+        "subject": "BANANA",
+        "candidates": ["Banana"]
+      },
+      "expected": []
+    },
+    {
+      "uuid": "ba53e423-7e02-41ee-9ae2-71f91e6d18e6",
+      "reimplements": "85757361-4535-45fd-ac0e-3810d40debc1",
+      "description": "words are not anagrams of themselves even if letter case is completely different",
+      "property": "findAnagrams",
+      "input": {
+        "subject": "BANANA",
+        "candidates": ["banana"]
+      },
+      "expected": []
+    },
+    {
       "uuid": "a0705568-628c-4b55-9798-82e4acde51ca",
       "description": "words other than themselves can be anagrams",
       "property": "findAnagrams",
       "input": {
         "subject": "LISTEN",
         "candidates": ["Listen", "Silent", "LISTEN"]
+      },
+      "expected": ["Silent"]
+    },
+    {
+      "uuid": "33d3f67e-fbb9-49d3-a90e-0beb00861da7",
+      "reimplements": "a0705568-628c-4b55-9798-82e4acde51ca",
+      "description": "words other than themselves can be anagrams",
+      "property": "findAnagrams",
+      "input": {
+        "subject": "LISTEN",
+        "candidates": ["LISTEN", "Silent"]
       },
       "expected": ["Silent"]
     }


### PR DESCRIPTION
Short version:

The focal question of this commit:
**Should determining set membership be case-insensitive?**

If yes, this commit makes it so.
If no, this commit should be rejected.

Long version:

In https://github.com/exercism/problem-specifications/pull/1928 it was
codified that the input `candidates` is a set of words. Recall that a
set contains no duplicates.

Recall that ever since July 2013, it has been the intent of this
exercise that determining whether two words are anagram of each other
should be case-insensitive:
https://github.com/exercism/exercism/commit/bf3e0117c584b0b2b8b2af655986ac1678b98185

Recall that ever since January 2014, it has also been the intent that
determining whether a word is an anagram of itself should be
case-insensitive:
https://github.com/exercism/exercism/pull/1266

The next step is to consider the focal question of this PR:
**Should determining set membership be case-insensitive?**

If yes, that is consistent with the anagram relation. Then, two current
cases are in violation because they contain multiple instances of the
same word. These instances are the same, even despite that they have
different letter case, becuse set membership is case-insensitive. If
this is so, this commit rectifies, while preserving tested
functionality.

If no, then we are declaring that this inconsistency is acceptable
because it simply means two different rules are applied in two different
situations, but they are both done consistently:
Set membership is case-sensitive.
The anagram relation is case-insensitive.
If this is so, then this PR should be closed, with the discussion
serving as affirmation that the question has been duly considered.

Please understand that the opinion of the author of this commit is
deliberately and explicitly left unspecified. The reason for that isn't
to avoid unfair influence, but instead because the author of this commit
does not anticipate having an opinion on this matter either way.