### PR TITLE
`state-of-tic-tac-toe`: tweak error nessage and add test case

### DIFF
--- a/exercises/state-of-tic-tac-toe/canonical-data.json
+++ b/exercises/state-of-tic-tac-toe/canonical-data.json
@@ -362,7 +362,6 @@
           "expected": {
             "error": "Impossible board: game should have ended after the game was won"
           }
-        }
         },
         {
           "uuid": "4801cda2-f5b7-4c36-8317-3cdd167ac22c",

--- a/exercises/state-of-tic-tac-toe/canonical-data.json
+++ b/exercises/state-of-tic-tac-toe/canonical-data.json
@@ -360,7 +360,23 @@
             ]
           },
           "expected": {
-            "error": "Impossible board: game should have ended after X won"
+            "error": "Impossible board: game should have ended after the game was won"
+          }
+        }
+        },
+        {
+          "uuid": "4801cda2-f5b7-4c36-8317-3cdd167ac22c",
+          "description": "Invalid board",
+          "property": "gamestate",
+          "input": {
+            "board": [
+              "XXX",
+              "OOO",
+              "XOX"
+            ]
+          },
+          "expected": {
+            "error": "Impossible board: game should have ended after the game was won"
           }
         }
       ]

--- a/exercises/state-of-tic-tac-toe/canonical-data.json
+++ b/exercises/state-of-tic-tac-toe/canonical-data.json
@@ -360,6 +360,23 @@
             ]
           },
           "expected": {
+            "error": "Impossible board: game should have ended after X won"
+          }
+        },
+        {
+          "uuid": "6c1920f2-ab5c-4648-a0c9-997414dda5eb",
+          "reimplements": "6c1920f2-ab5c-4648-a0c9-997414dda5eb",
+          "description": "Invalid board",
+          "comments": ["Error message was changed to be more general"],
+          "property": "gamestate",
+          "input": {
+            "board": [
+              "XXX",
+              "OOO",
+              "   "
+            ]
+          },
+          "expected": {
             "error": "Impossible board: game should have ended after the game was won"
           }
         },

--- a/exercises/state-of-tic-tac-toe/canonical-data.json
+++ b/exercises/state-of-tic-tac-toe/canonical-data.json
@@ -366,7 +366,7 @@
         {
           "uuid": "6c1920f2-ab5c-4648-a0c9-997414dda5eb",
           "reimplements": "6c1920f2-ab5c-4648-a0c9-997414dda5eb",
-          "description": "Invalid board",
+          "description": "Invalid board: X won and O kept playing",
           "comments": ["Error message was changed to be more general"],
           "property": "gamestate",
           "input": {
@@ -382,7 +382,7 @@
         },
         {
           "uuid": "4801cda2-f5b7-4c36-8317-3cdd167ac22c",
-          "description": "Invalid board",
+          "description": "Invalid board: players kept playing after a win",
           "property": "gamestate",
           "input": {
             "board": [


### PR DESCRIPTION
In the last test, the board is
```
XXX
OOO
   
```
and it's clear that `X` won and `O` kept playing, but for this board:
```
XXX
OOO
XOX
```
it's impossible to determine who won "first". 

And really, it doesn't matter who won, what matters is that this is an impossible board because the players kept going after the game was won, so I'm proposing to tweak the error message to reflect that and add one more test case to justify the change.

Credits to @angelikatyborska for finding this incompleteness issue.