### PR TITLE
Fix outdated description for Meetup exercise

### DIFF
--- a/exercises/meetup/description.md
+++ b/exercises/meetup/description.md
@@ -10,7 +10,7 @@ Examples of general descriptions are:
 - Teenth Sunday of July 2021
 - Last Thursday of November 2021
 
-The descriptors you are expected to process are: `first`, `second`, `third`, `fourth`, `fifth`, `last`, `teenth`.
+The descriptors you are expected to process are: `first`, `second`, `third`, `fourth`, `last`, `teenth`.
 
 Note that descriptor `teenth` is a made-up word.
 There are exactly seven numbered days in a month that end with "teenth" ("thirteenth" to "nineteenth").


### PR DESCRIPTION
Back in 2015 we determined that we should not implement fifth, since this exercise is about scheduling regular monthly meetups.

Since not all months have a fifth week, it doesn't make sense to schedule a regular meetup on the fifth Wednesday (or whatever) of every month.

We removed the test cases, but the description was not updated to remove the reference to the 'fifth' scenario.