### PR TITLE
matching brackets: reimplements wrong nested bracket tests

### DIFF
--- a/exercises/matching-brackets/canonical-data.json
+++ b/exercises/matching-brackets/canonical-data.json
@@ -120,8 +120,7 @@
     },
     {
       "uuid": "1d5c093f-fc84-41fb-8c2a-e052f9581602",
-      "reimplements": "a0205e34-c2ac-49e6-a88a-899508d7d68e",
-      "description": "paired and wrong nested brackets",
+      "description": "paired and wrong deep nested brackets",
       "comments": [
         "Ensures last opened bracket is not the only one being traced"
       ],

--- a/exercises/matching-brackets/canonical-data.json
+++ b/exercises/matching-brackets/canonical-data.json
@@ -119,6 +119,19 @@
       "expected": false
     },
     {
+      "uuid": "1d5c093f-fc84-41fb-8c2a-e052f9581602",
+      "reimplements": "a0205e34-c2ac-49e6-a88a-899508d7d68e",
+      "description": "paired and wrong nested brackets",
+      "comments": [
+        "Ensures last opened bracket is not the only one being traced"
+      ],
+      "property": "isPaired",
+      "input": {
+        "value": "[({}])"
+      },
+      "expected": false
+    },
+    {
       "uuid": "ef47c21b-bcfd-4998-844c-7ad5daad90a8",
       "description": "paired and incomplete brackets",
       "property": "isPaired",

--- a/exercises/matching-brackets/canonical-data.json
+++ b/exercises/matching-brackets/canonical-data.json
@@ -120,7 +120,7 @@
     },
     {
       "uuid": "1d5c093f-fc84-41fb-8c2a-e052f9581602",
-      "description": "paired and wrong deep nested brackets",
+      "description": "paired and wrong nested brackets but innermost are correct",
       "comments": [
         "Ensures last opened bracket is not the only one being traced"
       ],


### PR DESCRIPTION
Current input value for `paired and wrong nested brackets` (a0205e34-c2ac-49e6-a88a-899508d7d68e) allows for solutions where only the last opened bracket is being traced.

Current input value is `[({*]*})`.
Proposed input value is `[({}*]*)`.
<sub>"*" Used only to highlight the change.<sub>

By wrongly closing the second to last opened bracket (instead of the last one), we best cover wrongly nested brackets, because we ensure users realize they need to track all opened brackets.

I understand the most straighfoward and simple solution is to stack opened brackets and remove then when they're closed, but it's possible to green all tests by tracing brackets count and last opened bracket.

The next code is an example in ruby. It fails if the proposed input is used, but passes with the current one.
<sub>Code was omitted for brevity sake, full code [here](https://github.com/kimesf/exercism_solutions/blob/main/ruby/matching-brackets/matching_brackets_edge_case.rb) | Ruby problem [here](https://exercism.org/tracks/ruby/exercises/matching-brackets) for testing<sub>
```ruby
  def paired?
    brackets.each do |bracket|
      case bracket
      when '{' then count[:braces] += 1
      when '}' then count[:braces] -= 1
      when '(' then count[:parentheses] += 1
      when ')' then count[:parentheses] -= 1
      when '[' then count[:square_brackets] += 1
      when ']' then count[:square_brackets] -= 1
      end

      break if closes_unopened? # any count is negative?
      break if closes_wrong?(bracket) # other bracket being closed other than @last_opened_bracket?

      # By setting this to nil, the code complete ignores previous opened brackets, meaning it does not
      # detect any wrongly closed brackets that were opened before this one
      @last_opened_bracket = nil     if closes_last_opened?(bracket) # closes @last_opened_bracket?
      @last_opened_bracket = bracket if opener?(bracket) # bracket is '{', '(' or '['?
    end

    count.values.all?(&:zero?)
  end
```

I see that it's an unnecessarily overengineered/verbose solution and that one would probably realize that before going through with it, but I feel that when you're learning to code you often fail to see unnecessary complications with your code.

Let me know if you think testing this edge case is a stretch or if there is a better way to do it (maybe with a new test).

This is my first PR here, I've read README, but let me know if I missed anything, `yarn test` was run.