### PR TITLE
isbn-verifier - add  isValid test

### DIFF
--- a/exercises/isbn-verifier/canonical-data.json
+++ b/exercises/isbn-verifier/canonical-data.json
@@ -42,6 +42,15 @@
       "expected": false
     },
     {
+      "uuid": "9416f4a5-fe01-4b61-a07b-eb75892ef562",
+      "description": "invalid check digit in isbn is not treated as zero",
+      "property": "isValid",
+      "input": {
+        "isbn": "4-598-21507-B"
+      },
+      "expected": false
+    },
+    {
       "uuid": "c19ba0c4-014f-4dc3-a63f-ff9aefc9b5ec",
       "description": "invalid character in isbn is not treated as zero",
       "property": "isValid",


### PR DESCRIPTION
Adds an `isValid` test that catches incorrect programs which treat an invalid last character as zero.

Note that there is an existing test addressing invalid last characters, but that test does not catch programs which treat such characters as zero. This is because the resulting checksum will not be divisible by 11 and hence those programs will return `false` which is the expected value.  In the new test case, the resulting checksum would be divisible by 11, hence such programs will return `true` and thus fail this test.   
