### PR TITLE
Clarify the lens exercise description

### DIFF
--- a/exercises/lens-person/description.md
+++ b/exercises/lens-person/description.md
@@ -2,8 +2,13 @@
 
 Use lenses to update nested records (specific to languages with immutable data).
 
-Updating fields of nested records is kind of annoying in Haskell. One solution
-is to use [lenses](https://wiki.haskell.org/Lens).  Implement several record
-accessing functions using lenses, you may use any library you want. The test
-suite also allows you to avoid lenses altogether so you can experiment with
-different approaches.
+Updating fields of nested records is kind of annoying. One could say that the
+code for such cases is as cumbersome as the structure is deep. If you have, say,
+a Person, that contains an Address, which has a Street, that has a Number, updating
+the Number requires creating a new Street with the new Number, then a new Address
+with the new Street and, finally, a new Person with the new Address. Confused already?
+
+One solution to this problem is to use [lenses](https://en.wikibooks.org/wiki/Haskell/Lenses_and_functional_references).
+
+Implement several record accessing functions using lenses. The test suite also allows
+you to avoid lenses altogether so you can experiment with different approaches.


### PR DESCRIPTION
This PR improves the Lens exercise description in two ways:

1. Expand the description a bit to convey _why_ updating nested records are annoying
2. Remove direct reference to Haskell, as this is intended as a generic description