### PR TITLE
Exercise allergies test case

### DIFF
--- a/exercises/allergies/canonical-data.json
+++ b/exercises/allergies/canonical-data.json
@@ -566,6 +566,17 @@
             "pollen",
             "cats"
           ]
+        },
+        {
+          "uuid": "93c2df3e-4f55-4fed-8116-7513092819cd",
+          "description": "no allergen score parts without highest valid score",
+          "property": "list",
+          "input": {
+            "score": 257
+          },
+          "expected": [
+            "eggs"
+          ]
         }
       ]
     }


### PR DESCRIPTION
Added test case. As mentioned in instructions(https://github.com/karstenj/problem-specifications/blob/main/exercises/allergies/description.md) the program shall only report the eggs (1) allergy for a given score of 257. This case is currently not fully covered by the existing test cases.