### PR TITLE
pythagorean-triplet: testcase that triggers integer overflow

### DIFF
--- a/exercises/pythagorean-triplet/canonical-data.json
+++ b/exercises/pythagorean-triplet/canonical-data.json
@@ -81,6 +81,19 @@
         [6000, 11250, 12750],
         [7500, 10000, 12500]
       ]
+    },
+    {
+      "uuid": "270b8476-6f59-4621-bef7-70e6a3513923",
+      "description": "triplets to trigger integer overflow",
+      "property": "tripletsWithSum",
+      "input": {
+        "n": 65532
+      },
+      "expected": [
+        [1016, 32250, 32266],
+        [16383, 21844, 27305],
+        [17145, 21156, 27231]
+      ]
     }
   ]
 }


### PR DESCRIPTION
While reviewing a C submission for pythagorean triplet exercise, I noticed that larger numbers overflow `int` primitive if not explicitly forced to something like (uint32_t)

I feel this is a good test case to teach integer overflow right from the start.
This was some part of the discussion
```c
            if (a * a + b * b != c * c) {
```
which triggered
```
pythagorean_triplet.c:17:36: runtime error: signed integer overflow: 65529 * 65529 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior pythagorean_triplet.c:17:36 in
```