### PR TITLE
Additional tests for straights

### DIFF
--- a/exercises/poker/canonical-data.json
+++ b/exercises/poker/canonical-data.json
@@ -169,7 +169,7 @@
       "expected": ["4D AH 3S 2D 5C"]
     },
     {
-      "uuid": "?",
+      "uuid": "e214b7df-dcba-45d3-a2e5-342d8c46c286",
       "description": "aces cannot be in the middle of a straight (Q K A 2 3)",
       "property": "bestHands",
       "input": {
@@ -286,7 +286,7 @@
       "expected": ["5S 7S 8S 9S 6S"]
     },
     {
-      "uuid": "?",
+      "uuid": "d9629e22-c943-460b-a951-2134d1b43346",
       "description": "aces can end a straight flush (10 J Q K A)",
       "property": "bestHands",
       "input": {
@@ -295,7 +295,7 @@
       "expected": ["10C JC QC KC AC"]
     },
     {
-      "uuid": "?",
+      "uuid": "05d5ede9-64a5-4678-b8ae-cf4c595dc824",
       "description": "aces can start a straight flush (A 2 3 4 5)",
       "property": "bestHands",
       "input": {
@@ -304,7 +304,7 @@
       "expected": ["4H AH 3H 2H 5H"]
     },
     {
-      "uuid": "?",
+      "uuid": "ad655466-6d04-49e8-a50c-0043c3ac18ff",
       "description": "aces cannot be in the middle of a straight flush (Q K A 2 3)",
       "property": "bestHands",
       "input": {
@@ -313,7 +313,7 @@
       "expected": ["2C AC QC 10C KC"]
     },
     {
-      "uuid": "?",
+      "uuid": "be620e09-0397-497b-ac37-d1d7a4464cfc",
       "description": "even though an ace is usually high, a 5-high straight flush is the lowest-scoring straight flush",
       "property": "bestHands",
       "input": {

--- a/exercises/poker/canonical-data.json
+++ b/exercises/poker/canonical-data.json
@@ -277,15 +277,6 @@
       "expected": ["7S 8S 9S 6S 10S"]
     },
     {
-      "uuid": "d0927f70-5aec-43db-aed8-1cbd1b6ee9ad",
-      "description": "both hands have a straight flush, tie goes to highest-ranked card",
-      "property": "bestHands",
-      "input": {
-        "hands": ["4H 6H 7H 8H 5H", "5S 7S 8S 9S 6S"]
-      },
-      "expected": ["5S 7S 8S 9S 6S"]
-    },
-    {
       "uuid": "d9629e22-c943-460b-a951-2134d1b43346",
       "description": "aces can end a straight flush (10 J Q K A)",
       "property": "bestHands",
@@ -311,6 +302,15 @@
         "hands": ["2C AC QC 10C KC", "QH KH AH 2H 3H"]
       },
       "expected": ["2C AC QC 10C KC"]
+    },
+    {
+      "uuid": "d0927f70-5aec-43db-aed8-1cbd1b6ee9ad",
+      "description": "both hands have a straight flush, tie goes to highest-ranked card",
+      "property": "bestHands",
+      "input": {
+        "hands": ["4H 6H 7H 8H 5H", "5S 7S 8S 9S 6S"]
+      },
+      "expected": ["5S 7S 8S 9S 6S"]
     },
     {
       "uuid": "be620e09-0397-497b-ac37-d1d7a4464cfc",

--- a/exercises/poker/canonical-data.json
+++ b/exercises/poker/canonical-data.json
@@ -169,6 +169,15 @@
       "expected": ["4D AH 3S 2D 5C"]
     },
     {
+      "uuid": "?",
+      "description": "aces cannot be in the middle of a straight (Q K A 2 3)",
+      "property": "bestHands",
+      "input": {
+        "hands": ["2C 3D 7H 5H 2S", "QS KH AC 2D 3S"]
+      },
+      "expected": ["2C 3D 7H 5H 2S"]
+    },
+    {
       "uuid": "6980c612-bbff-4914-b17a-b044e4e69ea1",
       "description": "both hands with a straight, tie goes to highest ranked card",
       "property": "bestHands",
@@ -269,12 +278,48 @@
     },
     {
       "uuid": "d0927f70-5aec-43db-aed8-1cbd1b6ee9ad",
-      "description": "both hands have straight flush, tie goes to highest-ranked card",
+      "description": "both hands have a straight flush, tie goes to highest-ranked card",
       "property": "bestHands",
       "input": {
         "hands": ["4H 6H 7H 8H 5H", "5S 7S 8S 9S 6S"]
       },
       "expected": ["5S 7S 8S 9S 6S"]
-    }
+    },
+    {
+      "uuid": "?",
+      "description": "aces can end a straight flush (10 J Q K A)",
+      "property": "bestHands",
+      "input": {
+        "hands": ["KC AH AS AD AC", "10C JC QC KC AC"]
+      },
+      "expected": ["10C JC QC KC AC"]
+    },
+    {
+      "uuid": "?",
+      "description": "aces can start a straight flush (A 2 3 4 5)",
+      "property": "bestHands",
+      "input": {
+        "hands": ["KS AH AS AD AC", "4H AH 3H 2H 5H"]
+      },
+      "expected": ["4H AH 3H 2H 5H"]
+    },
+    {
+      "uuid": "?",
+      "description": "aces cannot be in the middle of a straight flush (Q K A 2 3)",
+      "property": "bestHands",
+      "input": {
+        "hands": ["2C AC QC 10C KC", "QH KH AH 2H 3H"]
+      },
+      "expected": ["2C AC QC 10C KC"]
+    },
+    {
+      "uuid": "?",
+      "description": "even though an ace is usually high, a 5-high straight flush is the lowest-scoring straight flush",
+      "property": "bestHands",
+      "input": {
+        "hands": ["2H 3H 4H 5H 6H", "4D AD 3D 2D 5D"]
+      },
+      "expected": ["2H 3H 4H 5H 6H"]
+    },
   ]
 }

--- a/exercises/poker/canonical-data.json
+++ b/exercises/poker/canonical-data.json
@@ -320,6 +320,6 @@
         "hands": ["2H 3H 4H 5H 6H", "4D AD 3D 2D 5D"]
       },
       "expected": ["2H 3H 4H 5H 6H"]
-    },
+    }
   ]
 }


### PR DESCRIPTION
Additional tests for straights with the same tests also for straight flushes. (Originally proposed in the Rust track: https://github.com/exercism/rust/pull/1555)