### PR TITLE
Update series/canonical-data.json

### DIFF
--- a/exercises/series/canonical-data.json
+++ b/exercises/series/canonical-data.json
@@ -83,6 +83,18 @@
       }
     },
     {
+      "uuid": "d7957455-346d-4e47-8e4b-87ed1564c6d7",
+      "description": "slice length is way too large",
+      "property": "slices",
+      "input": {
+        "series": "12345",
+        "sliceLength": 42
+      },
+      "expected": {
+        "error": "slice length cannot be greater than series length"
+      }
+    },
+    {
       "uuid": "d34004ad-8765-4c09-8ba1-ada8ce776806",
       "description": "slice length cannot be zero",
       "property": "slices",


### PR DESCRIPTION
This PR adds a simple test to the series exercise with a slice length way bigger than the series length plus one.

The need for such a case arises from strongly-typed languages like Rust where the specific edge case (slice length equals series length plus one) can be solved by unstable solutions that would overflow for any greater slice length input.

For instance, in Rust, with no type casting, computing `digits.len() + 1 - len` will panic for `len > 6`.
