### PR TITLE
Add more tests to Satellite

### DIFF
--- a/exercises/satellite/canonical-data.json
+++ b/exercises/satellite/canonical-data.json
@@ -74,6 +74,41 @@
       "expected": {
         "error": "traversals must contain unique items"
       }
+    },
+    {
+      "uuid": "d232a4e5-622e-4aaa-965e-244ddcdcdb96",
+      "description": "Complex tree with many integer values",
+      "property": "treeFromTraversals",
+      "input": {
+        "preorder": ["2", "1", "3", "6", "5", "7"],
+        "inorder": ["1", "2", "3", "5", "6", "7"]
+      },
+      "expected": {
+          "v": "4", 
+          "l":  {"v": "2", 
+                  "l": {"v": "1", "l": {}, "r": {}},
+                  "r": {"v": "3", "l": {}, "r": {}}
+                },
+          "r":  {"v": "6",
+                  "l": {"v": "5", "l": {}, "r": {}},
+                  "r": {"v": "7", "l": {}, "r": {}}
+                }
+        }
+    },
+    {
+      "uuid": "156a2dd8-a2c7-4a07-b9fe-ab599956d067",
+      "description": "Simple tree with integer values",
+      "property": "treeFromTraversals",
+      "input": {
+        "preorder": ["2", "1"],
+        "inorder": ["1", "2"]
+      },
+      "expected":
+        {
+        "v": "2",
+        "l": "1",
+        "r": {}
+        }
     }
   ]
 }


### PR DESCRIPTION
As discussed on [#3114 on the Python Track](https://github.com/exercism/python/issues/3114#issuecomment-1155439623), the Sattelite exercise has very few tests, and the trees used in the example don't even seem to follow an understandable logic for comparison, thus making the exercise not as clear to the student. I've thus added a few tests based on the Binary Search Tree exercise. 