### PR TITLE
Exercise state-of-tic-tac-toe: set proper value for 'reimplements' key of reimplemented test case

### DIFF
--- a/exercises/state-of-tic-tac-toe/canonical-data.json
+++ b/exercises/state-of-tic-tac-toe/canonical-data.json
@@ -380,7 +380,7 @@
         },
         {
           "uuid": "6c1920f2-ab5c-4648-a0c9-997414dda5eb",
-          "reimplements": "6c1920f2-ab5c-4648-a0c9-997414dda5eb",
+          "reimplements": "b1dc8b13-46c4-47db-a96d-aa90eedc4e8d",
           "description": "Invalid board: X won and O kept playing",
           "comments": ["Error message was changed to be more general"],
           "property": "gamestate",


### PR DESCRIPTION
Fixes #2069.

Set the 'reimplements' key for the reimplemented test to the uuid of the previous version of the test.