### PR TITLE
auto-format portions of some JSON files

### DIFF
--- a/exercises/go-counting/canonical-data.json
+++ b/exercises/go-counting/canonical-data.json
@@ -1,8 +1,6 @@
 {
   "exercise": "go-counting",
-  "comments": [
-    "Territory consists of [x, y] coordinate pairs."
-  ],
+  "comments": ["Territory consists of [x, y] coordinate pairs."],
   "cases": [
     {
       "uuid": "94d0c01a-17d0-424c-aab5-2736d0da3939",
@@ -21,7 +19,11 @@
       },
       "expected": {
         "owner": "BLACK",
-        "territory": [[0, 0], [0, 1], [1, 0]]
+        "territory": [
+          [0, 0],
+          [0, 1],
+          [1, 0]
+        ]
       }
     },
     {
@@ -61,7 +63,11 @@
       },
       "expected": {
         "owner": "NONE",
-        "territory": [[0, 3], [0, 4], [1, 4]]
+        "territory": [
+          [0, 3],
+          [0, 4],
+          [1, 4]
+        ]
       }
     },
     {
@@ -186,8 +192,14 @@
         ]
       },
       "expected": {
-        "territoryBlack": [[0, 0], [0, 1]],
-        "territoryWhite": [[3, 0], [3, 1]],
+        "territoryBlack": [
+          [0, 0],
+          [0, 1]
+        ],
+        "territoryWhite": [
+          [3, 0],
+          [3, 1]
+        ],
         "territoryNone": []
       }
     },
@@ -201,7 +213,10 @@
         ]
       },
       "expected": {
-        "territoryBlack": [[0, 0], [2, 0]],
+        "territoryBlack": [
+          [0, 0],
+          [2, 0]
+        ],
         "territoryWhite": [],
         "territoryNone": []
       }

--- a/exercises/ocr-numbers/canonical-data.json
+++ b/exercises/ocr-numbers/canonical-data.json
@@ -54,7 +54,7 @@
           "   "
         ]
       },
-      "expected": {"error": "Number of input lines is not a multiple of four"}
+      "expected": { "error": "Number of input lines is not a multiple of four" }
     },
     {
       "uuid": "235f7bd1-991b-4587-98d4-84206eec4cc6",
@@ -68,7 +68,9 @@
           "    "
         ]
       },
-      "expected": {"error": "Number of input columns is not a multiple of three"}
+      "expected": {
+        "error": "Number of input columns is not a multiple of three"
+      }
     },
     {
       "uuid": "4a841794-73c9-4da9-a779-1f9837faff66",

--- a/exercises/saddle-points/canonical-data.json
+++ b/exercises/saddle-points/canonical-data.json
@@ -10,9 +10,7 @@
     {
       "uuid": "3e374e63-a2e0-4530-a39a-d53c560382bd",
       "description": "Can identify single saddle point",
-      "comments": [
-        "This is the README example."
-      ],
+      "comments": ["This is the README example."],
       "property": "saddlePoints",
       "input": {
         "matrix": [

--- a/exercises/scale-generator/canonical-data.json
+++ b/exercises/scale-generator/canonical-data.json
@@ -149,7 +149,7 @@
         {
           "uuid": "87fdbcca-d3dd-46d5-9c56-ec79e25b19f4",
           "reimplements": "70517400-12b7-4530-b861-fa940ae69ee8",
-          "description": "Harmonic minor",          
+          "description": "Harmonic minor",
           "comments": [
             "Note that this case introduces the augmented second interval (A)"
           ],


### PR DESCRIPTION
this commit was made by having prettier format these files and
committing portions of the changes.

For now we want prettier to continue to ignore these files, but
eventually the plan would be to use prettier but to reformat specific
portions.

The portions in this commit are *not* the portions we would want to
reformat, so for these specific portions we are satisfied to accept
prettier's changes.