### PR TITLE
Add reimplement of "with apostrophes" test

### DIFF
--- a/exercises/word-count/canonical-data.json
+++ b/exercises/word-count/canonical-data.json
@@ -126,6 +126,26 @@
       }
     },
     {
+      "uuid": "4ff6c7d7-fcfc-43ef-b8e7-34ff1837a2d3",
+      "description": "with apostrophes",
+      "comments": ["Added a word with multiple letters after apostrophe"],
+      "reimplements": "4185a902-bdb0-4074-864c-f416e42a0f19",
+      "property": "countWords",
+      "input": {
+        "sentence": "'First: don't laugh. Then: don't cry. You're getting it.'"
+      },
+      "expected": {
+        "first": 1,
+        "don't": 2,
+        "laugh": 1,
+        "then": 1,
+        "cry": 1,
+        "you're": 1,
+        "getting": 1,
+        "it": 1
+      }
+    },
+    {
       "uuid": "be72af2b-8afe-4337-b151-b297202e4a7b",
       "description": "with quotations",
       "property": "countWords",

--- a/exercises/word-count/canonical-data.json
+++ b/exercises/word-count/canonical-data.json
@@ -127,9 +127,9 @@
     },
     {
       "uuid": "4ff6c7d7-fcfc-43ef-b8e7-34ff1837a2d3",
+      "reimplements": "4185a902-bdb0-4074-864c-f416e42a0f19",
       "description": "with apostrophes",
       "comments": ["Added a word with multiple letters after apostrophe"],
-      "reimplements": "4185a902-bdb0-4074-864c-f416e42a0f19",
       "property": "countWords",
       "input": {
         "sentence": "'First: don't laugh. Then: don't cry. You're getting it.'"


### PR DESCRIPTION
As per [issue 1977](https://github.com/exercism/problem-specifications/issues/1977), if the user's code was unable to correctly handle words with multiple letters after an apostrophe, e.g. "they've" (a plausible error one might make with a regex, for example), the previous version of the "with apostrophes" test, which only included the word "don't", would not detect the bug (and none of the other tests would detect it, either).

This change is a reimplement of the "with apostrophes" test to now include the word "you're" as part of the input, so if the user's code has a bug and incorrectly handles such words, the new version of the test will fail appropriately, and expose it.