### PR TITLE
Normalize reference links

### DIFF
--- a/exercises/affine-cipher/description.md
+++ b/exercises/affine-cipher/description.md
@@ -52,7 +52,7 @@ The MMI of `a` is `x` such that the remainder after dividing `ax` by `m` is `1`:
 ax mod m = 1
 ```
 
-More information regarding how to find a Modular Multiplicative Inverse and what it means can be found in the [related Wikipedia article][MMI].
+More information regarding how to find a Modular Multiplicative Inverse and what it means can be found in the [related Wikipedia article][mmi].
 
 ## General Examples
 
@@ -70,5 +70,5 @@ Finding MMI for `a = 15`:
 - `(15 * 7) mod 26 = 1`, ie. `105 mod 26 = 1`
 - `7` is the MMI of `15 mod 26`
 
-[MMI]: https://en.wikipedia.org/wiki/Modular_multiplicative_inverse
+[mmi]: https://en.wikipedia.org/wiki/Modular_multiplicative_inverse
 [coprime-integers]: https://en.wikipedia.org/wiki/Coprime_integers

--- a/exercises/alphametics/description.md
+++ b/exercises/alphametics/description.md
@@ -2,7 +2,7 @@
 
 Write a function to solve alphametics puzzles.
 
-[Alphametics][] is a puzzle where letters in words are replaced with numbers.
+[Alphametics][alphametics] is a puzzle where letters in words are replaced with numbers.
 
 For example `SEND + MORE = MONEY`:
 
@@ -30,4 +30,4 @@ a multi-digit number must not be zero.
 
 Write a function to solve alphametics puzzles.
 
-[Alphametics]: https://en.wikipedia.org/wiki/Alphametics
+[alphametics]: https://en.wikipedia.org/wiki/Alphametics

--- a/exercises/connect/description.md
+++ b/exercises/connect/description.md
@@ -2,7 +2,7 @@
 
 Compute the result for a game of Hex / Polygon.
 
-The abstract boardgame known as [Hex][] / Polygon /
+The abstract boardgame known as [Hex][hex] / Polygon /
 CON-TAC-TIX is quite simple in rules, though complex in practice. Two players
 place stones on a parallelogram with hexagonal fields. The player to connect his/her
 stones to the opposite side first wins. The four sides of the parallelogram are
@@ -29,4 +29,4 @@ The boards look like this:
 the above example `O` has made a connection from left to right but nobody has
 won since `O` didn't connect top and bottom.
 
-[Hex]: https://en.wikipedia.org/wiki/Hex_%28board_game%29
+[hex]: https://en.wikipedia.org/wiki/Hex_%28board_game%29

--- a/exercises/darts/description.md
+++ b/exercises/darts/description.md
@@ -2,7 +2,7 @@
 
 Write a function that returns the earned points in a single toss of a Darts game.
 
-[Darts][] is a game where players
+[Darts][darts] is a game where players
 throw darts at a [target][darts-target].
 
 In our particular instance of the game, the target rewards 4 different amounts of points, depending on where the dart lands:
@@ -16,8 +16,8 @@ The outer circle has a radius of 10 units (this is equivalent to the total radiu
 
 Write a function that given a point in the target (defined by its [Cartesian coordinates][cartesian-coordinates] `x` and `y`, where `x` and `y` are [real][real-numbers]), returns the correct amount earned by a dart landing at that point.
 
- [Darts]: https://en.wikipedia.org/wiki/Darts
- [darts-target]: https://en.wikipedia.org/wiki/Darts#/media/File:Darts_in_a_dartboard.jpg
- [concentric]: http://mathworld.wolfram.com/ConcentricCircles.html
- [cartesian-coordinates]: https://www.mathsisfun.com/data/cartesian-coordinates.html
- [real-numbers]: https://www.mathsisfun.com/numbers/real-numbers.html
+[darts]: https://en.wikipedia.org/wiki/Darts
+[darts-target]: https://en.wikipedia.org/wiki/Darts#/media/File:Darts_in_a_dartboard.jpg
+[concentric]: http://mathworld.wolfram.com/ConcentricCircles.html
+[cartesian-coordinates]: https://www.mathsisfun.com/data/cartesian-coordinates.html
+[real-numbers]: https://www.mathsisfun.com/numbers/real-numbers.html

--- a/exercises/dnd-character/description.md
+++ b/exercises/dnd-character/description.md
@@ -1,6 +1,6 @@
 # Description
 
-For a game of [Dungeons & Dragons][DND], each player starts by generating a
+For a game of [Dungeons & Dragons][dnd], each player starts by generating a
 character they can play with. This character has, among other things, six
 abilities; strength, dexterity, constitution, intelligence, wisdom and
 charisma. These six abilities have scores that are determined randomly. You
@@ -27,7 +27,7 @@ Because constitution is 3, the constitution modifier is -4 and the hitpoints are
 ## Notes
 
 Most programming languages feature (pseudo-)random generators, but few
-programming languages are designed to roll dice. One such language is [Troll].
+programming languages are designed to roll dice. One such language is [Troll][troll].
 
-[DND]: https://en.wikipedia.org/wiki/Dungeons_%26_Dragons
-[Troll]: http://hjemmesider.diku.dk/~torbenm/Troll/
+[dnd]: https://en.wikipedia.org/wiki/Dungeons_%26_Dragons
+[troll]: http://hjemmesider.diku.dk/~torbenm/Troll/

--- a/exercises/dot-dsl/description.md
+++ b/exercises/dot-dsl/description.md
@@ -9,7 +9,7 @@ One problem area where they are applied are complex customizations/configuration
 
 For example the [DOT language][dot-language] allows
 you to write a textual description of a graph which is then transformed into a picture by one of
-the [Graphviz][] tools (such as `dot`). A simple graph looks like this:
+the [Graphviz][graphviz] tools (such as `dot`). A simple graph looks like this:
 
     graph {
         graph [bgcolor="yellow"]
@@ -33,5 +33,5 @@ found [here][fowler-dsl].
 
 [dsl]: https://en.wikipedia.org/wiki/Domain-specific_language
 [dot-language]: https://en.wikipedia.org/wiki/DOT_(graph_description_language)
-[Graphviz]: http://graphviz.org/
+[graphviz]: http://graphviz.org/
 [fowler-dsl]: https://martinfowler.com/bliki/DomainSpecificLanguage.html

--- a/exercises/forth/description.md
+++ b/exercises/forth/description.md
@@ -2,7 +2,7 @@
 
 Implement an evaluator for a very simple subset of Forth.
 
-[Forth][]
+[Forth][forth]
 is a stack-based programming language. Implement a very basic evaluator
 for a small subset of Forth.
 
@@ -25,4 +25,4 @@ enough.)
 
 Words are case-insensitive.
 
-[Forth]: https://en.wikipedia.org/wiki/Forth_%28programming_language%29
+[forth]: https://en.wikipedia.org/wiki/Forth_%28programming_language%29

--- a/exercises/hangman/description.md
+++ b/exercises/hangman/description.md
@@ -2,7 +2,7 @@
 
 Implement the logic of the hangman game using functional reactive programming.
 
-[Hangman][] is a simple word guessing game.
+[Hangman][hangman] is a simple word guessing game.
 
 [Functional Reactive Programming][frp] is a way to write interactive
 programs. It differs from the usual perspective in that instead of
@@ -14,5 +14,5 @@ Implement the basic logic behind hangman using functional reactive
 programming.  You'll need to install an FRP library for this, this will
 be described in the language/track specific files of the exercise.
 
-[Hangman]: https://en.wikipedia.org/wiki/Hangman_%28game%29
+[hangman]: https://en.wikipedia.org/wiki/Hangman_%28game%29
 [frp]: https://en.wikipedia.org/wiki/Functional_reactive_programming

--- a/exercises/house/description.md
+++ b/exercises/house/description.md
@@ -9,7 +9,7 @@ Recite the nursery rhyme 'This is the House that Jack Built'.
 > Furthermore, embedding also allows us to construct an infinitely long
 > structure, in theory anyway.
 
-- [papyr.com][]
+- [papyr.com][papyr]
 
 The nursery rhyme reads as follows:
 
@@ -105,4 +105,4 @@ that ate the malt
 that lay in the house that Jack built.
 ```
 
-[papyr.com]: http://papyr.com/hypertextbooks/grammar/ph_noun.htm
+[papyr]: http://papyr.com/hypertextbooks/grammar/ph_noun.htm

--- a/exercises/paasio/description.md
+++ b/exercises/paasio/description.md
@@ -2,7 +2,7 @@
 
 Report network IO statistics.
 
-You are writing a [PaaS][], and you need a way to bill customers based
+You are writing a [PaaS][paas], and you need a way to bill customers based
 on network and filesystem usage.
 
 Create a wrapper for network connections and files that can report IO
@@ -11,4 +11,4 @@ statistics. The wrapper must report:
 - The total number of bytes read/written.
 - The total number of read/write operations.
 
-[PaaS]: http://en.wikipedia.org/wiki/Platform_as_a_service
+[paas]: http://en.wikipedia.org/wiki/Platform_as_a_service

--- a/exercises/rest-api/description.md
+++ b/exercises/rest-api/description.md
@@ -4,7 +4,7 @@ Implement a RESTful API for tracking IOUs.
 
 Four roommates have a habit of borrowing money from each other frequently, and have trouble remembering who owes whom, and how much.
 
-Your task is to implement a simple [RESTful API][restful-wikipedia] that receives [IOU][]s as POST requests, and can deliver specified summary information via GET requests.
+Your task is to implement a simple [RESTful API][restful-wikipedia] that receives [IOU][iou]s as POST requests, and can deliver specified summary information via GET requests.
 
 ## API Specification
 
@@ -42,7 +42,7 @@ Your task is to implement a simple [RESTful API][restful-wikipedia] that receive
   - [Reddit][reddit-rest]
 
 [restful-wikipedia]: https://en.wikipedia.org/wiki/Representational_state_transfer
-[IOU]: https://en.wikipedia.org/wiki/IOU
+[iou]: https://en.wikipedia.org/wiki/IOU
 [github-rest]: https://developer.github.com/v3/
 [reddit-rest]: https://www.reddit.com/dev/api/
 [restfulapi]: https://restfulapi.net/

--- a/exercises/sgf-parsing/description.md
+++ b/exercises/sgf-parsing/description.md
@@ -2,7 +2,7 @@
 
 Parsing a Smart Game Format string.
 
-[SGF][] is a standard format for storing board game files, in particular go.
+[SGF][sgf] is a standard format for storing board game files, in particular go.
 
 SGF is a fairly simple format. An SGF file usually contains a single
 tree of nodes where each node is a property list. The property list
@@ -76,5 +76,5 @@ structure of properties. You do not need to encode knowledge about the
 data types of properties, just use the rules for the
 [text][sgf-text] type everywhere.
 
-[SGF]: https://en.wikipedia.org/wiki/Smart_Game_Format
+[sgf]: https://en.wikipedia.org/wiki/Smart_Game_Format
 [sgf-text]: http://www.red-bean.com/sgf/sgf4.html#text

--- a/exercises/simple-cipher/description.md
+++ b/exercises/simple-cipher/description.md
@@ -25,7 +25,7 @@ recognize the few words that they did know.
 Your task is to create a simple shift cipher like the Caesar Cipher.
 This image is a great example of the Caesar Cipher:
 
-![Caesar Cipher][1]
+![Caesar Cipher][img-caesar-cipher]
 
 For example:
 
@@ -75,5 +75,5 @@ If you want to go farther in this field, the questions begin to be about
 how we can exchange keys in a secure way. Take a look at [Diffie-Hellman
 on Wikipedia][dh] for one of the first implementations of this scheme.
 
-[1]: https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Caesar_cipher_left_shift_of_3.svg/320px-Caesar_cipher_left_shift_of_3.svg.png
+[img-caesar-cipher]: https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Caesar_cipher_left_shift_of_3.svg/320px-Caesar_cipher_left_shift_of_3.svg.png
 [dh]: http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange

--- a/exercises/yacht/description.md
+++ b/exercises/yacht/description.md
@@ -1,6 +1,6 @@
 # Description
 
-The dice game [Yacht][] is from
+The dice game [Yacht][yacht] is from
 the same family as Poker Dice, Generala and particularly Yahtzee, of which it
 is a precursor. In the game, five dice are rolled and the result can be entered
 in any of twelve categories. The score of a throw of the dice depends on
@@ -35,4 +35,4 @@ of the category your solution should return 0. You can assume that five values
 will always be presented, and the value of each will be between one and six
 inclusively. You should not assume that the dice are ordered.
 
-[Yacht]: https://en.wikipedia.org/wiki/Yacht_(dice_game)
+[yacht]: https://en.wikipedia.org/wiki/Yacht_(dice_game)

--- a/exercises/zipper/description.md
+++ b/exercises/zipper/description.md
@@ -2,7 +2,7 @@
 
 Creating a zipper for a binary tree.
 
-[Zippers][] are
+[Zippers][zipper] are
 a purely functional way of navigating within a data structure and
 manipulating it.  They essentially contain a data structure and a
 pointer into that data structure (called the focus).
@@ -27,4 +27,4 @@ list of child nodes) a zipper might support these operations:
   `next` node if possible otherwise to the `prev` node if possible,
   otherwise to the parent node, returns a new zipper)
 
-[Zippers]: https://en.wikipedia.org/wiki/Zipper_%28data_structure%29
+[zipper]: https://en.wikipedia.org/wiki/Zipper_%28data_structure%29


### PR DESCRIPTION
Use only lowercase ASCII letters and hyphens in markdown reference links.

In #2113 @wolf99 questioned the use of the "empty" reference links (example below) and wondered whether we should standardize on using `lower-case-keys` for references.

```
Something about [Alphametics][].

[Alphametics]: https://example.com/alphametics
```

I like the suggestion, so I have changed reference links that do not have this format.

