### PR TITLE
sgf-parsing: Add warning about string literals

### DIFF
--- a/exercises/sgf-parsing/description.md
+++ b/exercises/sgf-parsing/description.md
@@ -64,6 +64,13 @@ newlines any whitespace character encountered is replaced with a single space
 character irrespective of if the original character is found in its escaped
 from or its unescaped from.
 
+Be careful not to get confused between:
+
+- The string as it is represented in a string literal in the tests
+- The string that is passed to the SGF parser
+
+Escape sequences in the string literals may have already been processed by the programming language's parser before they are passed to the SGF parser.
+
 There are a few more complexities to SGF (and parsing in general), which
 you can mostly ignore. You should assume that the input is encoded in
 UTF-8, the tests won't contain a charset property, so don't worry about


### PR DESCRIPTION
The test case added in 3c33c249121c16aa2a7fc3398a50349d8985f752 had to be very careful to specify the difference between the two. Add it to the description as well.