### PR TITLE
Delete bonus point sections from descriptions

### DIFF
--- a/exercises/beer-song/description.md
+++ b/exercises/beer-song/description.md
@@ -305,17 +305,3 @@ Take it down and pass it around, no more bottles of beer on the wall.
 No more bottles of beer on the wall, no more bottles of beer.
 Go to the store and buy some more, 99 bottles of beer on the wall.
 ```
-
-## For bonus points
-
-Did you get the tests passing and the code clean? If you want to, these
-are some additional things you could try:
-
-* Remove as much duplication as you possibly can.
-* Optimize for readability, even if it means introducing duplication.
-* If you've removed all the duplication, do you have a lot of
-  conditionals? Try replacing the conditionals with polymorphism, if it
-  applies in this language. How readable is it?
-
-Then please share your thoughts in a comment on the submission. Did this
-experiment make the code better? Worse? Did you learn anything from it?

--- a/exercises/bottle-song/description.md
+++ b/exercises/bottle-song/description.md
@@ -55,17 +55,3 @@ One green bottles hanging on the wall,
 And if one green bottle should accidentally fall,
 There'll be no green bottles hanging on the wall.
 ```
-
-## For bonus points
-
-Did you get the tests passing and the code clean?
-If you want to, these are some additional things you could try:
-
-* Remove as much duplication as you possibly can.
-* Optimize for readability, even if it means introducing duplication.
-* If you've removed all the duplication, do you have a lot of conditionals?
-  Try replacing the conditionals with polymorphism, if it applies in this language.
-  How readable is it?
-
-Then please share your thoughts in a comment on the submission.
-Did this experiment make the code better? Worse? Did you learn anything from it?

--- a/exercises/grade-school/description.md
+++ b/exercises/grade-school/description.md
@@ -26,16 +26,3 @@ do you want?) and each student cannot be added more than once to a grade or the
 roster.
 In fact, when a test attempts to add the same student more than once, your
 implementation should indicate that this is incorrect.
-
-## For bonus points
-
-Did you get the tests passing and the code clean? If you want to, these
-are some additional things you could try:
-
-- If you're working in a language with mutable data structures and your
-  implementation allows outside code to mutate the school's internal DB
-  directly, see if you can prevent this. Feel free to introduce additional
-  tests.
-
-Then please share your thoughts in a comment on the submission. Did this
-experiment make the code better? Worse? Did you learn anything from it?

--- a/exercises/grains/description.md
+++ b/exercises/grains/description.md
@@ -15,14 +15,3 @@ Write code that shows:
 
 - how many grains were on a given square, and
 - the total number of grains on the chessboard
-
-## For bonus points
-
-Did you get the tests passing and the code clean? If you want to, these
-are some additional things you could try:
-
-- Optimize for speed.
-- Optimize for readability.
-
-Then please share your thoughts in a comment on the submission. Did this
-experiment make the code better? Worse? Did you learn anything from it?

--- a/exercises/isbn-verifier/description.md
+++ b/exercises/isbn-verifier/description.md
@@ -34,9 +34,3 @@ The program should be able to verify ISBN-10 both with and without separating da
 
 Converting from strings to numbers can be tricky in certain languages.
 Now, it's even trickier since the check digit of an ISBN-10 may be 'X' (representing '10'). For instance `3-598-21507-X` is a valid ISBN-10.
-
-## Bonus tasks
-
-* Generate a valid ISBN-13 from the input ISBN-10 (and maybe verify it again with a derived verifier).
-
-* Generate valid ISBN, maybe even from a given starting ISBN.

--- a/exercises/triangle/description.md
+++ b/exercises/triangle/description.md
@@ -25,9 +25,3 @@ a + c ≥ b
 ```
 
 See [Triangle Inequality](https://en.wikipedia.org/wiki/Triangle_inequality).
-
-## Dig Deeper
-
-The case where the sum of the lengths of two sides _equals_ that of the
-third is known as a _degenerate_ triangle - it has zero area and looks like
-a single line. Feel free to add your own code/tests to check for degenerate triangles.

--- a/exercises/wordy/description.md
+++ b/exercises/wordy/description.md
@@ -58,11 +58,3 @@ The parser should reject:
 * Unsupported operations ("What is 52 cubed?")
 * Non-math questions ("Who is the President of the United States")
 * Word problems with invalid syntax ("What is 1 plus plus 2?")
-
-## Bonus — Exponentials
-
-If you'd like, handle exponentials.
-
-> What is 2 raised to the 5th power?
-
-32


### PR DESCRIPTION
The bonus points sections were a way of encouraging more discussion and exploration in v1.

Discussion:
Now that we have closed mentoring rather than open discussions it makes less sense to encourage discussion in this way. We may find other ways of encouraging discussions, but then it will be a product-level design choice rather than a textual call to action from within the exercise description.

Exploration:
We tend to want people to explore the approach to solving the problem rather than to explore how to expand the scope of the problem. As such I think it's worth deleting the exploration aspect of the bonus points sections.

Also, there are only a handful of exercises that had this sort of section, so it's also neater in terms of consistency.