### PR TITLE
phone number: only one problem per test input

### DIFF
--- a/exercises/phone-number/canonical-data.json
+++ b/exercises/phone-number/canonical-data.json
@@ -98,7 +98,7 @@
     {
       "uuid": "eb8a1fc0-64e5-46d3-b0c6-33184208e28a",
       "reimplements": "63f38f37-53f6-4a5f-bd86-e9b404f10a60",
-      "comment": "make input invalid only due to letters; area code may not start with 1",
+      "comments": "make input invalid only due to letters; area code may not start with 1",
       "description": "invalid with letters",
       "property": "clean",
       "input": {
@@ -122,7 +122,7 @@
     {
       "uuid": "065f6363-8394-4759-b080-e6c8c351dd1f",
       "reimplements": "4bd97d90-52fd-45d3-b0db-06ab95b1244e",
-      "comment": "make input invalid only due to punctuation; area code may not start with 1",
+      "comments": "make input invalid only due to punctuation; area code may not start with 1",
       "description": "invalid with punctuations",
       "property": "clean",
       "input": {

--- a/exercises/phone-number/canonical-data.json
+++ b/exercises/phone-number/canonical-data.json
@@ -98,7 +98,7 @@
     {
       "uuid": "eb8a1fc0-64e5-46d3-b0c6-33184208e28a",
       "reimplements": "63f38f37-53f6-4a5f-bd86-e9b404f10a60",
-      "comments": "make input invalid only due to letters; area code may not start with 1",
+      "comments": ["make input invalid only due to letters; area code may not start with 1"],
       "description": "invalid with letters",
       "property": "clean",
       "input": {
@@ -122,7 +122,7 @@
     {
       "uuid": "065f6363-8394-4759-b080-e6c8c351dd1f",
       "reimplements": "4bd97d90-52fd-45d3-b0db-06ab95b1244e",
-      "comments": "make input invalid only due to punctuation; area code may not start with 1",
+      "comments": ["make input invalid only due to punctuation; area code may not start with 1"],
       "description": "invalid with punctuations",
       "property": "clean",
       "input": {

--- a/exercises/phone-number/canonical-data.json
+++ b/exercises/phone-number/canonical-data.json
@@ -38,7 +38,7 @@
       "description": "invalid when 9 digits",
       "property": "clean",
       "input": {
-        "phrase": "213456789"
+        "phrase": "123456789"
       },
       "expected": {
         "error": "incorrect number of digits"
@@ -89,6 +89,19 @@
       "description": "invalid with letters",
       "property": "clean",
       "input": {
+        "phrase": "123-abc-7890"
+      },
+      "expected": {
+        "error": "letters not permitted"
+      }
+    },
+    {
+      "uuid": "eb8a1fc0-64e5-46d3-b0c6-33184208e28a",
+      "reimplements": "63f38f37-53f6-4a5f-bd86-e9b404f10a60",
+      "comment": "make input invalid only due to letters; area code may not start with 1",
+      "description": "invalid with letters",
+      "property": "clean",
+      "input": {
         "phrase": "523-abc-7890"
       },
       "expected": {
@@ -97,6 +110,19 @@
     },
     {
       "uuid": "4bd97d90-52fd-45d3-b0db-06ab95b1244e",
+      "description": "invalid with punctuations",
+      "property": "clean",
+      "input": {
+        "phrase": "123-@:!-7890"
+      },
+      "expected": {
+        "error": "punctuations not permitted"
+      }
+    },
+    {
+      "uuid": "065f6363-8394-4759-b080-e6c8c351dd1f",
+      "reimplements": "4bd97d90-52fd-45d3-b0db-06ab95b1244e",
+      "comment": "make input invalid only due to punctuation; area code may not start with 1",
       "description": "invalid with punctuations",
       "property": "clean",
       "input": {

--- a/exercises/phone-number/canonical-data.json
+++ b/exercises/phone-number/canonical-data.json
@@ -98,7 +98,9 @@
     {
       "uuid": "eb8a1fc0-64e5-46d3-b0c6-33184208e28a",
       "reimplements": "63f38f37-53f6-4a5f-bd86-e9b404f10a60",
-      "comments": ["make input invalid only due to letters; area code may not start with 1"],
+      "comments": [
+        "make input invalid only due to letters; area code may not start with 1"
+      ],
       "description": "invalid with letters",
       "property": "clean",
       "input": {
@@ -122,7 +124,9 @@
     {
       "uuid": "065f6363-8394-4759-b080-e6c8c351dd1f",
       "reimplements": "4bd97d90-52fd-45d3-b0db-06ab95b1244e",
-      "comments": ["make input invalid only due to punctuation; area code may not start with 1"],
+      "comments": [
+        "make input invalid only due to punctuation; area code may not start with 1"
+      ],
       "description": "invalid with punctuations",
       "property": "clean",
       "input": {

--- a/exercises/phone-number/canonical-data.json
+++ b/exercises/phone-number/canonical-data.json
@@ -38,7 +38,7 @@
       "description": "invalid when 9 digits",
       "property": "clean",
       "input": {
-        "phrase": "123456789"
+        "phrase": "213456789"
       },
       "expected": {
         "error": "incorrect number of digits"
@@ -89,7 +89,7 @@
       "description": "invalid with letters",
       "property": "clean",
       "input": {
-        "phrase": "123-abc-7890"
+        "phrase": "523-abc-7890"
       },
       "expected": {
         "error": "letters not permitted"
@@ -100,7 +100,7 @@
       "description": "invalid with punctuations",
       "property": "clean",
       "input": {
-        "phrase": "123-@:!-7890"
+        "phrase": "523-@:!-7890"
       },
       "expected": {
         "error": "punctuations not permitted"


### PR DESCRIPTION
Because the area code is not allowed to start with 0 or 1, inputs designed to elicit other errors should not use area codes that start with either of those digits.