### PR TITLE
Add test to Yacht to ensure fives are handled

### DIFF
--- a/exercises/yacht/canonical-data.json
+++ b/exercises/yacht/canonical-data.json
@@ -103,6 +103,16 @@
       "expected": 0
     },
     {
+      "uuid": "d054227f-3a71-4565-a684-5c7e621ec1e9",
+      "description": "Fives",
+      "property": "score",
+      "input": {
+        "dice": [1, 5, 3, 5, 3],
+        "category": "fives"
+      },
+      "expected": 10
+    },
+    {
       "uuid": "e8a036e0-9d21-443a-8b5f-e15a9e19a761",
       "description": "Sixes",
       "property": "score",


### PR DESCRIPTION
The current tests for "fives" only include a negative test where the score is 0. This PR adds a test for fives that has a score.