### PR TITLE
bank-account: remove additional notes

### DIFF
--- a/exercises/bank-account/description.md
+++ b/exercises/bank-account/description.md
@@ -12,16 +12,3 @@ Create an account that can be accessed from multiple threads/processes
 
 It should be possible to close an account; operations against a closed
 account must fail.
-
-## Instructions
-
-Run the test file, and fix each of the errors in turn. When you get the
-first test to pass, go to the first pending or skipped test, and make
-that pass as well. When all of the tests are passing, feel free to
-submit.
-
-Remember that passing code is just the first step. The goal is to work
-towards a solution that is as readable and expressive as you can make
-it.
-
-Have fun!


### PR DESCRIPTION
These additional notes are, while useful in general, not something we should be adding to a single exercise. For that a track can used its shared files.