### PR TITLE
[pythagorean-triplets] improved instruction clarity

### DIFF
--- a/exercises/pythagorean-triplet/description.md
+++ b/exercises/pythagorean-triplet/description.md
@@ -16,7 +16,7 @@ a < b < c
 For example,
 
 ```text
-3² + 4² = 9 + 16 = 25 = 5².
+3² + 4² = 5².
 ```
 
 Given an input integer N, find all Pythagorean triplets for which `a + b + c = N`.


### PR DESCRIPTION
prior instruction was not clear what it actually meant at first glace, the "+ 16 = 25 = " is extraneous information. It makes it feel like there is a missing piece beyond the actual meaning of 3^2 + 4^2 = 5^2