### PR TITLE
allergies: format

### DIFF
--- a/exercises/allergies/canonical-data.json
+++ b/exercises/allergies/canonical-data.json
@@ -560,9 +560,7 @@
           "input": {
             "score": 257
           },
-          "expected": [
-            "eggs"
-          ]
+          "expected": ["eggs"]
         }
       ]
     }


### PR DESCRIPTION
race condition between
"Exercise allergies test case"
https://github.com/exercism/problem-specifications/pull/1969
and
"allow prettier to format more files"
https://github.com/exercism/problem-specifications/pull/1966

Since this file is now being formatted by prettier, the test case added
in the latter PR must be formatted according to prettier.

Otherwise, as will be observable from any PR after
https://github.com/exercism/problem-specifications/pull/1966, CI fails
on main.

There are alternate approaches, such as directing format-array to always
format `expected` with one item on each line, but it doesn't seem like
this is particular important for the `allergies` exercise.