### PR TITLE
phone-number: Use consistent error style for incorrect number of digits

### DIFF
--- a/exercises/phone-number/canonical-data.json
+++ b/exercises/phone-number/canonical-data.json
@@ -45,6 +45,19 @@
       }
     },
     {
+      "uuid": "2de74156-f646-42b5-8638-0ef1d8b58bc2",
+      "reimplements": "598d8432-0659-4019-a78b-1c6a73691d21",
+      "description": "invalid when 9 digits",
+      "comments": ["Make incorrect number of digit errors consistent."],
+      "property": "clean",
+      "input": {
+        "phrase": "123456789"
+      },
+      "expected": {
+        "error": "must not be fewer than 10 digits"
+      }
+    },
+    {
       "uuid": "57061c72-07b5-431f-9766-d97da7c4399d",
       "description": "invalid when 11 digits does not start with a 1",
       "property": "clean",
@@ -88,15 +101,13 @@
       "uuid": "4a1509b7-8953-4eec-981b-c483358ff531",
       "reimplements": "c6a5f007-895a-4fc5-90bc-a7e70f9b5cad",
       "description": "invalid when more than 11 digits",
-      "comments": [
-        "Share incorrect number error instead of using unique error."
-      ],
+      "comments": ["Make incorrect number of digit errors consistent."],
       "property": "clean",
       "input": {
         "phrase": "321234567890"
       },
       "expected": {
-        "error": "incorrect number of digits"
+        "error": "must not be greater than 11 digits"
       }
     },
     {

--- a/exercises/phone-number/canonical-data.json
+++ b/exercises/phone-number/canonical-data.json
@@ -85,6 +85,21 @@
       }
     },
     {
+      "uuid": "4a1509b7-8953-4eec-981b-c483358ff531",
+      "reimplements": "c6a5f007-895a-4fc5-90bc-a7e70f9b5cad",
+      "description": "invalid when more than 11 digits",
+      "comments": [
+        "Share incorrect number error instead of using unique error."
+      ],
+      "property": "clean",
+      "input": {
+        "phrase": "321234567890"
+      },
+      "expected": {
+        "error": "incorrect number of digits"
+      }
+    },
+    {
       "uuid": "63f38f37-53f6-4a5f-bd86-e9b404f10a60",
       "description": "invalid with letters",
       "property": "clean",


### PR DESCRIPTION
Within the North American Numbering Plan, a phone number may have 10 or 11 digits.

Currently, we have a test for a phone number with 9 digits (too few digits) and another test for a phone number with 12 digits (too many digits).

The error messages are inconsistent and somewhat confusing:
- (for the test with 9 digits): _incorrect number of digits_
- (for the test with 12 digits): _more than 11 digits_

In the first case, the error message is correctly explaining that something is wrong, but it doesn't give enough information to actually fix the problem. "incorrect number of digits". Too few? Too many? How many would be just right?

In the second case, it says that there are more than 11 digits, which is correct, but it doesn't actually say that this is a problem.

This PR changes the error messages to explicitly say what the problem is, while also pointing out how to fix it.
- (for the test with 9 digits): _must not be fewer than 10 digits_
- (for the test with 12 digits): _must not be greater than 11 digits_