### PR TITLE
issue_2475_roman_numerals_max_3999

### DIFF
--- a/exercises/roman-numerals/canonical-data.json
+++ b/exercises/roman-numerals/canonical-data.json
@@ -250,7 +250,7 @@
       "input": {
         "number": 3001
       },
-      "expected":    "MMMI"
+      "expected": "MMMI"
     },
     {
       "uuid": "4e18e96b-5fbb-43df-a91b-9cb511fe0856",
@@ -259,7 +259,7 @@
       "input": {
         "number": 3999
       },
-      "expected":    "MMMCMXCIX"
+      "expected": "MMMCMXCIX"
     }
   ]
 }

--- a/exercises/roman-numerals/canonical-data.json
+++ b/exercises/roman-numerals/canonical-data.json
@@ -242,6 +242,24 @@
         "number": 1666
       },
       "expected": "MDCLXVI"
+    },
+    {
+      "uuid": "3bc4b41c-c2e6-49d9-9142-420691504336",
+      "description": "3001 is MMMI",
+      "property": "roman",
+      "input": {
+        "number": 3001
+      },
+      "expected":    "MMMI"
+    },
+    {
+      "uuid": "4e18e96b-5fbb-43df-a91b-9cb511fe0856",
+      "description": "3999 is MMMCMXCIX",
+      "property": "roman",
+      "input": {
+        "number": 3999
+      },
+      "expected":    "MMMCMXCIX"
     }
   ]
 }

--- a/exercises/roman-numerals/description.md
+++ b/exercises/roman-numerals/description.md
@@ -20,7 +20,7 @@ into stone tablets).
  7  => VII
 ```
 
-The maximum number supported by this this notation is 3,999.
+The maximum number supported by this notation is 3,999.
 (The Romans themselves didn't tend to go any higher)
 
 Wikipedia says: Modern Roman numerals ... are written by expressing each

--- a/exercises/roman-numerals/description.md
+++ b/exercises/roman-numerals/description.md
@@ -20,7 +20,7 @@ into stone tablets).
  7  => VII
 ```
 
-There is no need to be able to convert numbers larger than about 3000.
+The maximum number supported by this this notation is 3,999.
 (The Romans themselves didn't tend to go any higher)
 
 Wikipedia says: Modern Roman numerals ... are written by expressing each


### PR DESCRIPTION
Adjust Instructions and Unit Tests to support maximum Roman numeral 3999
Issue https://github.com/exercism/go/issues/2475

Adjustment to problem specification, instructions, and unit tests to support the max val 3,999 which can be expressed in Roman numerals (without getting into the "Larger number" scenarios)