### PR TITLE
Use reference links in descriptions

### DIFF
--- a/exercises/all-your-base/description.md
+++ b/exercises/all-your-base/description.md
@@ -10,7 +10,7 @@ represented as a sequence of digits, convert it to base **b**.
 - Try to implement the conversion yourself.
   Do not use something else to perform the conversion for you.
 
-## About [Positional Notation](https://en.wikipedia.org/wiki/Positional_notation)
+## About [Positional Notation][positional-notation]
 
 In positional notation, a number in base **b** can be understood as a linear
 combination of powers of **b**.
@@ -30,3 +30,5 @@ The number 1120, *in base 3*, means:
 I think you got the idea!
 
 *Yes. Those three numbers above are exactly the same. Congratulations!*
+
+[positional-notation]: https://en.wikipedia.org/wiki/Positional_notation

--- a/exercises/alphametics/description.md
+++ b/exercises/alphametics/description.md
@@ -2,8 +2,7 @@
 
 Write a function to solve alphametics puzzles.
 
-[Alphametics](https://en.wikipedia.org/wiki/Alphametics) is a puzzle where
-letters in words are replaced with numbers.
+[Alphametics][] is a puzzle where letters in words are replaced with numbers.
 
 For example `SEND + MORE = MONEY`:
 
@@ -30,3 +29,5 @@ Each letter must represent a different digit, and the leading digit of
 a multi-digit number must not be zero.
 
 Write a function to solve alphametics puzzles.
+
+[Alphametics]: https://en.wikipedia.org/wiki/Alphametics

--- a/exercises/armstrong-numbers/description.md
+++ b/exercises/armstrong-numbers/description.md
@@ -1,6 +1,6 @@
 # Description
 
-An [Armstrong number](https://en.wikipedia.org/wiki/Narcissistic_number) is a number that is the sum of its own digits each raised to the power of the number of digits.
+An [Armstrong number][armstrong-number] is a number that is the sum of its own digits each raised to the power of the number of digits.
 
 For example:
 
@@ -10,3 +10,5 @@ For example:
 - 154 is *not* an Armstrong number, because: `154 != 1^3 + 5^3 + 4^3 = 1 + 125 + 64 = 190`
 
 Write some code to determine whether a number is an Armstrong number.
+
+[armstrong-number]: https://en.wikipedia.org/wiki/Narcissistic_number

--- a/exercises/connect/description.md
+++ b/exercises/connect/description.md
@@ -2,8 +2,7 @@
 
 Compute the result for a game of Hex / Polygon.
 
-The abstract boardgame known as
-[Hex](https://en.wikipedia.org/wiki/Hex_%28board_game%29) / Polygon /
+The abstract boardgame known as [Hex][] / Polygon /
 CON-TAC-TIX is quite simple in rules, though complex in practice. Two players
 place stones on a parallelogram with hexagonal fields. The player to connect his/her
 stones to the opposite side first wins. The four sides of the parallelogram are
@@ -29,3 +28,5 @@ The boards look like this:
 "Player `O`" plays from top to bottom, "Player `X`" plays from left to right. In
 the above example `O` has made a connection from left to right but nobody has
 won since `O` didn't connect top and bottom.
+
+[Hex]: https://en.wikipedia.org/wiki/Hex_%28board_game%29

--- a/exercises/darts/description.md
+++ b/exercises/darts/description.md
@@ -2,8 +2,8 @@
 
 Write a function that returns the earned points in a single toss of a Darts game.
 
-[Darts](https://en.wikipedia.org/wiki/Darts) is a game where players
-throw darts at a [target](https://en.wikipedia.org/wiki/Darts#/media/File:Darts_in_a_dartboard.jpg).
+[Darts][] is a game where players
+throw darts at a [target][darts-target].
 
 In our particular instance of the game, the target rewards 4 different amounts of points, depending on where the dart lands:
 
@@ -12,6 +12,12 @@ In our particular instance of the game, the target rewards 4 different amounts o
 * If the dart lands in the middle circle of the target, player earns 5 points.
 * If the dart lands in the inner circle of the target, player earns 10 points.
 
-The outer circle has a radius of 10 units (this is equivalent to the total radius for the entire target), the middle circle a radius of 5 units, and the inner circle a radius of 1. Of course, they are all centered at the same point (that is, the circles are [concentric](http://mathworld.wolfram.com/ConcentricCircles.html)) defined by the coordinates (0, 0).
+The outer circle has a radius of 10 units (this is equivalent to the total radius for the entire target), the middle circle a radius of 5 units, and the inner circle a radius of 1. Of course, they are all centered at the same point (that is, the circles are [concentric][] defined by the coordinates (0, 0).
 
-Write a function that given a point in the target (defined by its [Cartesian coordinates](https://www.mathsisfun.com/data/cartesian-coordinates.html) `x` and `y`, where `x` and `y` are [real](https://www.mathsisfun.com/numbers/real-numbers.html)), returns the correct amount earned by a dart landing at that point.
+Write a function that given a point in the target (defined by its [Cartesian coordinates][cartesian-coordinates] `x` and `y`, where `x` and `y` are [real][real-numbers]), returns the correct amount earned by a dart landing at that point.
+
+ [Darts]: https://en.wikipedia.org/wiki/Darts
+ [darts-target]: https://en.wikipedia.org/wiki/Darts#/media/File:Darts_in_a_dartboard.jpg
+ [concentric]: http://mathworld.wolfram.com/ConcentricCircles.html
+ [cartesian-coordinates]: https://www.mathsisfun.com/data/cartesian-coordinates.html
+ [real-numbers]: https://www.mathsisfun.com/numbers/real-numbers.html

--- a/exercises/dot-dsl/description.md
+++ b/exercises/dot-dsl/description.md
@@ -1,16 +1,15 @@
 # Description
 
-A [Domain Specific Language
-(DSL)](https://en.wikipedia.org/wiki/Domain-specific_language) is a
+A [Domain Specific Language (DSL)][dsl] is a
 small language optimized for a specific domain. Since a DSL is
 targeted, it can greatly impact productivity/understanding by allowing the
 writer to declare *what* they want rather than *how*.
 
 One problem area where they are applied are complex customizations/configurations.
 
-For example the [DOT language](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) allows
+For example the [DOT language][dot-language] allows
 you to write a textual description of a graph which is then transformed into a picture by one of
-the [Graphviz](http://graphviz.org/) tools (such as `dot`). A simple graph looks like this:
+the [Graphviz][] tools (such as `dot`). A simple graph looks like this:
 
     graph {
         graph [bgcolor="yellow"]
@@ -30,4 +29,9 @@ to create graph data structures. However, unlike the DOT Language, our DSL will
 be an internal DSL for use only in our language.
 
 More information about the difference between internal and external DSLs can be
-found [here](https://martinfowler.com/bliki/DomainSpecificLanguage.html).
+found [here][fowler-dsl].
+
+[dsl]: https://en.wikipedia.org/wiki/Domain-specific_language
+[dot-language]: https://en.wikipedia.org/wiki/DOT_(graph_description_language)
+[Graphviz]: http://graphviz.org/
+[fowler-dsl]: https://martinfowler.com/bliki/DomainSpecificLanguage.html

--- a/exercises/food-chain/description.md
+++ b/exercises/food-chain/description.md
@@ -6,7 +6,7 @@ While you could copy/paste the lyrics,
 or read them from a file, this problem is much more
 interesting if you approach it algorithmically.
 
-This is a [cumulative song](http://en.wikipedia.org/wiki/Cumulative_song) of unknown origin.
+This is a [cumulative song][cumulative-song] of unknown origin.
 
 This is one of many common variants.
 
@@ -62,3 +62,5 @@ I don't know why she swallowed the fly. Perhaps she'll die.
 I know an old lady who swallowed a horse.
 She's dead, of course!
 ```
+
+[cumulative-song]: http://en.wikipedia.org/wiki/Cumulative_song

--- a/exercises/forth/description.md
+++ b/exercises/forth/description.md
@@ -2,7 +2,7 @@
 
 Implement an evaluator for a very simple subset of Forth.
 
-[Forth](https://en.wikipedia.org/wiki/Forth_%28programming_language%29)
+[Forth][]
 is a stack-based programming language. Implement a very basic evaluator
 for a small subset of Forth.
 
@@ -24,3 +24,5 @@ more letters, digits, symbols or punctuation that is not a number.
 enough.)
 
 Words are case-insensitive.
+
+[Forth]: https://en.wikipedia.org/wiki/Forth_%28programming_language%29

--- a/exercises/go-counting/description.md
+++ b/exercises/go-counting/description.md
@@ -31,6 +31,7 @@ To be more precise an empty intersection is part of a player's territory
 if all of its neighbors are either stones of that player or empty
 intersections that are part of that player's territory.
 
-For more information see
-[wikipedia](https://en.wikipedia.org/wiki/Go_%28game%29) or [Sensei's
-Library](http://senseis.xmp.net/).
+For more information see [wikipedia][go-wikipedia] or [Sensei's Library][go-sensei].
+
+[go-wikipedia]: https://en.wikipedia.org/wiki/Go_%28game%29
+[go-sensei]: http://senseis.xmp.net/

--- a/exercises/grep/description.md
+++ b/exercises/grep/description.md
@@ -3,7 +3,7 @@
 Search a file for lines matching a regular expression pattern. Return the line
 number and contents of each matching line.
 
-The Unix [`grep`](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html) command can be used to search for lines in one or more files
+The Unix [`grep`][grep] command can be used to search for lines in one or more files
 that match a user-provided search query (known as the *pattern*).
 
 The `grep` command takes three arguments:
@@ -75,3 +75,5 @@ The `grep` command should support multiple flags at once.
 
 For example, running `grep -l -v "hello" file1.txt file2.txt` should
 print the names of files that do not contain the string "hello".
+
+[grep]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html

--- a/exercises/hello-world/description.md
+++ b/exercises/hello-world/description.md
@@ -2,9 +2,7 @@
 
 The classical introductory exercise. Just say "Hello, World!".
 
-["Hello, World!"](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program) is
-the traditional first program for beginning programming in a new language
-or environment.
+["Hello, World!"][hello-world] is the traditional first program for beginning programming in a new language or environment.
 
 The objectives are simple:
 
@@ -13,3 +11,5 @@ The objectives are simple:
 - Submit your solution and check it at the website.
 
 If everything goes well, you will be ready to fetch your first real exercise.
+
+[hello-world]: http://en.wikipedia.org/wiki/%22Hello,_world!%22_program

--- a/exercises/house/description.md
+++ b/exercises/house/description.md
@@ -9,7 +9,7 @@ Recite the nursery rhyme 'This is the House that Jack Built'.
 > Furthermore, embedding also allows us to construct an infinitely long
 > structure, in theory anyway.
 
-- [papyr.com](http://papyr.com/hypertextbooks/grammar/ph_noun.htm)
+- [papyr.com][]
 
 The nursery rhyme reads as follows:
 
@@ -104,3 +104,5 @@ that killed the rat
 that ate the malt
 that lay in the house that Jack built.
 ```
+
+[papyr.com]: http://papyr.com/hypertextbooks/grammar/ph_noun.htm

--- a/exercises/isbn-verifier/description.md
+++ b/exercises/isbn-verifier/description.md
@@ -1,6 +1,6 @@
 # Description
 
-The [ISBN-10 verification process](https://en.wikipedia.org/wiki/International_Standard_Book_Number) is used to validate book identification
+The [ISBN-10 verification process][isbn-verification] is used to validate book identification
 numbers. These normally contain dashes and look like: `3-598-21508-8`
 
 ## ISBN
@@ -34,3 +34,5 @@ The program should be able to verify ISBN-10 both with and without separating da
 
 Converting from strings to numbers can be tricky in certain languages.
 Now, it's even trickier since the check digit of an ISBN-10 may be 'X' (representing '10'). For instance `3-598-21507-X` is a valid ISBN-10.
+
+[isbn-verification]: https://en.wikipedia.org/wiki/International_Standard_Book_Number

--- a/exercises/killer-sudoku-helper/description.md
+++ b/exercises/killer-sudoku-helper/description.md
@@ -7,11 +7,11 @@ To make the output of your program easy to read, the combinations it returns mus
 
 ## Killer Sudoku Rules
 
-- [Standard Sudoku rules](https://masteringsudoku.com/sudoku-rules-beginners/) apply.
+- [Standard Sudoku rules][sudoku-rules] apply.
 - The digits in a cage, usually marked by a dotted line, add up to the small number given in the corner of the cage.
 - A digit may only occur once in a cage.
 
-For a more detailed explanation, check out [this guide](https://masteringsudoku.com/killer-sudoku/).
+For a more detailed explanation, check out [this guide][killer-guide].
 
 ## Example 1: Cage with only 1 possible combination
 
@@ -20,7 +20,7 @@ In a 3-digit cage with a sum of 7, there is only one valid combination: 124.
 - 1 + 2 + 4 = 7
 - Any other combination that adds up to 7, e.g. 232, would violate the rule of not repeating digits within a cage.
 
-![Sudoku grid, with three killer cages that are marked as grouped together. The first killer cage is in the 3×3 box in the top left corner of the grid. The middle column of that box forms the cage, with the followings cells from top to bottom: first cell contains a 1 and a pencil mark of 7, indicating a cage sum of 7, second cell contains a 2, third cell contains a 5. The numbers are highlighted in red to indicate a mistake. The second killer cage is in the central 3×3 box of the grid. The middle column of that box forms the cage, with the followings cells from top to bottom: first cell contains a 1 and a pencil mark of 7, indicating a cage sum of 7, second cell contains a 2, third cell contains a 4. None of the numbers in this cage are highlighted and therefore don't contain any mistakes. The third killer cage follows the outside corner of the central 3×3 box of the grid. It is made up of the following three cells: the top left cell of the cage contains a 2, highlighted in red, and a cage sum of 7. The top right cell of the cage contains a 3. The bottom right cell of the cage contains a 2, highlighted in red. All other cells are empty.](https://media.githubusercontent.com/media/exercism/v3-files/main/julia/killer-sudoku-helper/example1.png)
+![Sudoku grid, with three killer cages that are marked as grouped together. The first killer cage is in the 3×3 box in the top left corner of the grid. The middle column of that box forms the cage, with the followings cells from top to bottom: first cell contains a 1 and a pencil mark of 7, indicating a cage sum of 7, second cell contains a 2, third cell contains a 5. The numbers are highlighted in red to indicate a mistake. The second killer cage is in the central 3×3 box of the grid. The middle column of that box forms the cage, with the followings cells from top to bottom: first cell contains a 1 and a pencil mark of 7, indicating a cage sum of 7, second cell contains a 2, third cell contains a 4. None of the numbers in this cage are highlighted and therefore don't contain any mistakes. The third killer cage follows the outside corner of the central 3×3 box of the grid. It is made up of the following three cells: the top left cell of the cage contains a 2, highlighted in red, and a cage sum of 7. The top right cell of the cage contains a 3. The bottom right cell of the cage contains a 2, highlighted in red. All other cells are empty.][one-solution-img]
 
 ## Example 2: Cage with several combinations
 
@@ -31,7 +31,7 @@ In a 2-digit cage with a sum 10, there are 4 possible combinations:
 - 37
 - 46
 
-![Sudoku grid, all squares empty except for the middle column, column 5, which has 8 rows filled. Each continguous two rows form a killer cage and are marked as grouped together. From top to bottom: first group is a cell with value 1 and a pencil mark indicating a cage sum of 10, cell with value 9. Second group is a cell with value 2 and a pencil mark of 10, cell with value 8. Third group is a cell with value 3 and a pencil mark of 10, cell with value 7. Fourth group is a cell with value 4 and a pencil mark of 10, cell with value 6. The last cell in the column is empty.](https://media.githubusercontent.com/media/exercism/v3-files/main/julia/killer-sudoku-helper/example2.png)
+![Sudoku grid, all squares empty except for the middle column, column 5, which has 8 rows filled. Each continguous two rows form a killer cage and are marked as grouped together. From top to bottom: first group is a cell with value 1 and a pencil mark indicating a cage sum of 10, cell with value 9. Second group is a cell with value 2 and a pencil mark of 10, cell with value 8. Third group is a cell with value 3 and a pencil mark of 10, cell with value 7. Fourth group is a cell with value 4 and a pencil mark of 10, cell with value 6. The last cell in the column is empty.][four-solutions-img]
 
 ## Example 3: Cage with several combinations that is restricted
 
@@ -42,14 +42,22 @@ In a 2-digit cage with a sum 10, where the column already contains a 1 and a 4, 
 
 19 and 46 are not possible due to the 1 and 4 in the column according to standard Sudoku rules.
 
-![Sudoku grid, all squares empty except for the middle column, column 5, which has 8 rows filled. The first row contains a 4, the second is empty, and the third contains a 1. The 1 is highlighted in red to indicate a mistake. The last 6 rows in the column form killer cages of two cells each. From top to bottom: first group is a cell with value 2 and a pencil mark indicating a cage sum of 10, cell with value 8. Second group is a cell with value 3 and a pencil mark of 10, cell with value 7. Third group is a cell with value 1, highlighted in red, and a pencil mark of 10, cell with value 9.](https://media.githubusercontent.com/media/exercism/v3-files/main/julia/killer-sudoku-helper/example3.png)
+![Sudoku grid, all squares empty except for the middle column, column 5, which has 8 rows filled. The first row contains a 4, the second is empty, and the third contains a 1. The 1 is highlighted in red to indicate a mistake. The last 6 rows in the column form killer cages of two cells each. From top to bottom: first group is a cell with value 2 and a pencil mark indicating a cage sum of 10, cell with value 8. Second group is a cell with value 3 and a pencil mark of 10, cell with value 7. Third group is a cell with value 1, highlighted in red, and a pencil mark of 10, cell with value 9.][not-possible-img]
 
 ## Trying it yourself
 
-If you want to give an approachable Killer Sudoku a go, you can try out [this puzzle](https://app.crackingthecryptic.com/sudoku/HqTBn3Pr6R) by Clover, featured by [Mark Goodliffe on Cracking The Cryptic on the 21st of June 2021](https://youtu.be/c_NjEbFEeW0?t=1180).
+If you want to give an approachable Killer Sudoku a go, you can try out [this puzzle][clover-puzzle] by Clover, featured by [Mark Goodliffe on Cracking The Cryptic on the 21st of June 2021][goodliffe-video].
 
 You can also find Killer Sudokus in varying difficulty in numerous newspapers, as well as Sudoku apps, books and websites.
 
 ## Credit
 
 The screenshots above have been generated using [F-Puzzles.com](https://www.f-puzzles.com/), a Puzzle Setting Tool by Eric Fox.
+
+[sudoku-rules]: https://masteringsudoku.com/sudoku-rules-beginners/
+[killer-guide]: https://masteringsudoku.com/killer-sudoku/
+[one-solution-img]: https://media.githubusercontent.com/media/exercism/v3-files/main/julia/killer-sudoku-helper/example1.png
+[four-solutions-img]: https://media.githubusercontent.com/media/exercism/v3-files/main/julia/killer-sudoku-helper/example2.png
+[not-possible-img]: https://media.githubusercontent.com/media/exercism/v3-files/main/julia/killer-sudoku-helper/example3.png
+[clover-puzzle]: https://app.crackingthecryptic.com/sudoku/HqTBn3Pr6R
+[goodliffe-video]: https://youtu.be/c_NjEbFEeW0?t=1180

--- a/exercises/lens-person/description.md
+++ b/exercises/lens-person/description.md
@@ -7,7 +7,9 @@ The code for such cases is as cumbersome as the structure is deep.
 If you have, say, a Person, that contains an Address, which has a Street, that has a Number, updating the Number requires creating a new Street with the new Number, then a new Address with the new Street and, finally, a new Person with the new Address.
 Confused already?
 
-One solution to this problem is to use [lenses](https://en.wikibooks.org/wiki/Haskell/Lenses_and_functional_references).
+One solution to this problem is to use [lenses][lenses].
 
 Implement several record accessing functions using lenses.
 The test suite also allows you to avoid lenses altogether so you can experiment with different approaches.
+
+[lenses]: https://en.wikibooks.org/wiki/Haskell/Lenses_and_functional_references

--- a/exercises/linked-list/description.md
+++ b/exercises/linked-list/description.md
@@ -25,4 +25,6 @@ To keep your implementation simple, the tests will not cover error
 conditions. Specifically: `pop` or `shift` will never be called on an
 empty list.
 
-If you want to know more about linked lists, check [Wikipedia](https://en.wikipedia.org/wiki/Linked_list).
+Read more about [linked lists on Wikipedia][linked-lists].
+
+[linked-lists]: https://en.wikipedia.org/wiki/Linked_list

--- a/exercises/luhn/description.md
+++ b/exercises/luhn/description.md
@@ -2,7 +2,7 @@
 
 Given a number determine whether or not it is valid per the Luhn formula.
 
-The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is
+The [Luhn algorithm][luhn] is
 a simple checksum formula used to validate a variety of identification
 numbers, such as credit card numbers and Canadian Social Insurance
 Numbers.
@@ -62,3 +62,5 @@ Sum the digits
 ```
 
 57 is not evenly divisible by 10, so this number is not valid.
+
+[luhn]: https://en.wikipedia.org/wiki/Luhn_algorithm

--- a/exercises/markdown/description.md
+++ b/exercises/markdown/description.md
@@ -3,8 +3,7 @@
 Refactor a Markdown parser.
 
 The markdown exercise is a refactoring exercise. There is code that parses a
-given string with [Markdown
-syntax](https://guides.github.com/features/mastering-markdown/) and returns the
+given string with [Markdown syntax][markdown] and returns the
 associated HTML for that string. Even though this code is confusingly written
 and hard to follow, somehow it works and all the tests are passing! Your
 challenge is to re-write this code to make it easier to read and maintain
@@ -13,3 +12,5 @@ while still making sure that all the tests keep passing.
 It would be helpful if you made notes of what you did in your refactoring in
 comments so reviewers can see that, but it isn't strictly necessary. The most
 important thing is to make the code better!
+
+[markdown]: https://guides.github.com/features/mastering-markdown/

--- a/exercises/nucleotide-codons/description.md
+++ b/exercises/nucleotide-codons/description.md
@@ -16,4 +16,6 @@ Write some code that given a codon, which may use shorthand, returns the
 name of the amino acid that that codon encodes for. You will be given
 a list of non-shorthand-codon/name pairs to base your computation on.
 
-See: [wikipedia](https://en.wikipedia.org/wiki/DNA_codon_table).
+See: [wikipedia][codon-table].
+
+[codon-table]: https://en.wikipedia.org/wiki/DNA_codon_table

--- a/exercises/perfect-numbers/description.md
+++ b/exercises/perfect-numbers/description.md
@@ -3,7 +3,7 @@
 Determine if a number is perfect, abundant, or deficient based on
 Nicomachus' (60 - 120 CE) classification scheme for positive integers.
 
-The Greek mathematician [Nicomachus](https://en.wikipedia.org/wiki/Nicomachus) devised a classification scheme for positive integers, identifying each as belonging uniquely to the categories of **perfect**, **abundant**, or **deficient** based on their [aliquot sum](https://en.wikipedia.org/wiki/Aliquot_sum). The aliquot sum is defined as the sum of the factors of a number not including the number itself. For example, the aliquot sum of 15 is (1 + 3 + 5) = 9
+The Greek mathematician [Nicomachus][nicomachus] devised a classification scheme for positive integers, identifying each as belonging uniquely to the categories of **perfect**, **abundant**, or **deficient** based on their [aliquot sum][aliquot-sum]. The aliquot sum is defined as the sum of the factors of a number not including the number itself. For example, the aliquot sum of 15 is (1 + 3 + 5) = 9
 
 - **Perfect**: aliquot sum = number
   - 6 is a perfect number because (1 + 2 + 3) = 6
@@ -16,3 +16,6 @@ The Greek mathematician [Nicomachus](https://en.wikipedia.org/wiki/Nicomachus) d
   - Prime numbers are deficient
 
 Implement a way to determine whether a given number is **perfect**. Depending on your language track, you may also need to implement a way to determine whether a given number is **abundant** or **deficient**.
+
+[nicomachus]: https://en.wikipedia.org/wiki/Nicomachus
+[aliquot-sum]: https://en.wikipedia.org/wiki/Aliquot_sum

--- a/exercises/pig-latin/description.md
+++ b/exercises/pig-latin/description.md
@@ -15,4 +15,6 @@ to understand.
 There are a few more rules for edge cases, and there are regional
 variants too.
 
-See <http://en.wikipedia.org/wiki/Pig_latin> for more details.
+Read more about [Pig Latin on Wikipedia][pig-latin].
+
+[pig-latin]: http://en.wikipedia.org/wiki/Pig_latin

--- a/exercises/poker/description.md
+++ b/exercises/poker/description.md
@@ -2,5 +2,6 @@
 
 Pick the best hand(s) from a list of poker hands.
 
-See [wikipedia](https://en.wikipedia.org/wiki/List_of_poker_hands) for an
-overview of poker hands.
+See [wikipedia][poker-hands] for an overview of poker hands.
+
+[poker-hands]: https://en.wikipedia.org/wiki/List_of_poker_hands

--- a/exercises/protein-translation/description.md
+++ b/exercises/protein-translation/description.md
@@ -39,4 +39,6 @@ UGU, UGC              | Cysteine
 UGG                   | Tryptophan
 UAA, UAG, UGA         | STOP
 
-Learn more about [protein translation on Wikipedia](http://en.wikipedia.org/wiki/Translation_(biology))
+Learn more about [protein translation on Wikipedia][protein-translation].
+
+[protein-translation]: http://en.wikipedia.org/wiki/Translation_(biology)

--- a/exercises/raindrops/description.md
+++ b/exercises/raindrops/description.md
@@ -1,6 +1,6 @@
 # Description
 
-Your task is to convert a number into a string that contains raindrop sounds corresponding to certain potential factors. A factor is a number that evenly divides into another number, leaving no remainder. The simplest way to test if one number is a factor of another is to use the [modulo operation](https://en.wikipedia.org/wiki/Modulo_operation).
+Your task is to convert a number into a string that contains raindrop sounds corresponding to certain potential factors. A factor is a number that evenly divides into another number, leaving no remainder. The simplest way to test if one number is a factor of another is to use the [modulo operation][modulo].
 
 The rules of `raindrops` are that if a given number:
 
@@ -14,3 +14,5 @@ The rules of `raindrops` are that if a given number:
 - 28 has 7 as a factor, but not 3 or 5, so the result would be "Plong".
 - 30 has both 3 and 5 as factors, but not 7, so the result would be "PlingPlang".
 - 34 is not factored by 3, 5, or 7, so the result would be "34".
+
+[modulo]: https://en.wikipedia.org/wiki/Modulo_operation

--- a/exercises/resistor-color/description.md
+++ b/exercises/resistor-color/description.md
@@ -33,4 +33,6 @@ The goal of this exercise is to create a way:
 
 Mnemonics map the colors to the numbers, that, when stored as an array, happen to map to their index in the array: Better Be Right Or Your Great Big Values Go Wrong.
 
-More information on the color encoding of resistors can be found in the [Electronic color code Wikipedia article](https://en.wikipedia.org/wiki/Electronic_color_code)
+More information on the color encoding of resistors can be found in the [Electronic color code Wikipedia article][e-color-code].
+
+[e-color-code]: https://en.wikipedia.org/wiki/Electronic_color_code

--- a/exercises/rest-api/description.md
+++ b/exercises/rest-api/description.md
@@ -4,7 +4,7 @@ Implement a RESTful API for tracking IOUs.
 
 Four roommates have a habit of borrowing money from each other frequently, and have trouble remembering who owes whom, and how much.
 
-Your task is to implement a simple [RESTful API](https://en.wikipedia.org/wiki/Representational_state_transfer) that receives [IOU](https://en.wikipedia.org/wiki/IOU)s as POST requests, and can deliver specified summary information via GET requests.
+Your task is to implement a simple [RESTful API][restful-wikipedia] that receives [IOU][]s as POST requests, and can deliver specified summary information via GET requests.
 
 ## API Specification
 
@@ -36,7 +36,13 @@ Your task is to implement a simple [RESTful API](https://en.wikipedia.org/wiki/R
 
 ## Other Resources
 
-- [https://restfulapi.net/](https://restfulapi.net/)
+- [REST API Tutorial][restfulapi]
 - Example RESTful APIs
-  - [GitHub](https://developer.github.com/v3/)
-  - [Reddit](https://www.reddit.com/dev/api/)
+  - [GitHub][github-rest]
+  - [Reddit][reddit-rest]
+
+[restful-wikipedia]: https://en.wikipedia.org/wiki/Representational_state_transfer
+[IOU]: https://en.wikipedia.org/wiki/IOU
+[github-rest]: https://developer.github.com/v3/
+[reddit-rest]: https://www.reddit.com/dev/api/
+[restfulapi]: https://restfulapi.net/

--- a/exercises/roman-numerals/description.md
+++ b/exercises/roman-numerals/description.md
@@ -40,4 +40,6 @@ In Roman numerals 1990 is MCMXC:
 2000=MM
 8=VIII
 
-See also: [https://wiki.imperivm-romanvm.com/wiki/Roman_Numerals](https://wiki.imperivm-romanvm.com/wiki/Roman_Numerals)
+Learn more about [Roman numberals on Wikipedia][roman-numerals].
+
+[roman-numerals]: https://wiki.imperivm-romanvm.com/wiki/Roman_Numerals

--- a/exercises/sgf-parsing/description.md
+++ b/exercises/sgf-parsing/description.md
@@ -2,8 +2,7 @@
 
 Parsing a Smart Game Format string.
 
-[SGF](https://en.wikipedia.org/wiki/Smart_Game_Format) is a standard format for
-storing board game files, in particular go.
+[SGF][] is a standard format for storing board game files, in particular go.
 
 SGF is a fairly simple format. An SGF file usually contains a single
 tree of nodes where each node is a property list. The property list
@@ -75,4 +74,7 @@ between properties, nodes, etc will be in the tests.
 The exercise will have you parse an SGF string and return a tree
 structure of properties. You do not need to encode knowledge about the
 data types of properties, just use the rules for the
-[text](http://www.red-bean.com/sgf/sgf4.html#text) type everywhere.
+[text][sgf-text] type everywhere.
+
+[SGF]: https://en.wikipedia.org/wiki/Smart_Game_Format
+[sgf-text]: http://www.red-bean.com/sgf/sgf4.html#text

--- a/exercises/sieve/description.md
+++ b/exercises/sieve/description.md
@@ -20,11 +20,12 @@ Repeat until you have processed each number in your range.
 When the algorithm terminates, all the numbers in the list that have not
 been marked are prime.
 
-The wikipedia article has a useful graphic that explains the algorithm:
-[https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes](https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes)
+[This wikipedia article][eratosthenes] has a useful graphic that explains the algorithm.
 
 Notice that this is a very specific algorithm, and the tests don't check
 that you've implemented the algorithm, only that you've come up with the
 correct list of primes. A good first test is to check that you do not use
 division or remainder operations (div, /, mod or % depending on the
 language).
+
+[eratosthenes]: https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes

--- a/exercises/space-age/description.md
+++ b/exercises/space-age/description.md
@@ -14,5 +14,6 @@ Given an age in seconds, calculate how old someone would be on:
 So if you were told someone were 1,000,000,000 seconds old, you should
 be able to say that they're 31.69 Earth-years old.
 
-If you're wondering why Pluto didn't make the cut, go watch [this
-YouTube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).
+If you're wondering why Pluto didn't make the cut, go watch [this YouTube video][pluto-video].
+
+[pluto-video]: http://www.youtube.com/watch?v=Z_2gbGXzFbs

--- a/exercises/square-root/description.md
+++ b/exercises/square-root/description.md
@@ -4,6 +4,9 @@ Given a natural radicand, return its square root.
 
 Note that the term "radicand" refers to the number for which the root is to be determined. That is, it is the number under the root symbol.
 
-Check out the Wikipedia pages on [square root](https://en.wikipedia.org/wiki/Square_root) and [methods of computing square roots](https://en.wikipedia.org/wiki/Methods_of_computing_square_roots).
+Check out the Wikipedia pages on [square root][square-root] and [methods of computing square roots][computing-square-roots].
 
 Recall also that natural numbers are positive real whole numbers (i.e. 1, 2, 3 and up).
+
+[square-root]: https://en.wikipedia.org/wiki/Square_root
+[computing-square-roots]: https://en.wikipedia.org/wiki/Methods_of_computing_square_roots

--- a/exercises/state-of-tic-tac-toe/description.md
+++ b/exercises/state-of-tic-tac-toe/description.md
@@ -1,6 +1,6 @@
 # Description
 
-In this exercise, you're going to implement a program that determines the state of a [tic-tac-toe](https://en.wikipedia.org/wiki/Tic-tac-toe) game.
+In this exercise, you're going to implement a program that determines the state of a [tic-tac-toe][] game.
 (_You may also know the game as "noughts and crosses" or "Xs and Os"._)
 
 The games is played on a 3×3 grid.
@@ -97,3 +97,5 @@ ___|___|___
    |   |
    |   |
 ```
+
+[tic-tac-toe]: https://en.wikipedia.org/wiki/Tic-tac-toe

--- a/exercises/transpose/description.md
+++ b/exercises/transpose/description.md
@@ -17,7 +17,7 @@ BE
 CF
 ```
 
-Rows become columns and columns become rows. See <https://en.wikipedia.org/wiki/Transpose>.
+Rows become columns and columns become rows. See [transpose][].
 
 If the input has rows of different lengths, this is to be solved as follows:
 
@@ -57,3 +57,5 @@ BE
 In general, all characters from the input should also be present in the transposed output.
 That means that if a column in the input text contains only spaces on its bottom-most row(s),
 the corresponding output row should contain the spaces in its right-most column(s).
+
+[transpose]: https://en.wikipedia.org/wiki/Transpose

--- a/exercises/triangle/description.md
+++ b/exercises/triangle/description.md
@@ -24,4 +24,6 @@ b + c ≥ a
 a + c ≥ b
 ```
 
-See [Triangle Inequality](https://en.wikipedia.org/wiki/Triangle_inequality).
+See [Triangle Inequality][triangle-inequality]
+
+[triangle-inequality]: https://en.wikipedia.org/wiki/Triangle_inequality

--- a/exercises/two-bucket/description.md
+++ b/exercises/two-bucket/description.md
@@ -34,4 +34,6 @@ Bucket one can hold up to 7 liters, and bucket two can hold up to 11 liters. Let
 Another Example:
 Bucket one can hold 3 liters, and bucket two can hold up to 5 liters.  You are told you must start with bucket one.  So your first action is to fill bucket one.  You choose to empty bucket one for your second action.  For your third action, you may not fill bucket two, because this violates the third rule -- you may not end up in a state after any action where the starting bucket is empty and the other bucket is full.
 
-Written with <3 at [Fullstack Academy](http://www.fullstackacademy.com/) by Lindsay Levine.
+Written with <3 at [Fullstack Academy][fulstack] by Lindsay Levine.
+
+[fullstack]: http://www.fullstackacademy.com/

--- a/exercises/variable-length-quantity/description.md
+++ b/exercises/variable-length-quantity/description.md
@@ -2,7 +2,7 @@
 
 Implement variable length quantity encoding and decoding.
 
-The goal of this exercise is to implement [VLQ](https://en.wikipedia.org/wiki/Variable-length_quantity) encoding/decoding.
+The goal of this exercise is to implement [VLQ][vlq] encoding/decoding.
 
 In short, the goal of this encoding is to encode integer values in a way that would save bytes.
 Only the first 7 bits of each byte are significant (right-justified; sort of like an ASCII byte).
@@ -30,3 +30,5 @@ Here are examples of integers as 32-bit values, and the variable length quantiti
 08000000          C0 80 80 00
 0FFFFFFF          FF FF FF 7F
 ```
+
+[vlq]: https://en.wikipedia.org/wiki/Variable-length_quantity

--- a/exercises/yacht/description.md
+++ b/exercises/yacht/description.md
@@ -1,6 +1,6 @@
 # Description
 
-The dice game [Yacht](https://en.wikipedia.org/wiki/Yacht_(dice_game)) is from
+The dice game [Yacht][] is from
 the same family as Poker Dice, Generala and particularly Yahtzee, of which it
 is a precursor. In the game, five dice are rolled and the result can be entered
 in any of twelve categories. The score of a throw of the dice depends on
@@ -34,3 +34,5 @@ the score of the dice for that category. If the dice do not satisfy the requirem
 of the category your solution should return 0. You can assume that five values
 will always be presented, and the value of each will be between one and six
 inclusively. You should not assume that the dice are ordered.
+
+[Yacht]: https://en.wikipedia.org/wiki/Yacht_(dice_game)

--- a/exercises/zipper/description.md
+++ b/exercises/zipper/description.md
@@ -2,7 +2,7 @@
 
 Creating a zipper for a binary tree.
 
-[Zippers](https://en.wikipedia.org/wiki/Zipper_%28data_structure%29) are
+[Zippers][] are
 a purely functional way of navigating within a data structure and
 manipulating it.  They essentially contain a data structure and a
 pointer into that data structure (called the focus).
@@ -26,3 +26,5 @@ list of child nodes) a zipper might support these operations:
 - `delete` (removes the focus node and all subtrees, focus moves to the
   `next` node if possible otherwise to the `prev` node if possible,
   otherwise to the parent node, returns a new zipper)
+
+[Zippers]: https://en.wikipedia.org/wiki/Zipper_%28data_structure%29


### PR DESCRIPTION
Exercism's Markdown Specification says to use reference links instead of inline markdown links.

This goes through all the description.md files for all the exercises and converts inline markdown links to reference links.

There's no pressure for maintainers to sync these changes; rather they're nice to have for future changes, and will make it easier to do other cleanup such as switching to one sentence per line (also preferred in the Exercism markdown specification https://exercism.org/docs/building/markdown/markdown#layout)