### PR TITLE
Reduced rational nr. should be in standard form.

### DIFF
--- a/exercises/rational-numbers/description.md
+++ b/exercises/rational-numbers/description.md
@@ -32,8 +32,6 @@ Implement the following operations:
 - absolute value, exponentiation of a given rational number to an integer power, exponentiation of a given rational number to a real (floating-point) power, exponentiation of a real number to a rational number.
 
 Your implementation of rational numbers should always be reduced to lowest terms. For example, `4/4` should reduce to `1/1`, `30/60` should reduce to `1/2`, `12/8` should reduce to `3/2`, etc. To reduce a rational number `r = a/b`, divide `a` and `b` by the greatest common divisor (gcd) of `a` and `b`. So, for example, `gcd(12, 8) = 4`, so `r = 12/8` can be reduced to `(12/4)/(8/4) = 3/2`.
-The reduced form of a rational number should be in "standard form": The denominator should always be a positive integer. If a denominator with a negative integer is present, multiply both numerator and denominator by `-1` to ensure standard form is reached. For example, `{3, -4}` should be reduced as `{-3, 4}`
-
-
+The reduced form of a rational number should be in "standard form" (the denominator should always be a positive integer). If a denominator with a negative integer is present, multiply both numerator and denominator by `-1` to ensure standard form is reached. For example, `{3, -4}` should be reduced to `{-3, 4}`
 
 Assume that the programming language you are using does not have an implementation of rational numbers.

--- a/exercises/rational-numbers/description.md
+++ b/exercises/rational-numbers/description.md
@@ -32,5 +32,8 @@ Implement the following operations:
 - absolute value, exponentiation of a given rational number to an integer power, exponentiation of a given rational number to a real (floating-point) power, exponentiation of a real number to a rational number.
 
 Your implementation of rational numbers should always be reduced to lowest terms. For example, `4/4` should reduce to `1/1`, `30/60` should reduce to `1/2`, `12/8` should reduce to `3/2`, etc. To reduce a rational number `r = a/b`, divide `a` and `b` by the greatest common divisor (gcd) of `a` and `b`. So, for example, `gcd(12, 8) = 4`, so `r = 12/8` can be reduced to `(12/4)/(8/4) = 3/2`.
+The reduced form of a rational number should be in "standard form": The denominator should always be a positive integer. If a denominator with a negative integer is present, multiply both numerator and denominator by `-1` to ensure standard form is reached. For example, `{3, -4}` should be reduced as `{-3, 4}`
+
+
 
 Assume that the programming language you are using does not have an implementation of rational numbers.


### PR DESCRIPTION
The current instructions fail to mention that a reduced rational number should always be rendered in standard form (without any negative value at the denominator).