### PR TITLE
triangle: Add new test case for scalene triangles to solve a bug [#2072]

### DIFF
--- a/exercises/triangle/canonical-data.json
+++ b/exercises/triangle/canonical-data.json
@@ -192,7 +192,7 @@
           "expected": false
         },
         {
-          "uuid": "",
+          "uuid": "3da23a91-a166-419a-9abf-baf4868fd985",
           "description": "two unadjacent sides are equal",
           "property": "scalene",
           "input": {

--- a/exercises/triangle/canonical-data.json
+++ b/exercises/triangle/canonical-data.json
@@ -184,10 +184,19 @@
         },
         {
           "uuid": "c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e",
-          "description": "two sides are equal",
+          "description": "two adjacent sides are equal",
           "property": "scalene",
           "input": {
             "sides": [4, 4, 3]
+          },
+          "expected": false
+        },
+        {
+          "uuid": "",
+          "description": "two unadjacent sides are equal",
+          "property": "scalene",
+          "input": {
+            "sides": [3, 4, 3]
           },
           "expected": false
         },

--- a/exercises/triangle/canonical-data.json
+++ b/exercises/triangle/canonical-data.json
@@ -184,7 +184,7 @@
         },
         {
           "uuid": "c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e",
-          "description": "two adjacent sides are equal",
+          "description": "first and second sides are equal",
           "property": "scalene",
           "input": {
             "sides": [4, 4, 3]
@@ -193,7 +193,7 @@
         },
         {
           "uuid": "3da23a91-a166-419a-9abf-baf4868fd985",
-          "description": "two unadjacent sides are equal",
+          "description": "first and third sides are equal",
           "property": "scalene",
           "input": {
             "sides": [3, 4, 3]

--- a/exercises/triangle/canonical-data.json
+++ b/exercises/triangle/canonical-data.json
@@ -205,7 +205,7 @@
           "description": "second and third sides are equal",
           "property": "scalene",
           "input": {
-            "sides": [4, 3, 4]
+            "sides": [4, 3, 3]
           },
           "expected": false
         },

--- a/exercises/triangle/canonical-data.json
+++ b/exercises/triangle/canonical-data.json
@@ -201,6 +201,15 @@
           "expected": false
         },
         {
+          "uuid": "b6a75d98-1fef-4c42-8e9a-9db854ba0a4d",
+          "description": "second and third sides are equal",
+          "property": "scalene",
+          "input": {
+            "sides": [4, 3, 4]
+          },
+          "expected": false
+        },
+        {
           "uuid": "70ad5154-0033-48b7-af2c-b8d739cd9fdc",
           "description": "may not violate triangle inequality",
           "property": "scalene",


### PR DESCRIPTION
To solve a bug discussed in #2072, I have made this PR. 

In short, I added a new test case to the scalene triangle part of the test cases with the name "two unadjacent sides are equal" of [3, 4, 3], while still keeping the existing "two sides are equal" test case albeit renamed.