### PR TITLE
Reorder keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,9 @@ jobs:
 
           exit "$fail"
 
+      - name: Verify that all keys are in the correct order
+        run: ./bin/check_key_order.rb
+
   markdown-lint:
     name: Lint markdown files
     runs-on: ubuntu-latest

--- a/bin/check_key_order.rb
+++ b/bin/check_key_order.rb
@@ -14,12 +14,13 @@ end
 
 exit_code = 0
 
-Dir.glob('exercises/*/canonical-data.json').each do |path|
+root_dir = "#{__dir__}/.."
+Dir.glob("#{root_dir}/exercises/*/canonical-data.json").each do |path|
   json = JSON.parse(File.read(path))
   invalid_tests = find_tests(json).select {|test| (CORRECT_ORDER & test.keys) != test.keys}
   next if invalid_tests.empty?
 
-  puts "The following tests in #{path} use the wrong key order:"
+  puts "The following tests in #{path.delete_prefix("#{root_dir}/")} use the wrong key order:"
   invalid_tests.each do |test|
     puts "- Test: #{test['uuid']} (#{test['description']})"
     puts "  Actual: #{test.keys}"

--- a/bin/check_key_order.rb
+++ b/bin/check_key_order.rb
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+
+CORRECT_ORDER = %w[uuid reimplements description comments scenarios property input expected]
+
+require 'json'
+
+def find_tests(json)
+  if json['cases']
+    json['cases'].flat_map {|cases| find_tests(cases)}
+  elsif json['uuid']
+    [json]
+  end
+end
+
+exit_code = 0
+
+Dir.glob('exercises/*/canonical-data.json').each do |path|
+  json = JSON.parse(File.read(path))
+  invalid_tests = find_tests(json).select {|test| (CORRECT_ORDER & test.keys) != test.keys}
+  next if invalid_tests.empty?
+
+  puts "The following tests in #{path} use the wrong key order:"
+  invalid_tests.each do |test|
+    puts "- Test: #{test['uuid']} (#{test['description']})"
+    puts "  Actual: #{test.keys}"
+    puts "  Expected: #{(CORRECT_ORDER & test.keys)}"
+    puts ""
+  end
+
+  exit_code = 1
+end
+
+exit(exit_code)

--- a/exercises/accumulate/canonical-data.json
+++ b/exercises/accumulate/canonical-data.json
@@ -64,10 +64,10 @@
     },
     {
       "uuid": "0b357334-4cad-49e1-a741-425202edfc7c",
-      "description": "accumulate recursively",
-      "property": "accumulate",
       "reimplements": "bee8e9b6-b16f-4cd2-be3b-ccf7457e50bb",
+      "description": "accumulate recursively",
       "comments": ["Removes the trailing `)` at the end of the expression"],
+      "property": "accumulate",
       "input": {
         "list": ["a", "b", "c"],
         "accumulator": "(x) => accumulate([\"1\", \"2\", \"3\"], (y) => x + y)"

--- a/exercises/anagram/canonical-data.json
+++ b/exercises/anagram/canonical-data.json
@@ -24,10 +24,10 @@
     {
       "uuid": "03eb9bbe-8906-4ea0-84fa-ffe711b52c8b",
       "reimplements": "b3cca662-f50a-489e-ae10-ab8290a09bdc",
+      "description": "detects two anagrams",
       "comments": [
         "Reimplemented to be consistent about removing references to 'master'"
       ],
-      "description": "detects two anagrams",
       "property": "findAnagrams",
       "input": {
         "subject": "solemn",

--- a/exercises/book-store/canonical-data.json
+++ b/exercises/book-store/canonical-data.json
@@ -11,9 +11,9 @@
   "cases": [
     {
       "uuid": "17146bd5-2e80-4557-ab4c-05632b6b0d01",
-      "property": "total",
       "description": "Only a single book",
       "comments": ["Suggested grouping, [[1]]."],
+      "property": "total",
       "input": {
         "basket": [1]
       },
@@ -21,9 +21,9 @@
     },
     {
       "uuid": "cc2de9ac-ff2a-4efd-b7c7-bfe0f43271ce",
-      "property": "total",
       "description": "Two of the same book",
       "comments": ["Suggested grouping, [[2],[2]]."],
+      "property": "total",
       "input": {
         "basket": [2, 2]
       },
@@ -31,9 +31,9 @@
     },
     {
       "uuid": "5a86eac0-45d2-46aa-bbf0-266b94393a1a",
-      "property": "total",
       "description": "Empty basket",
       "comments": ["Suggested grouping, []."],
+      "property": "total",
       "input": {
         "basket": []
       },
@@ -41,9 +41,9 @@
     },
     {
       "uuid": "158bd19a-3db4-4468-ae85-e0638a688990",
-      "property": "total",
       "description": "Two different books",
       "comments": ["Suggested grouping, [[1,2]]."],
+      "property": "total",
       "input": {
         "basket": [1, 2]
       },
@@ -51,9 +51,9 @@
     },
     {
       "uuid": "f3833f6b-9332-4a1f-ad98-6c3f8e30e163",
-      "property": "total",
       "description": "Three different books",
       "comments": ["Suggested grouping, [[1,2,3]]."],
+      "property": "total",
       "input": {
         "basket": [1, 2, 3]
       },
@@ -61,9 +61,9 @@
     },
     {
       "uuid": "1951a1db-2fb6-4cd1-a69a-f691b6dd30a2",
-      "property": "total",
       "description": "Four different books",
       "comments": ["Suggested grouping, [[1,2,3,4]]."],
+      "property": "total",
       "input": {
         "basket": [1, 2, 3, 4]
       },
@@ -71,9 +71,9 @@
     },
     {
       "uuid": "d70f6682-3019-4c3f-aede-83c6a8c647a3",
-      "property": "total",
       "description": "Five different books",
       "comments": ["Suggested grouping, [[1,2,3,4,5]]."],
+      "property": "total",
       "input": {
         "basket": [1, 2, 3, 4, 5]
       },
@@ -81,9 +81,9 @@
     },
     {
       "uuid": "78cacb57-911a-45f1-be52-2a5bd428c634",
-      "property": "total",
       "description": "Two groups of four is cheaper than group of five plus group of three",
       "comments": ["Suggested grouping, [[1,2,3,4],[1,2,3,5]]."],
+      "property": "total",
       "input": {
         "basket": [1, 1, 2, 2, 3, 3, 4, 5]
       },
@@ -91,11 +91,11 @@
     },
     {
       "uuid": "f808b5a4-e01f-4c0d-881f-f7b90d9739da",
-      "property": "total",
       "description": "Two groups of four is cheaper than groups of five and three",
       "comments": [
         "Suggested grouping, [[1,2,4,5],[1,3,4,5]]. This differs from the other 'two groups of four' test in that it will fail for solutions that add books to groups in the order in which they appear in the list."
       ],
+      "property": "total",
       "input": {
         "basket": [1, 1, 2, 3, 4, 4, 5, 5]
       },
@@ -103,9 +103,9 @@
     },
     {
       "uuid": "fe96401c-5268-4be2-9d9e-19b76478007c",
-      "property": "total",
       "description": "Group of four plus group of two is cheaper than two groups of three",
       "comments": ["Suggested grouping, [[1,2,3,4],[1,2]]."],
+      "property": "total",
       "input": {
         "basket": [1, 1, 2, 2, 3, 4]
       },
@@ -113,9 +113,9 @@
     },
     {
       "uuid": "68ea9b78-10ad-420e-a766-836a501d3633",
-      "property": "total",
       "description": "Two each of first 4 books and 1 copy each of rest",
       "comments": ["Suggested grouping, [[1,2,3,4,5],[1,2,3,4]]."],
+      "property": "total",
       "input": {
         "basket": [1, 1, 2, 2, 3, 3, 4, 4, 5]
       },
@@ -123,9 +123,9 @@
     },
     {
       "uuid": "c0a779d5-a40c-47ae-9828-a340e936b866",
-      "property": "total",
       "description": "Two copies of each book",
       "comments": ["Suggested grouping, [[1,2,3,4,5],[1,2,3,4,5]]."],
+      "property": "total",
       "input": {
         "basket": [1, 1, 2, 2, 3, 3, 4, 4, 5, 5]
       },
@@ -133,9 +133,9 @@
     },
     {
       "uuid": "18fd86fe-08f1-4b68-969b-392b8af20513",
-      "property": "total",
       "description": "Three copies of first book and 2 each of remaining",
       "comments": ["Suggested grouping, [[1,2,3,4,5],[1,2,3,4,5],[1]]."],
+      "property": "total",
       "input": {
         "basket": [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 1]
       },
@@ -143,9 +143,9 @@
     },
     {
       "uuid": "0b19a24d-e4cf-4ec8-9db2-8899a41af0da",
-      "property": "total",
       "description": "Three each of first 2 books and 2 each of remaining books",
       "comments": ["Suggested grouping, [[1,2,3,4,5],[1,2,3,4,5],[1,2]]."],
+      "property": "total",
       "input": {
         "basket": [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 1, 2]
       },
@@ -153,11 +153,11 @@
     },
     {
       "uuid": "bb376344-4fb2-49ab-ab85-e38d8354a58d",
-      "property": "total",
       "description": "Four groups of four are cheaper than two groups each of five and three",
       "comments": [
         "Suggested grouping, [[1,2,3,4],[1,2,3,5],[1,2,3,4],[1,2,3,5]]."
       ],
+      "property": "total",
       "input": {
         "basket": [1, 1, 2, 2, 3, 3, 4, 5, 1, 1, 2, 2, 3, 3, 4, 5]
       },
@@ -165,11 +165,11 @@
     },
     {
       "uuid": "5260ddde-2703-4915-b45a-e54dbbac4303",
-      "property": "total",
       "description": "Check that groups of four are created properly even when there are more groups of three than groups of five",
       "comments": [
         "Suggested grouping, [[1,2,3,4],[1,2,3,5],[1,2,3,4],[1,2,3,5],[1,2,3],[1,2,3]]."
       ],
+      "property": "total",
       "input": {
         "basket": [1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 5, 5]
       },
@@ -177,9 +177,9 @@
     },
     {
       "uuid": "b0478278-c551-4747-b0fc-7e0be3158b1f",
-      "property": "total",
       "description": "One group of one and four is cheaper than one group of two and three",
       "comments": ["Suggested grouping, [[1],[1,2,3,4]]."],
+      "property": "total",
       "input": {
         "basket": [1, 1, 2, 3, 4]
       },
@@ -187,11 +187,11 @@
     },
     {
       "uuid": "cf868453-6484-4ae1-9dfc-f8ee85bbde01",
-      "property": "total",
       "description": "One group of one and two plus three groups of four is cheaper than one group of each size",
       "comments": [
         "Suggested grouping, [[5],[5,4],[5,4,3,2],[5,4,3,2],[5,4,3,1]]."
       ],
+      "property": "total",
       "input": {
         "basket": [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5]
       },

--- a/exercises/collatz-conjecture/canonical-data.json
+++ b/exercises/collatz-conjecture/canonical-data.json
@@ -50,10 +50,10 @@
     },
     {
       "uuid": "2187673d-77d6-4543-975e-66df6c50e2da",
-      "description": "zero is an error",
-      "property": "steps",
-      "comments": ["Collatz Conjecture holds only for positive integers"],
       "reimplements": "7d4750e6-def9-4b86-aec7-9f7eb44f95a3",
+      "description": "zero is an error",
+      "comments": ["Collatz Conjecture holds only for positive integers"],
+      "property": "steps",
       "input": {
         "number": 0
       },
@@ -74,9 +74,9 @@
     },
     {
       "uuid": "ec11f479-56bc-47fd-a434-bcd7a31a7a2e",
+      "reimplements": "c6c795bf-a288-45e9-86a1-841359ad426d",
       "description": "negative value is an error",
       "comments": ["Collatz Conjecture holds only for positive integers"],
-      "reimplements": "c6c795bf-a288-45e9-86a1-841359ad426d",
       "property": "steps",
       "input": {
         "number": -15

--- a/exercises/darts/canonical-data.json
+++ b/exercises/darts/canonical-data.json
@@ -6,8 +6,8 @@
   "cases": [
     {
       "uuid": "9033f731-0a3a-4d9c-b1c0-34a1c8362afb",
-      "property": "score",
       "description": "Missed target",
+      "property": "score",
       "input": {
         "x": -9,
         "y": 9
@@ -16,8 +16,8 @@
     },
     {
       "uuid": "4c9f6ff4-c489-45fd-be8a-1fcb08b4d0ba",
-      "property": "score",
       "description": "On the outer circle",
+      "property": "score",
       "input": {
         "x": 0,
         "y": 10
@@ -26,8 +26,8 @@
     },
     {
       "uuid": "14378687-ee58-4c9b-a323-b089d5274be8",
-      "property": "score",
       "description": "On the middle circle",
+      "property": "score",
       "input": {
         "x": -5,
         "y": 0
@@ -36,8 +36,8 @@
     },
     {
       "uuid": "849e2e63-85bd-4fed-bc3b-781ae962e2c9",
-      "property": "score",
       "description": "On the inner circle",
+      "property": "score",
       "input": {
         "x": 0,
         "y": -1
@@ -46,8 +46,8 @@
     },
     {
       "uuid": "1c5ffd9f-ea66-462f-9f06-a1303de5a226",
-      "property": "score",
       "description": "Exactly on centre",
+      "property": "score",
       "input": {
         "x": 0,
         "y": 0
@@ -56,8 +56,8 @@
     },
     {
       "uuid": "b65abce3-a679-4550-8115-4b74bda06088",
-      "property": "score",
       "description": "Near the centre",
+      "property": "score",
       "input": {
         "x": -0.1,
         "y": -0.1
@@ -66,8 +66,8 @@
     },
     {
       "uuid": "66c29c1d-44f5-40cf-9927-e09a1305b399",
-      "property": "score",
       "description": "Just within the inner circle",
+      "property": "score",
       "input": {
         "x": 0.7,
         "y": 0.7
@@ -76,8 +76,8 @@
     },
     {
       "uuid": "d1012f63-c97c-4394-b944-7beb3d0b141a",
-      "property": "score",
       "description": "Just outside the inner circle",
+      "property": "score",
       "input": {
         "x": 0.8,
         "y": -0.8
@@ -86,8 +86,8 @@
     },
     {
       "uuid": "ab2b5666-b0b4-49c3-9b27-205e790ed945",
-      "property": "score",
       "description": "Just within the middle circle",
+      "property": "score",
       "input": {
         "x": -3.5,
         "y": 3.5
@@ -96,8 +96,8 @@
     },
     {
       "uuid": "70f1424e-d690-4860-8caf-9740a52c0161",
-      "property": "score",
       "description": "Just outside the middle circle",
+      "property": "score",
       "input": {
         "x": -3.6,
         "y": -3.6
@@ -106,8 +106,8 @@
     },
     {
       "uuid": "a7dbf8db-419c-4712-8a7f-67602b69b293",
-      "property": "score",
       "description": "Just within the outer circle",
+      "property": "score",
       "input": {
         "x": -7.0,
         "y": 7.0
@@ -116,8 +116,8 @@
     },
     {
       "uuid": "e0f39315-9f9a-4546-96e4-a9475b885aa7",
-      "property": "score",
       "description": "Just outside the outer circle",
+      "property": "score",
       "input": {
         "x": 7.1,
         "y": -7.1
@@ -126,8 +126,8 @@
     },
     {
       "uuid": "045d7d18-d863-4229-818e-b50828c75d19",
-      "property": "score",
       "description": "Asymmetric position between the inner and middle circles",
+      "property": "score",
       "input": {
         "x": 0.5,
         "y": -4

--- a/exercises/diffie-hellman/canonical-data.json
+++ b/exercises/diffie-hellman/canonical-data.json
@@ -56,14 +56,14 @@
         "public key from different values, for example from the test with     ",
         "uuid (b4161d8e-53a1-4241-ae8f-48cc86527f22).                         "
       ],
+      "scenarios": ["immutable"],
       "property": "publicKey",
       "input": {
         "p": 23,
         "g": 5,
         "privateKey": 15
       },
-      "expected": 19,
-      "scenarios": ["immutable"]
+      "expected": 19
     },
     {
       "uuid": "cd02ad45-3f52-4510-99cc-5161dad948a8",

--- a/exercises/grade-school/canonical-data.json
+++ b/exercises/grade-school/canonical-data.json
@@ -88,8 +88,8 @@
     {
       "uuid": "a0c7b9b8-0e89-47f8-8b4a-c50f885e79d1",
       "reimplements": "c125dab7-2a53-492f-a99a-56ad511940d8",
-      "comments": ["Reimplemented to be logically consistent"],
       "description": "A student can only be added to the same grade in the roster once",
+      "comments": ["Reimplemented to be logically consistent"],
       "property": "roster",
       "input": {
         "students": [
@@ -101,8 +101,8 @@
     },
     {
       "uuid": "d7982c4f-1602-49f6-a651-620f2614243a",
-      "description": "Student not added to same grade in the roster more than once",
       "reimplements": "a0c7b9b8-0e89-47f8-8b4a-c50f885e79d1",
+      "description": "Student not added to same grade in the roster more than once",
       "comments": [
         "Ensure the implementation does not affect students already added",
         "Ensure the implementation does not prevent addition of other students after preventing the error case"
@@ -159,8 +159,8 @@
     {
       "uuid": "6a03b61e-1211-4783-a3cc-fc7f773fba3f",
       "reimplements": "c125dab7-2a53-492f-a99a-56ad511940d8",
-      "comments": ["Reimplemented to be logically consistent"],
       "description": "A student cannot be added to more than one grade in the sorted roster",
+      "comments": ["Reimplemented to be logically consistent"],
       "property": "roster",
       "input": {
         "students": [
@@ -173,11 +173,11 @@
     {
       "uuid": "c7ec1c5e-9ab7-4d3b-be5c-29f2f7a237c5",
       "reimplements": "6a03b61e-1211-4783-a3cc-fc7f773fba3f",
+      "description": "Student not added to multiple grades in the roster",
       "comments": [
         "Ensure the implementation does not affect students already added",
         "Ensure the implementation does not prevent addition of other students after preventing the error case"
       ],
-      "description": "Student not added to multiple grades in the roster",
       "property": "roster",
       "input": {
         "students": [

--- a/exercises/hamming/canonical-data.json
+++ b/exercises/hamming/canonical-data.json
@@ -74,9 +74,9 @@
     },
     {
       "uuid": "b9228bb1-465f-4141-b40f-1f99812de5a8",
+      "reimplements": "919f8ef0-b767-4d1b-8516-6379d07fcb28",
       "description": "disallow first strand longer",
       "comments": ["Normalises error messages"],
-      "reimplements": "919f8ef0-b767-4d1b-8516-6379d07fcb28",
       "property": "distance",
       "input": {
         "strand1": "AATG",
@@ -100,9 +100,9 @@
     },
     {
       "uuid": "dab38838-26bb-4fff-acbe-3b0a9bfeba2d",
+      "reimplements": "8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e",
       "description": "disallow second strand longer",
       "comments": ["Normalises error messages"],
-      "reimplements": "8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e",
       "property": "distance",
       "input": {
         "strand1": "ATA",
@@ -126,9 +126,9 @@
     },
     {
       "uuid": "db92e77e-7c72-499d-8fe6-9354d2bfd504",
+      "reimplements": "5dce058b-28d4-4ca7-aa64-adfe4e17784c",
       "description": "disallow left empty strand",
       "comments": ["Normalises error messages"],
-      "reimplements": "5dce058b-28d4-4ca7-aa64-adfe4e17784c",
       "property": "distance",
       "input": {
         "strand1": "",
@@ -140,9 +140,9 @@
     },
     {
       "uuid": "b764d47c-83ff-4de2-ab10-6cfe4b15c0f3",
+      "reimplements": "db92e77e-7c72-499d-8fe6-9354d2bfd504",
       "description": "disallow empty first strand",
       "comments": ["Normalises error messages"],
-      "reimplements": "db92e77e-7c72-499d-8fe6-9354d2bfd504",
       "property": "distance",
       "input": {
         "strand1": "",
@@ -166,9 +166,9 @@
     },
     {
       "uuid": "920cd6e3-18f4-4143-b6b8-74270bb8f8a3",
+      "reimplements": "38826d4b-16fb-4639-ac3e-ba027dec8b5f",
       "description": "disallow right empty strand",
       "comments": ["Normalises error messages"],
-      "reimplements": "38826d4b-16fb-4639-ac3e-ba027dec8b5f",
       "property": "distance",
       "input": {
         "strand1": "G",
@@ -180,9 +180,9 @@
     },
     {
       "uuid": "9ab9262f-3521-4191-81f5-0ed184a5aa89",
+      "reimplements": "920cd6e3-18f4-4143-b6b8-74270bb8f8a3",
       "description": "disallow empty second strand",
       "comments": ["Normalises error messages"],
-      "reimplements": "920cd6e3-18f4-4143-b6b8-74270bb8f8a3",
       "property": "distance",
       "input": {
         "strand1": "G",

--- a/exercises/high-scores/canonical-data.json
+++ b/exercises/high-scores/canonical-data.json
@@ -87,42 +87,42 @@
         {
           "uuid": "2df075f9-fec9-4756-8f40-98c52a11504f",
           "description": "Latest score after personal top scores",
+          "scenarios": ["immutable"],
           "property": "latestAfterTopThree",
           "input": {
             "scores": [70, 50, 20, 30]
           },
-          "expected": 30,
-          "scenarios": ["immutable"]
+          "expected": 30
         },
         {
           "uuid": "809c4058-7eb1-4206-b01e-79238b9b71bc",
           "description": "Scores after personal top scores",
+          "scenarios": ["immutable"],
           "property": "scoresAfterTopThree",
           "input": {
             "scores": [30, 50, 20, 70]
           },
-          "expected": [30, 50, 20, 70],
-          "scenarios": ["immutable"]
+          "expected": [30, 50, 20, 70]
         },
         {
           "uuid": "ddb0efc0-9a86-4f82-bc30-21ae0bdc6418",
           "description": "Latest score after personal best",
+          "scenarios": ["immutable"],
           "property": "latestAfterBest",
           "input": {
             "scores": [20, 70, 15, 25, 30]
           },
-          "expected": 30,
-          "scenarios": ["immutable"]
+          "expected": 30
         },
         {
           "uuid": "6a0fd2d1-4cc4-46b9-a5bb-2fb667ca2364",
           "description": "Scores after personal best",
+          "scenarios": ["immutable"],
           "property": "scoresAfterBest",
           "input": {
             "scores": [20, 70, 15, 25, 30]
           },
-          "expected": [20, 70, 15, 25, 30],
-          "scenarios": ["immutable"]
+          "expected": [20, 70, 15, 25, 30]
         }
       ]
     }

--- a/exercises/largest-series-product/canonical-data.json
+++ b/exercises/largest-series-product/canonical-data.json
@@ -114,6 +114,8 @@
       }
     },
     {
+      "uuid": "06bc8b90-0c51-4c54-ac22-3ec3893a079e",
+      "description": "reports 1 for empty string and empty product (0 span)",
       "comments": [
         "There may be some confusion about whether this should be 1 or error.",
         "The reasoning for it being 1 is this:",
@@ -128,8 +130,6 @@
         "So LSP('123', 4) really DOES take the max of an empty list.",
         "So LSP('123', 4) errors and LSP('', 0) does NOT."
       ],
-      "uuid": "06bc8b90-0c51-4c54-ac22-3ec3893a079e",
-      "description": "reports 1 for empty string and empty product (0 span)",
       "property": "largestProduct",
       "input": {
         "digits": "",
@@ -138,12 +138,12 @@
       "expected": 1
     },
     {
+      "uuid": "3ec0d92e-f2e2-4090-a380-70afee02f4c0",
+      "description": "reports 1 for nonempty string and empty product (0 span)",
       "comments": [
         "As above, there is one 0-character string in '123'.",
         "So again no error. It's the empty product, 1."
       ],
-      "uuid": "3ec0d92e-f2e2-4090-a380-70afee02f4c0",
-      "description": "reports 1 for nonempty string and empty product (0 span)",
       "property": "largestProduct",
       "input": {
         "digits": "123",
@@ -189,8 +189,8 @@
     },
     {
       "uuid": "c859f34a-9bfe-4897-9c2f-6d7f8598e7f0",
-      "description": "rejects negative span",
       "reimplements": "5fe3c0e5-a945-49f2-b584-f0814b4dd1ef",
+      "description": "rejects negative span",
       "comments": ["Previous error message was incorrect"],
       "property": "largestProduct",
       "input": {

--- a/exercises/list-ops/canonical-data.json
+++ b/exercises/list-ops/canonical-data.json
@@ -204,11 +204,11 @@
         {
           "uuid": "36549237-f765-4a4c-bfd9-5d3a8f7b07d2",
           "reimplements": "613b20b7-1873-4070-a3a6-70ae5f50d7cc",
+          "description": "empty list",
           "comments": [
             "Reimplemented to remove ambiguity about the parameters of the    ",
             "function input."
           ],
-          "description": "empty list",
           "property": "foldl",
           "input": {
             "list": [],
@@ -220,11 +220,11 @@
         {
           "uuid": "7a626a3c-03ec-42bc-9840-53f280e13067",
           "reimplements": "e56df3eb-9405-416a-b13a-aabb4c3b5194",
+          "description": "direction independent function applied to non-empty list",
           "comments": [
             "Reimplemented to remove ambiguity about the parameters of the    ",
             "function input."
           ],
-          "description": "direction independent function applied to non-empty list",
           "property": "foldl",
           "input": {
             "list": [1, 2, 3, 4],
@@ -236,6 +236,7 @@
         {
           "uuid": "d7fcad99-e88e-40e1-a539-4c519681f390",
           "reimplements": "d2cf5644-aee1-4dfc-9b88-06896676fe27",
+          "description": "direction dependent function applied to non-empty list",
           "comments": [
             "Reimplemented to remove ambiguity about the parameters of the    ",
             "function input. Expects / to preserve fractions. Integer division",
@@ -243,7 +244,6 @@
             "original test values (d2cf5644-aee1-4dfc-9b88-06896676fe27) if   ",
             "integer division is expected / required.                         "
           ],
-          "description": "direction dependent function applied to non-empty list",
           "property": "foldl",
           "input": {
             "list": [1, 2, 3, 4],
@@ -302,11 +302,11 @@
         {
           "uuid": "17214edb-20ba-42fc-bda8-000a5ab525b0",
           "reimplements": "aeb576b9-118e-4a57-a451-db49fac20fdc",
+          "description": "empty list",
           "comments": [
             "Reimplemented to remove ambiguity about the parameters of the    ",
             "function input."
           ],
-          "description": "empty list",
           "property": "foldr",
           "input": {
             "list": [],
@@ -318,11 +318,11 @@
         {
           "uuid": "e1c64db7-9253-4a3d-a7c4-5273b9e2a1bd",
           "reimplements": "c4b64e58-313e-4c47-9c68-7764964efb8e",
+          "description": "direction independent function applied to non-empty list",
           "comments": [
             "Reimplemented to remove ambiguity about the parameters of the    ",
             "function input."
           ],
-          "description": "direction independent function applied to non-empty list",
           "property": "foldr",
           "input": {
             "list": [1, 2, 3, 4],
@@ -334,6 +334,7 @@
         {
           "uuid": "8066003b-f2ff-437e-9103-66e6df474844",
           "reimplements": "be396a53-c074-4db3-8dd6-f7ed003cce7c",
+          "description": "direction dependent function applied to non-empty list",
           "comments": [
             "Reimplemented to remove ambiguity about the parameters of the    ",
             "function input. Expects / to preserve fractions. Integer division",
@@ -341,7 +342,6 @@
             "the original test values (be396a53-c074-4db3-8dd6-f7ed003cce7c)  ",
             "if integer division is expected / required."
           ],
-          "description": "direction dependent function applied to non-empty list",
           "property": "foldr",
           "input": {
             "list": [1, 2, 3, 4],

--- a/exercises/luhn/canonical-data.json
+++ b/exercises/luhn/canonical-data.json
@@ -167,12 +167,12 @@
       "expected": true
     },
     {
+      "uuid": "39a06a5a-5bad-4e0f-b215-b042d46209b1",
+      "description": "using ascii value for non-doubled non-digit isn't allowed",
       "comments": [
         "Convert non-digits to their ascii values and then offset them by 48 sometimes accidentally declare an invalid string to be valid.",
         "This test is designed to avoid that solution."
       ],
-      "uuid": "39a06a5a-5bad-4e0f-b215-b042d46209b1",
-      "description": "using ascii value for non-doubled non-digit isn't allowed",
       "property": "valid",
       "input": {
         "value": "055b 444 285"
@@ -180,12 +180,12 @@
       "expected": false
     },
     {
+      "uuid": "f94cf191-a62f-4868-bc72-7253114aa157",
+      "description": "using ascii value for doubled non-digit isn't allowed",
       "comments": [
         "Convert non-digits to their ascii values and then offset them by 48 sometimes accidentally declare an invalid string to be valid.",
         "This test is designed to avoid that solution."
       ],
-      "uuid": "f94cf191-a62f-4868-bc72-7253114aa157",
-      "description": "using ascii value for doubled non-digit isn't allowed",
       "property": "valid",
       "input": {
         "value": ":9"

--- a/exercises/phone-number/canonical-data.json
+++ b/exercises/phone-number/canonical-data.json
@@ -98,10 +98,10 @@
     {
       "uuid": "eb8a1fc0-64e5-46d3-b0c6-33184208e28a",
       "reimplements": "63f38f37-53f6-4a5f-bd86-e9b404f10a60",
+      "description": "invalid with letters",
       "comments": [
         "make input invalid only due to letters; area code may not start with 1"
       ],
-      "description": "invalid with letters",
       "property": "clean",
       "input": {
         "phrase": "523-abc-7890"
@@ -124,10 +124,10 @@
     {
       "uuid": "065f6363-8394-4759-b080-e6c8c351dd1f",
       "reimplements": "4bd97d90-52fd-45d3-b0db-06ab95b1244e",
+      "description": "invalid with punctuations",
       "comments": [
         "make input invalid only due to punctuation; area code may not start with 1"
       ],
-      "description": "invalid with punctuations",
       "property": "clean",
       "input": {
         "phrase": "523-@:!-7890"

--- a/exercises/saddle-points/canonical-data.json
+++ b/exercises/saddle-points/canonical-data.json
@@ -129,6 +129,11 @@
     {
       "uuid": "5b9499ca-fcea-4195-830a-9c4584a0ee79",
       "description": "Can identify saddle points in a non square matrix",
+      "comments": [
+        "If your tests depend on the order of the saddle points,",
+        "note that this case breaks the sorting convention used in other cases (row ascending, column ascencding),",
+        "so you might want to swap the two points in the expected output."
+      ],
       "property": "saddlePoints",
       "input": {
         "matrix": [
@@ -145,11 +150,6 @@
           "row": 1,
           "column": 1
         }
-      ],
-      "comments": [
-        "If your tests depend on the order of the saddle points,",
-        "note that this case breaks the sorting convention used in other cases (row ascending, column ascencding),",
-        "so you might want to swap the two points in the expected output."
       ]
     },
     {

--- a/exercises/scale-generator/canonical-data.json
+++ b/exercises/scale-generator/canonical-data.json
@@ -147,12 +147,12 @@
           "expected": ["G", "Ab", "Bb", "C", "Db", "Eb", "F", "G"]
         },
         {
+          "uuid": "87fdbcca-d3dd-46d5-9c56-ec79e25b19f4",
+          "reimplements": "70517400-12b7-4530-b861-fa940ae69ee8",
+          "description": "Harmonic minor",          
           "comments": [
             "Note that this case introduces the augmented second interval (A)"
           ],
-          "uuid": "87fdbcca-d3dd-46d5-9c56-ec79e25b19f4",
-          "reimplements": "70517400-12b7-4530-b861-fa940ae69ee8",
-          "description": "Harmonic minor",
           "property": "interval",
           "input": {
             "tonic": "d",
@@ -306,11 +306,11 @@
           "expected": ["G", "Ab", "Bb", "C", "Db", "Eb", "F"]
         },
         {
+          "uuid": "70517400-12b7-4530-b861-fa940ae69ee8",
+          "description": "Harmonic minor",
           "comments": [
             "Note that this case introduces the accidental interval (A)"
           ],
-          "uuid": "70517400-12b7-4530-b861-fa940ae69ee8",
-          "description": "Harmonic minor",
           "property": "interval",
           "input": {
             "tonic": "d",

--- a/exercises/triangle/canonical-data.json
+++ b/exercises/triangle/canonical-data.json
@@ -57,12 +57,12 @@
           "expected": false
         },
         {
+          "uuid": "3022f537-b8e5-4cc1-8f12-fd775827a00c",
+          "description": "sides may be floats",
           "comments": [
             " Your track may choose to skip this test    ",
             " and deal only with integers if appropriate "
           ],
-          "uuid": "3022f537-b8e5-4cc1-8f12-fd775827a00c",
-          "description": "sides may be floats",
           "property": "equilateral",
           "input": {
             "sides": [0.5, 0.5, 0.5]
@@ -148,12 +148,12 @@
         },
         {
           "uuid": "adb4ee20-532f-43dc-8d31-e9271b7ef2bc",
+          "description": "sides may be floats",
           "comments": [
             " Your track may choose to skip this test    ",
             " and deal only with integers if appropriate "
           ],
           "property": "isosceles",
-          "description": "sides may be floats",
           "input": {
             "sides": [0.5, 0.4, 0.5]
           },
@@ -201,12 +201,12 @@
           "expected": false
         },
         {
+          "uuid": "26d9d59d-f8f1-40d3-ad58-ae4d54123d7d",
+          "description": "sides may be floats",
           "comments": [
             " Your track may choose to skip this test    ",
             " and deal only with integers if appropriate "
           ],
-          "uuid": "26d9d59d-f8f1-40d3-ad58-ae4d54123d7d",
-          "description": "sides may be floats",
           "property": "scalene",
           "input": {
             "sides": [0.5, 0.4, 0.6]


### PR DESCRIPTION
This PR makes the order of the keys in the `canonical-data.json` files consistent and adds a CI check to verify its order.
This is just a minor improvement, so if people are not convinced this is useful, I'm happy to not go through with this.

See https://github.com/ErikSchierboom/problem-specifications/runs/5158116886?check_suite_focus=true for an example of the output.

Closes https://github.com/exercism/problem-specifications/issues/1705