### PR TITLE
updated the ISBN description for additonal clarity

### DIFF
--- a/exercises/isbn-verifier/description.md
+++ b/exercises/isbn-verifier/description.md
@@ -5,11 +5,11 @@ numbers. These normally contain dashes and look like: `3-598-21508-8`
 
 ## ISBN
 
-The ISBN-10 format is 9 digits (0 to 9) plus one check character (either a digit or an X only). In the case the check character is an X, this represents the value '10'. These may be communicated with or without hyphens, and can be checked for their validity by the following formula:
+The ISBN-10 format is 9 digits (0 to 9, represented below with a subscript) plus one check character (either a digit or an X only). In the case the check character is an X, this represents the value '10'. These may be communicated with or without hyphens, and can be checked for their validity by the following formula:
 
-```text
-(x1 * 10 + x2 * 9 + x3 * 8 + x4 * 7 + x5 * 6 + x6 * 5 + x7 * 4 + x8 * 3 + x9 * 2 + x10 * 1) mod 11 == 0
-```
+
+> (1₁ * 10 + 2₂ * 9 + 3₃ * 8 + 4₄ * 7 + 5₅ * 6 + 6₆ * 5 + 7₇ * 4 + 8₈ * 3 + 9₉ * 2 + 10₁₀ * 1) mod 11 == 0
+
 
 If the result is 0, then it is a valid ISBN-10, otherwise it is invalid.
 
@@ -17,9 +17,9 @@ If the result is 0, then it is a valid ISBN-10, otherwise it is invalid.
 
 Let's take the ISBN-10 `3-598-21508-8`. We plug it in to the formula, and get:
 
-```text
-(3 * 10 + 5 * 9 + 9 * 8 + 8 * 7 + 2 * 6 + 1 * 5 + 5 * 4 + 0 * 3 + 8 * 2 + 8 * 1) mod 11 == 0
-```
+
+> (3 * 10 + 5 * 9 + 9 * 8 + 8 * 7 + 2 * 6 + 1 * 5 + 5 * 4 + 0 * 3 + 8 * 2 + 8 * 1) mod 11 == 0
+
 
 Since the result is 0, this proves that our ISBN is valid.
 

--- a/exercises/isbn-verifier/description.md
+++ b/exercises/isbn-verifier/description.md
@@ -10,6 +10,7 @@ The ISBN-10 format is 9 digits (0 to 9) plus one check character (either a digit
 ```text
 (d₁ * 10 + d₂ * 9 + d₃ * 8 + d₄ * 7 + d₅ * 6 + d₆ * 5 + d₇ * 4 + d₈ * 3 + d₉ * 2 + d₁₀ * 1) mod 11 == 0
 ```
+
 If the result is 0, then it is a valid ISBN-10, otherwise it is invalid.
 
 ## Example
@@ -19,6 +20,7 @@ Let's take the ISBN-10 `3-598-21508-8`. We plug it in to the formula, and get:
 ```text
 (3 * 10 + 5 * 9 + 9 * 8 + 8 * 7 + 2 * 6 + 1 * 5 + 5 * 4 + 0 * 3 + 8 * 2 + 8 * 1) mod 11 == 0
 ```
+
 Since the result is 0, this proves that our ISBN is valid.
 
 ## Task

--- a/exercises/isbn-verifier/description.md
+++ b/exercises/isbn-verifier/description.md
@@ -5,11 +5,9 @@ numbers. These normally contain dashes and look like: `3-598-21508-8`
 
 ## ISBN
 
-The ISBN-10 format is 9 digits (0 to 9, represented below with a subscript) plus one check character (either a digit or an X only). In the case the check character is an X, this represents the value '10'. These may be communicated with or without hyphens, and can be checked for their validity by the following formula:
+The ISBN-10 format is 9 digits (0 to 9) plus one check character (either a digit or an X only). In the case the check character is an X, this represents the value '10'. These may be communicated with or without hyphens, and can be checked for their validity by the following formula:
 
-
-> (1₁ * 10 + 2₂ * 9 + 3₃ * 8 + 4₄ * 7 + 5₅ * 6 + 6₆ * 5 + 7₇ * 4 + 8₈ * 3 + 9₉ * 2 + 10₁₀ * 1) mod 11 == 0
-
+> (d₁ \* 10 + d₂ \* 9 + d₃ \* 8 + d₄ \* 7 + d₅ \* 6 + d₆ \* 5 + d₇ \* 4 + d₈ \* 3 + d₉ \* 2 + d₁₀ \* 1) mod 11 == 0
 
 If the result is 0, then it is a valid ISBN-10, otherwise it is invalid.
 
@@ -17,9 +15,7 @@ If the result is 0, then it is a valid ISBN-10, otherwise it is invalid.
 
 Let's take the ISBN-10 `3-598-21508-8`. We plug it in to the formula, and get:
 
-
-> (3 * 10 + 5 * 9 + 9 * 8 + 8 * 7 + 2 * 6 + 1 * 5 + 5 * 4 + 0 * 3 + 8 * 2 + 8 * 1) mod 11 == 0
-
+> (3 \* 10 + 5 \* 9 + 9 \* 8 + 8 \* 7 + 2 \* 6 + 1 \* 5 + 5 \* 4 + 0 \* 3 + 8 \* 2 + 8 \* 1) mod 11 == 0
 
 Since the result is 0, this proves that our ISBN is valid.
 

--- a/exercises/isbn-verifier/description.md
+++ b/exercises/isbn-verifier/description.md
@@ -7,7 +7,8 @@ numbers. These normally contain dashes and look like: `3-598-21508-8`
 
 The ISBN-10 format is 9 digits (0 to 9) plus one check character (either a digit or an X only). In the case the check character is an X, this represents the value '10'. These may be communicated with or without hyphens, and can be checked for their validity by the following formula:
 
-> (d₁ \* 10 + d₂ \* 9 + d₃ \* 8 + d₄ \* 7 + d₅ \* 6 + d₆ \* 5 + d₇ \* 4 + d₈ \* 3 + d₉ \* 2 + d₁₀ \* 1) mod 11 == 0
+```text
+(d₁ * 10 + d₂ * 9 + d₃ * 8 + d₄ * 7 + d₅ * 6 + d₆ * 5 + d₇ * 4 + d₈ * 3 + d₉ * 2 + d₁₀ * 1) mod 11 == 0
 
 If the result is 0, then it is a valid ISBN-10, otherwise it is invalid.
 

--- a/exercises/isbn-verifier/description.md
+++ b/exercises/isbn-verifier/description.md
@@ -16,7 +16,8 @@ If the result is 0, then it is a valid ISBN-10, otherwise it is invalid.
 
 Let's take the ISBN-10 `3-598-21508-8`. We plug it in to the formula, and get:
 
-> (3 \* 10 + 5 \* 9 + 9 \* 8 + 8 \* 7 + 2 \* 6 + 1 \* 5 + 5 \* 4 + 0 \* 3 + 8 \* 2 + 8 \* 1) mod 11 == 0
+```text
+(3 * 10 + 5 * 9 + 9 * 8 + 8 * 7 + 2 * 6 + 1 * 5 + 5 * 4 + 0 * 3 + 8 * 2 + 8 * 1) mod 11 == 0
 
 Since the result is 0, this proves that our ISBN is valid.
 

--- a/exercises/isbn-verifier/description.md
+++ b/exercises/isbn-verifier/description.md
@@ -9,7 +9,7 @@ The ISBN-10 format is 9 digits (0 to 9) plus one check character (either a digit
 
 ```text
 (d₁ * 10 + d₂ * 9 + d₃ * 8 + d₄ * 7 + d₅ * 6 + d₆ * 5 + d₇ * 4 + d₈ * 3 + d₉ * 2 + d₁₀ * 1) mod 11 == 0
-
+```
 If the result is 0, then it is a valid ISBN-10, otherwise it is invalid.
 
 ## Example
@@ -18,7 +18,7 @@ Let's take the ISBN-10 `3-598-21508-8`. We plug it in to the formula, and get:
 
 ```text
 (3 * 10 + 5 * 9 + 9 * 8 + 8 * 7 + 2 * 6 + 1 * 5 + 5 * 4 + 0 * 3 + 8 * 2 + 8 * 1) mod 11 == 0
-
+```
 Since the result is 0, this proves that our ISBN is valid.
 
 ## Task


### PR DESCRIPTION
This PR is based on the discussion of [this issue.](https://github.com/exercism/problem-specifications/issues/1975)

When using the default code blocks with the text language, the subscript characters are removed. I switched them to block quotes to preserve the subscripts and everything looks good because it is only text anyways. Let me know if this violates a standard somewhere