### PR TITLE
Add new test case for Poker

### DIFF
--- a/exercises/poker/canonical-data.json
+++ b/exercises/poker/canonical-data.json
@@ -97,6 +97,15 @@
       "expected": ["JD QH JS 8D QC"]
     },
     {
+      "uuid": "f761e21b-2560-4774-a02a-b3e9366a51ce",
+      "description": "both hands have two pairs that add to the same value, win goes to highest first pair",
+      "property": "bestHands",
+      "input": {
+        "hands": ["6S 6H 3S 3H AS", "7H 7S 2H 2S AC"]
+      },
+      "expected": ["7H 7S 2H 2S AC"]
+    },
+    {
       "uuid": "21e9f1e6-2d72-49a1-a930-228e5e0195dc",
       "description": "three of a kind beats two pair",
       "property": "bestHands",

--- a/exercises/poker/canonical-data.json
+++ b/exercises/poker/canonical-data.json
@@ -98,12 +98,21 @@
     },
     {
       "uuid": "f761e21b-2560-4774-a02a-b3e9366a51ce",
-      "description": "both hands have two pairs that add to the same value, win goes to highest first pair",
+      "description": "both hands have two pairs that add to the same value, win goes to highest pair",
       "property": "bestHands",
       "input": {
         "hands": ["6S 6H 3S 3H AS", "7H 7S 2H 2S AC"]
       },
       "expected": ["7H 7S 2H 2S AC"]
+    },
+    {
+      "uuid": "fc6277ac-94ac-4078-8d39-9d441bc7a79e",
+      "description": "two pairs first ranked by largest pair",
+      "property": "bestHands",
+      "input": {
+        "hands": ["5C 2S 5S 4H 4C", "6S 2S 6H 7C 2C"]
+      },
+      "expected": ["6S 2S 6H 7C 2C"]
     },
     {
       "uuid": "21e9f1e6-2d72-49a1-a930-228e5e0195dc",


### PR DESCRIPTION
Ensures ranking based on adding pair values with equal
weight does not erroneously rank different two-pair
hands as equivalent.

Found an exemplar implementation that ranks two pair hands by summing the two face values. This test case will mean an update to the exemplar is needed in order to be correct.

