### PR TITLE
Add Dependabot ecosystem labels

### DIFF
--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -86,3 +86,11 @@
 - name: "won't fix"
   description: ""
   color: "d88b34"
+
+- name: "javascript"
+  description: "Label used by Dependabot to indicate the ecosystem its PR affects."
+  color: "f8dc3d"
+
+- name: "github_actions"
+  description: "Label used by Dependabot to indicate the ecosystem its PR affects."
+  color: "#2289fe"

--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -93,4 +93,4 @@
 
 - name: "github_actions"
   description: "Label used by Dependabot to indicate the ecosystem its PR affects."
-  color: "#2289fe"
+  color: "2289fe"


### PR DESCRIPTION
Dependabot labels its PRs with the ecosystem, which is quite useful to see at a glance which workflows are affected by a PR.

Currently, the label sync removes them after a while.

Examples:

- https://github.com/exercism/problem-specifications/pull/2008
- https://github.com/exercism/problem-specifications/pull/1995