### PR TITLE
pangram: remove overly specific description

### DIFF
--- a/exercises/pangram/description.md
+++ b/exercises/pangram/description.md
@@ -5,5 +5,5 @@ Determine if a sentence is a pangram. A pangram (Greek: παν γράμμα, pan
 The best known English pangram is:
 > The quick brown fox jumps over the lazy dog.
 
-The alphabet used consists of ASCII letters `a` to `z`, inclusive, and is case
-insensitive. Input will not contain non-ASCII symbols.
+The alphabet used consists of letters `a` to `z`, inclusive, and is case
+insensitive.


### PR DESCRIPTION
This makes it easier for tracks to add additional test cases that aren't ascii without having to deal with manually syncing the instructions.

I think this is in line with the vast majority of exercises where the inputs aren't described in too much detail.