### PR TITLE
Add test case for `complex-number`: exponential resulting in a number with real and imaginary part

### DIFF
--- a/exercises/complex-numbers/canonical-data.json
+++ b/exercises/complex-numbers/canonical-data.json
@@ -361,6 +361,15 @@
             "z": ["ln(2)", "pi"]
           },
           "expected": [-2, 0]
+        },
+        {
+          "uuid": "d2de4375-7537-479a-aa0e-d474f4f09859",
+          "description": "Exponential resulting in a number with real and imaginary part",
+          "property": "exp",
+          "input": {
+            "z": ["ln(2)/2", "pi/4"]
+          },
+          "expected": [1, 1]
         }
       ]
     },


### PR DESCRIPTION
I have noticed solutions with the wrong scaling for the imaginary part of the exponential of a complex number (including in the example implementation of the Elixir track by yours truly) which went unnoticed because we only have tests with purely real results, so I would like to add this case.