### PR TITLE
rectangles: Add test for missing sides

### DIFF
--- a/exercises/rectangles/canonical-data.json
+++ b/exercises/rectangles/canonical-data.json
@@ -174,6 +174,23 @@
         ]
       },
       "expected": 60
+    },
+    {
+      "uuid": "6ef24e0f-d191-46da-b929-4faca24b4cd2",
+      "description": "rectangles must have four sides",
+      "property": "rectangles",
+      "input": {
+        "strings": [
+          "+-+ +-+",
+          "| | | |",
+          "+-+-+-+",
+          "  | |  ",
+          "+-+-+-+",
+          "| | | |",
+          "+-+ +-+"
+        ]
+      },
+      "expected": 5
     }
   ]
 }


### PR DESCRIPTION
Some solutions to this exercise will look for the top corners of the rectangles, making sure they are connected by a horizontal line, then go on to walk down the left and right side to find corners at the same row, in which case a rectangle is detected. These solutions sometimes fail to check that the bottom two corners are connected by a horizontal line. This test case will catch that.