### PR TITLE
space-age: calculate using correct average calendar year

### DIFF
--- a/exercises/space-age/canonical-data.json
+++ b/exercises/space-age/canonical-data.json
@@ -19,7 +19,7 @@
         "planet": "Mercury",
         "seconds": 2134835688
       },
-      "expected": 280.88
+      "expected": 280.89
     },
     {
       "uuid": "502c6529-fd1b-41d3-8fab-65e03082b024",


### PR DESCRIPTION
The expected values are calculated incorrectly based on an average Julian calendar year (365.25 days). They should be computed based on an average Gregorian calendar year (365.2425 days). Fortunately, the only value affected is for Mercury.
https://en.wikipedia.org/wiki/Gregorian_calendar