### PR TITLE
Word count: test with quotations for word with apostrophe

### DIFF
--- a/exercises/word-count/canonical-data.json
+++ b/exercises/word-count/canonical-data.json
@@ -203,6 +203,18 @@
         "two": 1,
         "three": 1
       }
+    },
+    {
+      "uuid": "6d00f1db-901c-4bec-9829-d20eb3044557",
+      "description": "quotation for word with apostrophe",
+      "property": "countWords",
+      "input": {
+        "sentence": "can, can't, 'can't'"
+      },
+      "expected": {
+        "can": 1,
+        "can't": 2
+      }
     }
   ]
 }


### PR DESCRIPTION
While solving the exercise I noticed that there is no test that contains quotations around a word with apostrophes, eg 'can't'.

Some naive implementations for quotation filtering might not be able to filter these quotations out correctly.

Let me know if I'm missing anything, happy to fix it :)