### PR TITLE
Reformat one sentence per line

### DIFF
--- a/exercises/accumulate/description.md
+++ b/exercises/accumulate/description.md
@@ -1,9 +1,6 @@
 # Description
 
-Implement the `accumulate` operation, which, given a collection and an
-operation to perform on each element of the collection, returns a new
-collection containing the result of applying that operation to each element of
-the input collection.
+Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.
 
 Given the collection of numbers:
 
@@ -21,6 +18,5 @@ Check out the test suite to see the expected function signature.
 
 ## Restrictions
 
-Keep your hands off that collect/map/fmap/whatchamacallit functionality
-provided by your standard library!
+Keep your hands off that collect/map/fmap/whatchamacallit functionality provided by your standard library!
 Solve this one yourself using other basic tools instead.

--- a/exercises/all-your-base/description.md
+++ b/exercises/all-your-base/description.md
@@ -2,8 +2,8 @@
 
 Convert a number, represented as a sequence of digits in one base, to any other base.
 
-Implement general base conversion. Given a number in base **a**,
-represented as a sequence of digits, convert it to base **b**.
+Implement general base conversion.
+Given a number in base **a**, represented as a sequence of digits, convert it to base **b**.
 
 ## Note
 
@@ -12,8 +12,7 @@ represented as a sequence of digits, convert it to base **b**.
 
 ## About [Positional Notation][positional-notation]
 
-In positional notation, a number in base **b** can be understood as a linear
-combination of powers of **b**.
+In positional notation, a number in base **b** can be understood as a linear combination of powers of **b**.
 
 The number 42, *in base 10*, means:
 

--- a/exercises/allergies/description.md
+++ b/exercises/allergies/description.md
@@ -2,9 +2,7 @@
 
 Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.
 
-An allergy test produces a single numeric score which contains the
-information about all the allergies the person has (that they were
-tested for).
+An allergy test produces a single numeric score which contains the information about all the allergies the person has (that they were tested for).
 
 The list of items (and their value) that were tested are:
 
@@ -24,7 +22,6 @@ Now, given just that score of 34, your program should be able to say:
 * Whether Tom is allergic to any one of those allergens listed above.
 * All the allergens Tom is allergic to.
 
-Note: a given score may include allergens **not** listed above (i.e.
-allergens that score 256, 512, 1024, etc.).  Your program should
-ignore those components of the score.  For example, if the allergy
-score is 257, your program should only report the eggs (1) allergy.
+Note: a given score may include allergens **not** listed above (i.e.  allergens that score 256, 512, 1024, etc.).
+Your program should ignore those components of the score.
+For example, if the allergy score is 257, your program should only report the eggs (1) allergy.

--- a/exercises/alphametics/description.md
+++ b/exercises/alphametics/description.md
@@ -22,11 +22,9 @@ Replacing these with valid numbers gives:
 1 0 6 5 2
 ```
 
-This is correct because every letter is replaced by a different number and the
-words, translated into numbers, then make a valid sum.
+This is correct because every letter is replaced by a different number and the words, translated into numbers, then make a valid sum.
 
-Each letter must represent a different digit, and the leading digit of
-a multi-digit number must not be zero.
+Each letter must represent a different digit, and the leading digit of a multi-digit number must not be zero.
 
 Write a function to solve alphametics puzzles.
 

--- a/exercises/atbash-cipher/description.md
+++ b/exercises/atbash-cipher/description.md
@@ -2,10 +2,8 @@
 
 Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.
 
-The Atbash cipher is a simple substitution cipher that relies on
-transposing all the letters in the alphabet such that the resulting
-alphabet is backwards. The first letter is replaced with the last
-letter, the second with the second-last, and so on.
+The Atbash cipher is a simple substitution cipher that relies on transposing all the letters in the alphabet such that the resulting alphabet is backwards.
+The first letter is replaced with the last letter, the second with the second-last, and so on.
 
 An Atbash cipher for the Latin alphabet would be as follows:
 
@@ -14,12 +12,10 @@ Plain:  abcdefghijklmnopqrstuvwxyz
 Cipher: zyxwvutsrqponmlkjihgfedcba
 ```
 
-It is a very weak cipher because it only has one possible key, and it is
-a simple mono-alphabetic substitution cipher. However, this may not have
-been an issue in the cipher's time.
+It is a very weak cipher because it only has one possible key, and it is a simple mono-alphabetic substitution cipher.
+However, this may not have been an issue in the cipher's time.
 
-Ciphertext is written out in groups of fixed length, the traditional group size
-being 5 letters, leaving numbers unchanged, and punctuation is excluded.
+Ciphertext is written out in groups of fixed length, the traditional group size being 5 letters, leaving numbers unchanged, and punctuation is excluded.
 This is to make it harder to guess things based on word boundaries.
 All text will be encoded as lowercase letters.
 

--- a/exercises/bank-account/description.md
+++ b/exercises/bank-account/description.md
@@ -1,14 +1,12 @@
 # Description
 
-Simulate a bank account supporting opening/closing, withdrawals, and deposits
-of money. Watch out for concurrent transactions!
+Simulate a bank account supporting opening/closing, withdrawals, and deposits of money.
+Watch out for concurrent transactions!
 
-A bank account can be accessed in multiple ways. Clients can make
-deposits and withdrawals using the internet, mobile phones, etc. Shops
-can charge against the account.
+A bank account can be accessed in multiple ways.
+Clients can make deposits and withdrawals using the internet, mobile phones, etc.
+Shops can charge against the account.
 
-Create an account that can be accessed from multiple threads/processes
-(terminology depends on your programming language).
+Create an account that can be accessed from multiple threads/processes (terminology depends on your programming language).
 
-It should be possible to close an account; operations against a closed
-account must fail.
+It should be possible to close an account; operations against a closed account must fail.

--- a/exercises/binary-search-tree/description.md
+++ b/exercises/binary-search-tree/description.md
@@ -2,29 +2,22 @@
 
 Insert and search for numbers in a binary tree.
 
-When we need to represent sorted data, an array does not make a good
-data structure.
+When we need to represent sorted data, an array does not make a good data structure.
 
-Say we have the array `[1, 3, 4, 5]`, and we add 2 to it so it becomes
-`[1, 3, 4, 5, 2]` now we must sort the entire array again! We can
-improve on this by realizing that we only need to make space for the new
-item `[1, nil, 3, 4, 5]`, and then adding the item in the space we
-added. But this still requires us to shift many elements down by one.
+Say we have the array `[1, 3, 4, 5]`, and we add 2 to it so it becomes `[1, 3, 4, 5, 2]`.
+Now we must sort the entire array again!
+We can improve on this by realizing that we only need to make space for the new item `[1, nil, 3, 4, 5]`, and then adding the item in the space we added.
+But this still requires us to shift many elements down by one.
 
-Binary Search Trees, however, can operate on sorted data much more
-efficiently.
+Binary Search Trees, however, can operate on sorted data much more efficiently.
 
-A binary search tree consists of a series of connected nodes. Each node
-contains a piece of data (e.g. the number 3), a variable named `left`,
-and a variable named `right`. The `left` and `right` variables point at
-`nil`, or other nodes. Since these other nodes in turn have other nodes
-beneath them, we say that the left and right variables are pointing at
-subtrees. All data in the left subtree is less than or equal to the
-current node's data, and all data in the right subtree is greater than
-the current node's data.
+A binary search tree consists of a series of connected nodes.
+Each node contains a piece of data (e.g. the number 3), a variable named `left`, and a variable named `right`.
+The `left` and `right` variables point at `nil`, or other nodes.
+Since these other nodes in turn have other nodes beneath them, we say that the left and right variables are pointing at subtrees.
+All data in the left subtree is less than or equal to the current node's data, and all data in the right subtree is greater than the current node's data.
 
-For example, if we had a node containing the data 4, and we added the
-data 2, our tree would look like this:
+For example, if we had a node containing the data 4, and we added the data 2, our tree would look like this:
 
       4
      /

--- a/exercises/binary-search/description.md
+++ b/exercises/binary-search/description.md
@@ -2,34 +2,23 @@
 
 Implement a binary search algorithm.
 
-Searching a sorted collection is a common task. A dictionary is a sorted
-list of word definitions. Given a word, one can find its definition. A
-telephone book is a sorted list of people's names, addresses, and
-telephone numbers. Knowing someone's name allows one to quickly find
-their telephone number and address.
+Searching a sorted collection is a common task.
+A dictionary is a sorted list of word definitions.
+Given a word, one can find its definition.
+A telephone book is a sorted list of people's names, addresses, and telephone numbers.
+Knowing someone's name allows one to quickly find their telephone number and address.
 
-If the list to be searched contains more than a few items (a dozen, say)
-a binary search will require far fewer comparisons than a linear search,
-but it imposes the requirement that the list be sorted.
+If the list to be searched contains more than a few items (a dozen, say) a binary search will require far fewer comparisons than a linear search, but it imposes the requirement that the list be sorted.
 
-In computer science, a binary search or half-interval search algorithm
-finds the position of a specified input value (the search "key") within
-an array sorted by key value.
+In computer science, a binary search or half-interval search algorithm finds the position of a specified input value (the search "key") within an array sorted by key value.
 
-In each step, the algorithm compares the search key value with the key
-value of the middle element of the array.
+In each step, the algorithm compares the search key value with the key value of the middle element of the array.
 
-If the keys match, then a matching element has been found and its index,
-or position, is returned.
+If the keys match, then a matching element has been found and its index, or position, is returned.
 
-Otherwise, if the search key is less than the middle element's key, then
-the algorithm repeats its action on the sub-array to the left of the
-middle element or, if the search key is greater, on the sub-array to the
-right.
+Otherwise, if the search key is less than the middle element's key, then the algorithm repeats its action on the sub-array to the left of the middle element or, if the search key is greater, on the sub-array to the right.
 
-If the remaining array to be searched is empty, then the key cannot be
-found in the array and a special "not found" indication is returned.
+If the remaining array to be searched is empty, then the key cannot be found in the array and a special "not found" indication is returned.
 
-A binary search halves the number of items to check with each iteration,
-so locating an item (or determining its absence) takes logarithmic time.
+A binary search halves the number of items to check with each iteration, so locating an item (or determining its absence) takes logarithmic time.
 A binary search is a dichotomic divide and conquer search algorithm.

--- a/exercises/binary/description.md
+++ b/exercises/binary/description.md
@@ -2,9 +2,9 @@
 
 Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles.
 
-Implement binary to decimal conversion. Given a binary input
-string, your program should produce a decimal output. The
-program should handle invalid inputs.
+Implement binary to decimal conversion.
+Given a binary input string, your program should produce a decimal output.
+The program should handle invalid inputs.
 
 ## Note
 
@@ -15,8 +15,7 @@ program should handle invalid inputs.
 
 Decimal is a base-10 system.
 
-A number 23 in base 10 notation can be understood
-as a linear combination of powers of 10:
+A number 23 in base 10 notation can be understood as a linear combination of powers of 10:
 
 - The rightmost digit gets multiplied by 10^0 = 1
 - The next number gets multiplied by 10^1 = 10

--- a/exercises/bob/description.md
+++ b/exercises/bob/description.md
@@ -1,6 +1,7 @@
 # Description
 
-Bob is a lackadaisical teenager. In conversation, his responses are very limited.
+Bob is a lackadaisical teenager.
+In conversation, his responses are very limited.
 
 Bob answers 'Sure.' if you ask him a question, such as "How are you?".
 
@@ -8,8 +9,7 @@ He answers 'Whoa, chill out!' if you YELL AT HIM (in all capitals).
 
 He answers 'Calm down, I know what I'm doing!' if you yell a question at him.
 
-He says 'Fine. Be that way!' if you address him without actually saying
-anything.
+He says 'Fine. Be that way!' if you address him without actually saying anything.
 
 He answers 'Whatever.' to anything else.
 

--- a/exercises/book-store/description.md
+++ b/exercises/book-store/description.md
@@ -1,12 +1,10 @@
 # Description
 
-To try and encourage more sales of different books from a popular 5 book
-series, a bookshop has decided to offer discounts on multiple book purchases.
+To try and encourage more sales of different books from a popular 5 book series, a bookshop has decided to offer discounts on multiple book purchases.
 
 One copy of any of the five books costs $8.
 
-If, however, you buy two different books, you get a 5%
-discount on those two books.
+If, however, you buy two different books, you get a 5% discount on those two books.
 
 If you buy 3 different books, you get a 10% discount.
 
@@ -14,14 +12,9 @@ If you buy 4 different books, you get a 20% discount.
 
 If you buy all 5, you get a 25% discount.
 
-Note: that if you buy four books, of which 3 are
-different titles, you get a 10% discount on the 3 that
-form part of a set, but the fourth book still costs $8.
+Note: that if you buy four books, of which 3 are different titles, you get a 10% discount on the 3 that form part of a set, but the fourth book still costs $8.
 
-Your mission is to write a piece of code to calculate the
-price of any conceivable shopping basket (containing only
-books of the same series), giving as big a discount as
-possible.
+Your mission is to write a piece of code to calculate the price of any conceivable shopping basket (containing only books of the same series), giving as big a discount as possible.
 
 For example, how much does this basket of books cost?
 

--- a/exercises/bowling/description.md
+++ b/exercises/bowling/description.md
@@ -2,29 +2,24 @@
 
 Score a bowling game.
 
-Bowling is a game where players roll a heavy ball to knock down pins
-arranged in a triangle. Write code to keep track of the score
-of a game of bowling.
+Bowling is a game where players roll a heavy ball to knock down pins arranged in a triangle.
+Write code to keep track of the score of a game of bowling.
 
 ## Scoring Bowling
 
-The game consists of 10 frames. A frame is composed of one or two ball
-throws with 10 pins standing at frame initialization. There are three
-cases for the tabulation of a frame.
+The game consists of 10 frames.
+A frame is composed of one or two ball throws with 10 pins standing at frame initialization.
+There are three cases for the tabulation of a frame.
 
-* An open frame is where a score of less than 10 is recorded for the
-  frame. In this case the score for the frame is the number of pins
-  knocked down.
+* An open frame is where a score of less than 10 is recorded for the frame.
+  In this case the score for the frame is the number of pins knocked down.
 
-* A spare is where all ten pins are knocked down by the second
-  throw. The total value of a spare is 10 plus the number of pins
-  knocked down in their next throw.
+* A spare is where all ten pins are knocked down by the second throw.
+  The total value of a spare is 10 plus the number of pins knocked down in their next throw.
 
-* A strike is where all ten pins are knocked down by the first
-  throw. The total value of a strike is 10 plus the number of pins
-  knocked down in the next two throws. If a strike is immediately
-  followed by a second strike, then the value of the first strike
-  cannot be determined until the ball is thrown one more time.
+* A strike is where all ten pins are knocked down by the first throw.
+  The total value of a strike is 10 plus the number of pins knocked down in the next two throws.
+  If a strike is immediately followed by a second strike, then the value of the first strike cannot be determined until the ball is thrown one more time.
 
 Here is a three frame example:
 
@@ -40,11 +35,11 @@ Frame 3 is (9 + 0) = 9
 
 This means the current running total is 48.
 
-The tenth frame in the game is a special case. If someone throws a
-strike or a spare then they get a fill ball. Fill balls exist to
-calculate the total of the 10th frame. Scoring a strike or spare on
-the fill ball does not give the player more fill balls. The total
-value of the 10th frame is the total number of pins knocked down.
+The tenth frame in the game is a special case.
+If someone throws a strike or a spare then they get a fill ball.
+Fill balls exist to calculate the total of the 10th frame.
+Scoring a strike or spare on the fill ball does not give the player more fill balls.
+The total value of the 10th frame is the total number of pins knocked down.
 
 For a tenth frame of X1/ (strike and a spare), the total value is 20.
 
@@ -52,10 +47,10 @@ For a tenth frame of XXX (three strikes), the total value is 30.
 
 ## Requirements
 
-Write code to keep track of the score of a game of bowling. It should
-support two operations:
+Write code to keep track of the score of a game of bowling.
+It should support two operations:
 
-* `roll(pins : int)` is called each time the player rolls a ball.  The
-  argument is the number of pins knocked down.
-* `score() : int` is called only at the very end of the game.  It
-  returns the total score for that game.
+* `roll(pins : int)` is called each time the player rolls a ball.
+  The argument is the number of pins knocked down.
+* `score() : int` is called only at the very end of the game.
+  It returns the total score for that game.

--- a/exercises/change/description.md
+++ b/exercises/change/description.md
@@ -1,14 +1,11 @@
 # Description
 
-Correctly determine the fewest number of coins to be given to a customer such
-that the sum of the coins' value would equal the correct amount of change.
+Correctly determine the fewest number of coins to be given to a customer such that the sum of the coins' value would equal the correct amount of change.
 
 ## For example
 
-- An input of 15 with [1, 5, 10, 25, 100] should return one nickel (5)
-  and one dime (10) or [5, 10]
-- An input of 40 with [1, 5, 10, 25, 100] should return one nickel (5)
-  and one dime (10) and one quarter (25) or [5, 10, 25]
+- An input of 15 with [1, 5, 10, 25, 100] should return one nickel (5) and one dime (10) or [5, 10]
+- An input of 40 with [1, 5, 10, 25, 100] should return one nickel (5) and one dime (10) and one quarter (25) or [5, 10, 25]
 
 ## Edge cases
 

--- a/exercises/circular-buffer/description.md
+++ b/exercises/circular-buffer/description.md
@@ -1,26 +1,22 @@
 # Description
 
-A circular buffer, cyclic buffer or ring buffer is a data structure that
-uses a single, fixed-size buffer as if it were connected end-to-end.
+A circular buffer, cyclic buffer or ring buffer is a data structure that uses a single, fixed-size buffer as if it were connected end-to-end.
 
-A circular buffer first starts empty and of some predefined length. For
-example, this is a 7-element buffer:
+A circular buffer first starts empty and of some predefined length.
+For example, this is a 7-element buffer:
 <!-- prettier-ignore -->
     [ ][ ][ ][ ][ ][ ][ ]
 
-Assume that a 1 is written into the middle of the buffer (exact starting
-location does not matter in a circular buffer):
+Assume that a 1 is written into the middle of the buffer (exact starting location does not matter in a circular buffer):
 <!-- prettier-ignore -->
     [ ][ ][ ][1][ ][ ][ ]
 
-Then assume that two more elements are added — 2 & 3 — which get
-appended after the 1:
+Then assume that two more elements are added — 2 & 3 — which get appended after the 1:
 <!-- prettier-ignore -->
     [ ][ ][ ][1][2][3][ ]
 
-If two elements are then removed from the buffer, the oldest values
-inside the buffer are removed. The two elements removed, in this case,
-are 1 & 2, leaving the buffer with just a 3:
+If two elements are then removed from the buffer, the oldest values inside the buffer are removed.
+The two elements removed, in this case, are 1 & 2, leaving the buffer with just a 3:
 <!-- prettier-ignore -->
     [ ][ ][ ][ ][ ][3][ ]
 
@@ -28,24 +24,19 @@ If the buffer has 7 elements then it is completely full:
 <!-- prettier-ignore -->
     [5][6][7][8][9][3][4]
 
-When the buffer is full an error will be raised, alerting the client
-that further writes are blocked until a slot becomes free.
+When the buffer is full an error will be raised, alerting the client that further writes are blocked until a slot becomes free.
 
-When the buffer is full, the client can opt to overwrite the oldest
-data with a forced write. In this case, two more elements — A & B —
-are added and they overwrite the 3 & 4:
+When the buffer is full, the client can opt to overwrite the oldest data with a forced write.
+In this case, two more elements — A & B — are added and they overwrite the 3 & 4:
 <!-- prettier-ignore -->
     [5][6][7][8][9][A][B]
 
-3 & 4 have been replaced by A & B making 5 now the oldest data in the
-buffer. Finally, if two elements are removed then what would be
-returned is 5 & 6 yielding the buffer:
+3 & 4 have been replaced by A & B making 5 now the oldest data in the buffer.
+Finally, if two elements are removed then what would be returned is 5 & 6 yielding the buffer:
 <!-- prettier-ignore -->
     [ ][ ][7][8][9][A][B]
 
-Because there is space available, if the client again uses overwrite
-to store C & D then the space where 5 & 6 were stored previously will
-be used not the location of 7 & 8. 7 is still the oldest element and
-the buffer is once again full.
+Because there is space available, if the client again uses overwrite to store C & D then the space where 5 & 6 were stored previously will be used not the location of 7 & 8.
+7 is still the oldest element and the buffer is once again full.
 <!-- prettier-ignore -->
     [C][D][7][8][9][A][B]

--- a/exercises/collatz-conjecture/description.md
+++ b/exercises/collatz-conjecture/description.md
@@ -2,10 +2,11 @@
 
 The Collatz Conjecture or 3x+1 problem can be summarized as follows:
 
-Take any positive integer n. If n is even, divide n by 2 to get n / 2. If n is
-odd, multiply n by 3 and add 1 to get 3n + 1. Repeat the process indefinitely.
-The conjecture states that no matter which number you start with, you will
-always reach 1 eventually.
+Take any positive integer n.
+If n is even, divide n by 2 to get n / 2.
+If n is odd, multiply n by 3 and add 1 to get 3n + 1.
+Repeat the process indefinitely.
+The conjecture states that no matter which number you start with, you will always reach 1 eventually.
 
 Given a number n, return the number of steps required to reach 1.
 
@@ -24,4 +25,5 @@ Starting with n = 12, the steps would be as follows:
 8. 2
 9. 1
 
-Resulting in 9 steps. So for input n = 12, the return value would be 9.
+Resulting in 9 steps.
+So for input n = 12, the return value would be 9.

--- a/exercises/connect/description.md
+++ b/exercises/connect/description.md
@@ -2,18 +2,14 @@
 
 Compute the result for a game of Hex / Polygon.
 
-The abstract boardgame known as [Hex][hex] / Polygon /
-CON-TAC-TIX is quite simple in rules, though complex in practice. Two players
-place stones on a parallelogram with hexagonal fields. The player to connect his/her
-stones to the opposite side first wins. The four sides of the parallelogram are
-divided between the two players (i.e. one player gets assigned a side and the
-side directly opposite it and the other player gets assigned the two other
-sides).
+The abstract boardgame known as [Hex][hex] / Polygon / CON-TAC-TIX is quite simple in rules, though complex in practice.
+Two players place stones on a parallelogram with hexagonal fields.
+The player to connect his/her stones to the opposite side first wins.
+The four sides of the parallelogram are divided between the two players (i.e. one player gets assigned a side and the side directly opposite it and the other player gets assigned the two other sides).
 
-Your goal is to build a program that given a simple representation of a board
-computes the winner (or lack thereof). Note that all games need not be "fair".
-(For example, players may have mismatched piece counts or the game's board might
-have a different width and height.)
+Your goal is to build a program that given a simple representation of a board computes the winner (or lack thereof).
+Note that all games need not be "fair".
+(For example, players may have mismatched piece counts or the game's board might have a different width and height.)
 
 The boards look like this:
 
@@ -25,8 +21,7 @@ The boards look like this:
     X O O O X
 ```
 
-"Player `O`" plays from top to bottom, "Player `X`" plays from left to right. In
-the above example `O` has made a connection from left to right but nobody has
-won since `O` didn't connect top and bottom.
+"Player `O`" plays from top to bottom, "Player `X`" plays from left to right.
+In the above example `O` has made a connection from left to right but nobody has won since `O` didn't connect top and bottom.
 
 [hex]: https://en.wikipedia.org/wiki/Hex_%28board_game%29

--- a/exercises/custom-set/description.md
+++ b/exercises/custom-set/description.md
@@ -2,7 +2,6 @@
 
 Create a custom set type.
 
-Sometimes it is necessary to define a custom data structure of some
-type, like a set. In this exercise you will define your own set. How it
-works internally doesn't matter, as long as it behaves like a set of
-unique elements.
+Sometimes it is necessary to define a custom data structure of some type, like a set.
+In this exercise you will define your own set.
+How it works internally doesn't matter, as long as it behaves like a set of unique elements.

--- a/exercises/darts/description.md
+++ b/exercises/darts/description.md
@@ -2,8 +2,7 @@
 
 Write a function that returns the earned points in a single toss of a Darts game.
 
-[Darts][darts] is a game where players
-throw darts at a [target][darts-target].
+[Darts][darts] is a game where players throw darts at a [target][darts-target].
 
 In our particular instance of the game, the target rewards 4 different amounts of points, depending on where the dart lands:
 
@@ -12,7 +11,8 @@ In our particular instance of the game, the target rewards 4 different amounts o
 * If the dart lands in the middle circle of the target, player earns 5 points.
 * If the dart lands in the inner circle of the target, player earns 10 points.
 
-The outer circle has a radius of 10 units (this is equivalent to the total radius for the entire target), the middle circle a radius of 5 units, and the inner circle a radius of 1. Of course, they are all centered at the same point (that is, the circles are [concentric][] defined by the coordinates (0, 0).
+The outer circle has a radius of 10 units (this is equivalent to the total radius for the entire target), the middle circle a radius of 5 units, and the inner circle a radius of 1.
+Of course, they are all centered at the same point (that is, the circles are [concentric][] defined by the coordinates (0, 0).
 
 Write a function that given a point in the target (defined by its [Cartesian coordinates][cartesian-coordinates] `x` and `y`, where `x` and `y` are [real][real-numbers]), returns the correct amount earned by a dart landing at that point.
 

--- a/exercises/diamond/description.md
+++ b/exercises/diamond/description.md
@@ -1,8 +1,7 @@
 # Description
 
-The diamond kata takes as its input a letter, and outputs it in a diamond
-shape. Given a letter, it prints a diamond starting with 'A', with the
-supplied letter at the widest point.
+The diamond kata takes as its input a letter, and outputs it in a diamond shape.
+Given a letter, it prints a diamond starting with 'A', with the supplied letter at the widest point.
 
 ## Requirements
 

--- a/exercises/difference-of-squares/description.md
+++ b/exercises/difference-of-squares/description.md
@@ -8,10 +8,7 @@ The square of the sum of the first ten natural numbers is
 The sum of the squares of the first ten natural numbers is
 1² + 2² + ... + 10² = 385.
 
-Hence the difference between the square of the sum of the first
-ten natural numbers and the sum of the squares of the first ten
-natural numbers is 3025 - 385 = 2640.
+Hence the difference between the square of the sum of the first ten natural numbers and the sum of the squares of the first ten natural numbers is 3025 - 385 = 2640.
 
-You are not expected to discover an efficient solution to this yourself from
-first principles; research is allowed, indeed, encouraged. Finding the best
-algorithm for the problem is a key skill in software engineering.
+You are not expected to discover an efficient solution to this yourself from first principles; research is allowed, indeed, encouraged.
+Finding the best algorithm for the problem is a key skill in software engineering.

--- a/exercises/diffie-hellman/description.md
+++ b/exercises/diffie-hellman/description.md
@@ -2,9 +2,8 @@
 
 Diffie-Hellman key exchange.
 
-Alice and Bob use Diffie-Hellman key exchange to share secrets.  They
-start with prime numbers, pick private keys, generate and share public
-keys, and then generate a shared secret key.
+Alice and Bob use Diffie-Hellman key exchange to share secrets.
+They start with prime numbers, pick private keys, generate and share public keys, and then generate a shared secret key.
 
 ## Step 0
 
@@ -12,8 +11,8 @@ The test program supplies prime numbers p and g.
 
 ## Step 1
 
-Alice picks a private key, a, greater than 1 and less than p.  Bob does
-the same to pick a private key b.
+Alice picks a private key, a, greater than 1 and less than p.
+Bob does the same to pick a private key b.
 
 ## Step 2
 
@@ -21,12 +20,12 @@ Alice calculates a public key A.
 
     A = gᵃ mod p
 
-Using the same p and g, Bob similarly calculates a public key B from his
-private key b.
+Using the same p and g, Bob similarly calculates a public key B from his private key b.
 
 ## Step 3
 
-Alice and Bob exchange public keys.  Alice calculates secret key s.
+Alice and Bob exchange public keys.
+Alice calculates secret key s.
 
     s = Bᵃ mod p
 
@@ -34,5 +33,5 @@ Bob calculates
 
     s = Aᵇ mod p
 
-The calculations produce the same result!  Alice and Bob now share
-secret s.
+The calculations produce the same result!
+Alice and Bob now share secret s.

--- a/exercises/dnd-character/description.md
+++ b/exercises/dnd-character/description.md
@@ -1,15 +1,13 @@
 # Description
 
-For a game of [Dungeons & Dragons][dnd], each player starts by generating a
-character they can play with. This character has, among other things, six
-abilities; strength, dexterity, constitution, intelligence, wisdom and
-charisma. These six abilities have scores that are determined randomly. You
-do this by rolling four 6-sided dice and record the sum of the largest three
-dice. You do this six times, once for each ability.
+For a game of [Dungeons & Dragons][dnd], each player starts by generating a character they can play with.
+This character has, among other things, six abilities; strength, dexterity, constitution, intelligence, wisdom and charisma.
+These six abilities have scores that are determined randomly.
+You do this by rolling four 6-sided dice and record the sum of the largest three dice.
+You do this six times, once for each ability.
 
-Your character's initial hitpoints are 10 + your character's constitution
-modifier. You find your character's constitution modifier by subtracting 10
-from your character's constitution, divide by 2 and round down.
+Your character's initial hitpoints are 10 + your character's constitution modifier.
+You find your character's constitution modifier by subtracting 10 from your character's constitution, divide by 2 and round down.
 
 Write a random character generator that follows the rules above.
 
@@ -26,8 +24,8 @@ Because constitution is 3, the constitution modifier is -4 and the hitpoints are
 
 ## Notes
 
-Most programming languages feature (pseudo-)random generators, but few
-programming languages are designed to roll dice. One such language is [Troll][troll].
+Most programming languages feature (pseudo-)random generators, but few programming languages are designed to roll dice.
+One such language is [Troll][troll].
 
 [dnd]: https://en.wikipedia.org/wiki/Dungeons_%26_Dragons
 [troll]: http://hjemmesider.diku.dk/~torbenm/Troll/

--- a/exercises/dominoes/description.md
+++ b/exercises/dominoes/description.md
@@ -2,14 +2,12 @@
 
 Make a chain of dominoes.
 
-Compute a way to order a given set of dominoes in such a way that they form a
-correct domino chain (the dots on one half of a stone match the dots on the
-neighboring half of an adjacent stone) and that dots on the halves of the
-stones which don't have a neighbor (the first and last stone) match each other.
+Compute a way to order a given set of dominoes in such a way that they form a correct domino chain (the dots on one half of a stone match the dots on the neighboring half of an adjacent stone) and that dots on the halves of the stones which don't have a neighbor (the first and last stone) match each other.
 
 For example given the stones `[2|1]`, `[2|3]` and `[1|3]` you should compute something
 like `[1|2] [2|3] [3|1]` or `[3|2] [2|1] [1|3]` or `[1|3] [3|2] [2|1]` etc, where the first and last numbers are the same.
 
-For stones `[1|2]`, `[4|1]` and `[2|3]` the resulting chain is not valid: `[4|1] [1|2] [2|3]`'s first and last numbers are not the same. 4 != 3
+For stones `[1|2]`, `[4|1]` and `[2|3]` the resulting chain is not valid: `[4|1] [1|2] [2|3]`'s first and last numbers are not the same.
+4 != 3
 
 Some test cases may use duplicate stones in a chain solution, assume that multiple Domino sets are being used.

--- a/exercises/dot-dsl/description.md
+++ b/exercises/dot-dsl/description.md
@@ -1,15 +1,13 @@
 # Description
 
 A [Domain Specific Language (DSL)][dsl] is a
-small language optimized for a specific domain. Since a DSL is
-targeted, it can greatly impact productivity/understanding by allowing the
-writer to declare *what* they want rather than *how*.
+small language optimized for a specific domain.
+Since a DSL is targeted, it can greatly impact productivity/understanding by allowing the writer to declare *what* they want rather than *how*.
 
 One problem area where they are applied are complex customizations/configurations.
 
-For example the [DOT language][dot-language] allows
-you to write a textual description of a graph which is then transformed into a picture by one of
-the [Graphviz][graphviz] tools (such as `dot`). A simple graph looks like this:
+For example the [DOT language][dot-language] allows you to write a textual description of a graph which is then transformed into a picture by one of the [Graphviz][graphviz] tools (such as `dot`).
+A simple graph looks like this:
 
     graph {
         graph [bgcolor="yellow"]
@@ -18,18 +16,14 @@ the [Graphviz][graphviz] tools (such as `dot`). A simple graph looks like this:
         a -- b [color="green"]
     }
 
-Putting this in a file `example.dot` and running `dot example.dot -T png
--o example.png` creates an image `example.png` with red and blue circle
-connected by a green line on a yellow background.
+Putting this in a file `example.dot` and running `dot example.dot -T png -o example.png` creates an image `example.png` with red and blue circle connected by a green line on a yellow background.
 
 Write a Domain Specific Language similar to the Graphviz dot language.
 
-Our DSL is similar to the Graphviz dot language in that our DSL will be used
-to create graph data structures. However, unlike the DOT Language, our DSL will
-be an internal DSL for use only in our language.
+Our DSL is similar to the Graphviz dot language in that our DSL will be used to create graph data structures.
+However, unlike the DOT Language, our DSL will be an internal DSL for use only in our language.
 
-More information about the difference between internal and external DSLs can be
-found [here][fowler-dsl].
+More information about the difference between internal and external DSLs can be found [here][fowler-dsl].
 
 [dsl]: https://en.wikipedia.org/wiki/Domain-specific_language
 [dot-language]: https://en.wikipedia.org/wiki/DOT_(graph_description_language)

--- a/exercises/error-handling/description.md
+++ b/exercises/error-handling/description.md
@@ -2,9 +2,7 @@
 
 Implement various kinds of error handling and resource management.
 
-An important point of programming is how to handle errors and close
-resources even if errors occur.
+An important point of programming is how to handle errors and close resources even if errors occur.
 
-This exercise requires you to handle various errors. Because error handling
-is rather programming language specific you'll have to refer to the tests
-for your track to see what's exactly required.
+This exercise requires you to handle various errors.
+Because error handling is rather programming language specific you'll have to refer to the tests for your track to see what's exactly required.

--- a/exercises/etl/description.md
+++ b/exercises/etl/description.md
@@ -4,12 +4,10 @@ We are going to do the `Transform` step of an Extract-Transform-Load.
 
 ## ETL
 
-Extract-Transform-Load (ETL) is a fancy way of saying, "We have some crufty, legacy data over in this system, and now we need it in this shiny new system over here, so
-we're going to migrate this."
+Extract-Transform-Load (ETL) is a fancy way of saying, "We have some crufty, legacy data over in this system, and now we need it in this shiny new system over here, so we're going to migrate this."
 
-(Typically, this is followed by, "We're only going to need to run this
-once." That's then typically followed by much forehead slapping and
-moaning about how stupid we could possibly be.)
+(Typically, this is followed by, "We're only going to need to run this once."
+That's then typically followed by much forehead slapping and moaning about how stupid we could possibly be.)
 
 ## The goal
 
@@ -25,10 +23,8 @@ The old system stored a list of letters per score:
 - 8 points: "J", "X",
 - 10 points: "Q", "Z",
 
-The shiny new Scrabble system instead stores the score per letter, which
-makes it much faster and easier to calculate the score for a word. It
-also stores the letters in lower-case regardless of the case of the
-input letters:
+The shiny new Scrabble system instead stores the score per letter, which makes it much faster and easier to calculate the score for a word.
+It also stores the letters in lower-case regardless of the case of the input letters:
 
 - "a" is worth 1 point.
 - "b" is worth 3 points.
@@ -36,12 +32,9 @@ input letters:
 - "d" is worth 2 points.
 - Etc.
 
-Your mission, should you choose to accept it, is to transform the legacy data
-format to the shiny new format.
+Your mission, should you choose to accept it, is to transform the legacy data format to the shiny new format.
 
 ## Notes
 
-A final note about scoring, Scrabble is played around the world in a
-variety of languages, each with its own unique scoring table. For
-example, an "E" is scored at 2 in the Māori-language version of the
-game while being scored at 4 in the Hawaiian-language version.
+A final note about scoring, Scrabble is played around the world in a variety of languages, each with its own unique scoring table.
+For example, an "E" is scored at 2 in the Māori-language version of the game while being scored at 4 in the Hawaiian-language version.

--- a/exercises/flatten-array/description.md
+++ b/exercises/flatten-array/description.md
@@ -4,7 +4,7 @@ Take a nested list and return a single flattened list with all values except nil
 
 The challenge is to write a function that accepts an arbitrarily-deep nested list-like structure and returns a flattened structure without any nil/null values.
 
-For Example
+For example:
 
 input: [1,[2,3,null,4],[null],5]
 

--- a/exercises/food-chain/description.md
+++ b/exercises/food-chain/description.md
@@ -2,9 +2,7 @@
 
 Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'.
 
-While you could copy/paste the lyrics,
-or read them from a file, this problem is much more
-interesting if you approach it algorithmically.
+While you could copy/paste the lyrics, or read them from a file, this problem is much more interesting if you approach it algorithmically.
 
 This is a [cumulative song][cumulative-song] of unknown origin.
 

--- a/exercises/forth/description.md
+++ b/exercises/forth/description.md
@@ -3,25 +3,20 @@
 Implement an evaluator for a very simple subset of Forth.
 
 [Forth][forth]
-is a stack-based programming language. Implement a very basic evaluator
-for a small subset of Forth.
+is a stack-based programming language.
+Implement a very basic evaluator for a small subset of Forth.
 
 Your evaluator has to support the following words:
 
 - `+`, `-`, `*`, `/` (integer arithmetic)
 - `DUP`, `DROP`, `SWAP`, `OVER` (stack manipulation)
 
-Your evaluator also has to support defining new words using the
-customary syntax: `: word-name definition ;`.
+Your evaluator also has to support defining new words using the customary syntax: `: word-name definition ;`.
 
-To keep things simple the only data type you need to support is signed
-integers of at least 16 bits size.
+To keep things simple the only data type you need to support is signed integers of at least 16 bits size.
 
-You should use the following rules for the syntax: a number is a
-sequence of one or more (ASCII) digits, a word is a sequence of one or
-more letters, digits, symbols or punctuation that is not a number.
-(Forth probably uses slightly different rules, but this is close
-enough.)
+You should use the following rules for the syntax: a number is a sequence of one or more (ASCII) digits, a word is a sequence of one or more letters, digits, symbols or punctuation that is not a number.
+(Forth probably uses slightly different rules, but this is close enough.)
 
 Words are case-insensitive.
 

--- a/exercises/gigasecond/description.md
+++ b/exercises/gigasecond/description.md
@@ -1,6 +1,5 @@
 # Description
 
-Given a moment, determine the moment that would be after a gigasecond
-has passed.
+Given a moment, determine the moment that would be after a gigasecond has passed.
 
 A gigasecond is 10^9 (1,000,000,000) seconds.

--- a/exercises/go-counting/description.md
+++ b/exercises/go-counting/description.md
@@ -2,21 +2,17 @@
 
 Count the scored points on a Go board.
 
-In the game of go (also known as baduk, igo, cờ vây and wéiqí) points
-are gained by completely encircling empty intersections with your
-stones. The encircled intersections of a player are known as its
-territory.
+In the game of go (also known as baduk, igo, cờ vây and wéiqí) points are gained by completely encircling empty intersections with your stones.
+The encircled intersections of a player are known as its territory.
 
-Write a function that determines the territory of each player. You may
-assume that any stones that have been stranded in enemy territory have
-already been taken off the board.
+Write a function that determines the territory of each player.
+You may assume that any stones that have been stranded in enemy territory have already been taken off the board.
 
 Write a function that determines the territory which includes a specified coordinate.
 
-Multiple empty intersections may be encircled at once and for encircling
-only horizontal and vertical neighbors count. In the following diagram
-the stones which matter are marked "O" and the stones that don't are
-marked "I" (ignored).  Empty spaces represent empty intersections.
+Multiple empty intersections may be encircled at once and for encircling only horizontal and vertical neighbors count.
+In the following diagram the stones which matter are marked "O" and the stones that don't are marked "I" (ignored).
+Empty spaces represent empty intersections.
 
 ```text
 +----+
@@ -27,9 +23,7 @@ marked "I" (ignored).  Empty spaces represent empty intersections.
 +----+
 ```
 
-To be more precise an empty intersection is part of a player's territory
-if all of its neighbors are either stones of that player or empty
-intersections that are part of that player's territory.
+To be more precise an empty intersection is part of a player's territory if all of its neighbors are either stones of that player or empty intersections that are part of that player's territory.
 
 For more information see [wikipedia][go-wikipedia] or [Sensei's Library][go-sensei].
 

--- a/exercises/grade-school/description.md
+++ b/exercises/grade-school/description.md
@@ -1,7 +1,6 @@
 # Description
 
-Given students' names along with the grade that they are in, create a roster
-for the school.
+Given students' names along with the grade that they are in, create a roster for the school.
 
 In the end, you should be able to:
 
@@ -11,18 +10,12 @@ In the end, you should be able to:
 - Get a list of all students enrolled in a grade
   - "Which students are in grade 2?"
   - "We've only got Jim just now."
-- Get a sorted list of all students in all grades.  Grades should sort
-  as 1, 2, 3, etc., and students within a grade should be sorted
-  alphabetically by name.
+- Get a sorted list of all students in all grades.
+  Grades should sort as 1, 2, 3, etc., and students within a grade should be sorted alphabetically by name.
   - "Who all is enrolled in school right now?"
-  - "Let me think. We have
-  Anna, Barb, and Charlie in grade 1,
-  Alex, Peter, and Zoe in grade 2
-  and Jim in grade 5.
-  So the answer is: Anna, Barb, Charlie, Alex, Peter, Zoe and Jim"
+  - "Let me think.
+    We have Anna, Barb, and Charlie in grade 1, Alex, Peter, and Zoe in grade 2 and Jim in grade 5.
+    So the answer is: Anna, Barb, Charlie, Alex, Peter, Zoe and Jim"
 
-Note that all our students only have one name  (It's a small town, what
-do you want?) and each student cannot be added more than once to a grade or the
-roster.
-In fact, when a test attempts to add the same student more than once, your
-implementation should indicate that this is incorrect.
+Note that all our students only have one name (It's a small town, what do you want?) and each student cannot be added more than once to a grade or the roster.
+In fact, when a test attempts to add the same student more than once, your implementation should indicate that this is incorrect.

--- a/exercises/grains/description.md
+++ b/exercises/grains/description.md
@@ -1,13 +1,11 @@
 # Description
 
-Calculate the number of grains of wheat on a chessboard given that the number
-on each square doubles.
+Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.
 
-There once was a wise servant who saved the life of a prince. The king
-promised to pay whatever the servant could dream up. Knowing that the
-king loved chess, the servant told the king he would like to have grains
-of wheat. One grain on the first square of a chess board, with the number
-of grains doubling on each successive square.
+There once was a wise servant who saved the life of a prince.
+The king promised to pay whatever the servant could dream up.
+Knowing that the king loved chess, the servant told the king he would like to have grains of wheat.
+One grain on the first square of a chess board, with the number of grains doubling on each successive square.
 
 There are 64 squares on a chessboard (where square 1 has one grain, square 2 has two grains, and so on).
 

--- a/exercises/hamming/description.md
+++ b/exercises/hamming/description.md
@@ -2,11 +2,17 @@
 
 Calculate the Hamming Distance between two DNA strands.
 
-Your body is made up of cells that contain DNA. Those cells regularly wear out and need replacing, which they achieve by dividing into daughter cells. In fact, the average human body experiences about 10 quadrillion cell divisions in a lifetime!
+Your body is made up of cells that contain DNA.
+Those cells regularly wear out and need replacing, which they achieve by dividing into daughter cells.
+In fact, the average human body experiences about 10 quadrillion cell divisions in a lifetime!
 
-When cells divide, their DNA replicates too. Sometimes during this process mistakes happen and single pieces of DNA get encoded with the incorrect information. If we compare two strands of DNA and count the differences between them we can see how many mistakes occurred. This is known as the "Hamming Distance".
+When cells divide, their DNA replicates too.
+Sometimes during this process mistakes happen and single pieces of DNA get encoded with the incorrect information.
+If we compare two strands of DNA and count the differences between them we can see how many mistakes occurred.
+This is known as the "Hamming Distance".
 
-We read DNA using the letters C,A,G and T. Two strands might look like this:
+We read DNA using the letters C,A,G and T.
+Two strands might look like this:
 
     GAGCCTACTAACGGGAT
     CATCGTAATGACGGCCT
@@ -18,6 +24,4 @@ The Hamming Distance is useful for lots of things in science, not just biology, 
 
 ## Implementation notes
 
-The Hamming distance is only defined for sequences of equal length, so
-an attempt to calculate it between sequences of different lengths should
-not work.
+The Hamming distance is only defined for sequences of equal length, so an attempt to calculate it between sequences of different lengths should not work.

--- a/exercises/hangman/description.md
+++ b/exercises/hangman/description.md
@@ -4,15 +4,11 @@ Implement the logic of the hangman game using functional reactive programming.
 
 [Hangman][hangman] is a simple word guessing game.
 
-[Functional Reactive Programming][frp] is a way to write interactive
-programs. It differs from the usual perspective in that instead of
-saying "when the button is pressed increment the counter", you write
-"the value of the counter is the sum of the number of times the button
-is pressed."
+[Functional Reactive Programming][frp] is a way to write interactive programs.
+It differs from the usual perspective in that instead of saying "when the button is pressed increment the counter", you write "the value of the counter is the sum of the number of times the button is pressed."
 
-Implement the basic logic behind hangman using functional reactive
-programming.  You'll need to install an FRP library for this, this will
-be described in the language/track specific files of the exercise.
+Implement the basic logic behind hangman using functional reactive programming.
+You'll need to install an FRP library for this, this will be described in the language/track specific files of the exercise.
 
 [hangman]: https://en.wikipedia.org/wiki/Hangman_%28game%29
 [frp]: https://en.wikipedia.org/wiki/Functional_reactive_programming

--- a/exercises/hello-world/description.md
+++ b/exercises/hello-world/description.md
@@ -1,6 +1,7 @@
 # Description
 
-The classical introductory exercise. Just say "Hello, World!".
+The classical introductory exercise.
+Just say "Hello, World!".
 
 ["Hello, World!"][hello-world] is the traditional first program for beginning programming in a new language or environment.
 

--- a/exercises/hexadecimal/description.md
+++ b/exercises/hexadecimal/description.md
@@ -2,7 +2,6 @@
 
 Convert a hexadecimal number, represented as a string (e.g. "10af8c"), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).
 
-On the web we use hexadecimal to represent colors, e.g. green: 008000,
-teal: 008080, navy: 000080).
+On the web we use hexadecimal to represent colors, e.g. green: 008000, teal: 008080, navy: 000080).
 
 The program should handle invalid hexadecimal strings.

--- a/exercises/house/description.md
+++ b/exercises/house/description.md
@@ -2,12 +2,9 @@
 
 Recite the nursery rhyme 'This is the House that Jack Built'.
 
-> [The] process of placing a phrase of clause within another phrase of
-> clause is called embedding. It is through the processes of recursion
-> and embedding that we are able to take a finite number of forms (words
-> and phrases) and construct an infinite number of expressions.
-> Furthermore, embedding also allows us to construct an infinitely long
-> structure, in theory anyway.
+> [The] process of placing a phrase of clause within another phrase of clause is called embedding.
+> It is through the processes of recursion and embedding that we are able to take a finite number of forms (words and phrases) and construct an infinite number of expressions.
+> Furthermore, embedding also allows us to construct an infinitely long structure, in theory anyway.
 
 - [papyr.com][papyr]
 

--- a/exercises/isbn-verifier/description.md
+++ b/exercises/isbn-verifier/description.md
@@ -1,11 +1,13 @@
 # Description
 
-The [ISBN-10 verification process][isbn-verification] is used to validate book identification
-numbers. These normally contain dashes and look like: `3-598-21508-8`
+The [ISBN-10 verification process][isbn-verification] is used to validate book identification numbers.
+These normally contain dashes and look like: `3-598-21508-8`
 
 ## ISBN
 
-The ISBN-10 format is 9 digits (0 to 9) plus one check character (either a digit or an X only). In the case the check character is an X, this represents the value '10'. These may be communicated with or without hyphens, and can be checked for their validity by the following formula:
+The ISBN-10 format is 9 digits (0 to 9) plus one check character (either a digit or an X only).
+In the case the check character is an X, this represents the value '10'.
+These may be communicated with or without hyphens, and can be checked for their validity by the following formula:
 
 ```text
 (d₁ * 10 + d₂ * 9 + d₃ * 8 + d₄ * 7 + d₅ * 6 + d₆ * 5 + d₇ * 4 + d₈ * 3 + d₉ * 2 + d₁₀ * 1) mod 11 == 0
@@ -15,7 +17,8 @@ If the result is 0, then it is a valid ISBN-10, otherwise it is invalid.
 
 ## Example
 
-Let's take the ISBN-10 `3-598-21508-8`. We plug it in to the formula, and get:
+Let's take the ISBN-10 `3-598-21508-8`.
+We plug it in to the formula, and get:
 
 ```text
 (3 * 10 + 5 * 9 + 9 * 8 + 8 * 7 + 2 * 6 + 1 * 5 + 5 * 4 + 0 * 3 + 8 * 2 + 8 * 1) mod 11 == 0
@@ -33,6 +36,7 @@ The program should be able to verify ISBN-10 both with and without separating da
 ## Caveats
 
 Converting from strings to numbers can be tricky in certain languages.
-Now, it's even trickier since the check digit of an ISBN-10 may be 'X' (representing '10'). For instance `3-598-21507-X` is a valid ISBN-10.
+Now, it's even trickier since the check digit of an ISBN-10 may be 'X' (representing '10').
+For instance `3-598-21507-X` is a valid ISBN-10.
 
 [isbn-verification]: https://en.wikipedia.org/wiki/International_Standard_Book_Number

--- a/exercises/kindergarten-garden/description.md
+++ b/exercises/kindergarten-garden/description.md
@@ -3,9 +3,8 @@
 Given a diagram, determine which plants each child in the kindergarten class is
 responsible for.
 
-The kindergarten class is learning about growing plants. The teacher
-thought it would be a good idea to give them actual seeds, plant them in
-actual dirt, and grow actual plants.
+The kindergarten class is learning about growing plants.
+The teacher thought it would be a good idea to give them actual seeds, plant them in actual dirt, and grow actual plants.
 
 They've chosen to grow grass, clover, radishes, and violets.
 
@@ -25,8 +24,8 @@ There are 12 children in the class:
 - Eve, Fred, Ginny, Harriet,
 - Ileana, Joseph, Kincaid, and Larry.
 
-Each child gets 4 cups, two on each row. Their teacher assigns cups to
-the children alphabetically by their names.
+Each child gets 4 cups, two on each row.
+Their teacher assigns cups to the children alphabetically by their names.
 
 The following diagram represents Alice's plants:
 
@@ -36,12 +35,11 @@ VR......................
 RG......................
 ```
 
-In the first row, nearest the windows, she has a violet and a radish.  In the
-second row she has a radish and some grass.
+In the first row, nearest the windows, she has a violet and a radish.
+In the second row she has a radish and some grass.
 
-Your program will be given the plants from left-to-right starting with
-the row nearest the windows. From this, it should be able to determine
-which plants belong to each student.
+Your program will be given the plants from left-to-right starting with the row nearest the windows.
+From this, it should be able to determine which plants belong to each student.
 
 For example, if it's told that the garden looks like so:
 

--- a/exercises/knapsack/description.md
+++ b/exercises/knapsack/description.md
@@ -2,21 +2,18 @@
 
 In this exercise, let's try to solve a classic problem.
 
-Bob is a thief. After months of careful planning, he finally manages to
-crack the security systems of a high-class apartment.
+Bob is a thief.
+After months of careful planning, he finally manages to crack the security systems of a high-class apartment.
 
-In front of him are many items, each with a value (v) and weight (w). Bob,
-of course, wants to maximize the total value he can get; he would gladly
-take all of the items if he could. However, to his horror, he realizes that
-the knapsack he carries with him can only hold so much weight (W).
+In front of him are many items, each with a value (v) and weight (w).
+Bob, of course, wants to maximize the total value he can get; he would gladly take all of the items if he could.
+However, to his horror, he realizes that the knapsack he carries with him can only hold so much weight (W).
 
-Given a knapsack with a specific carrying capacity (W), help Bob determine
-the maximum value he can get from the items in the house. Note that Bob can
-take only one of each item.
+Given a knapsack with a specific carrying capacity (W), help Bob determine the maximum value he can get from the items in the house.
+Note that Bob can take only one of each item.
 
-All values given will be strictly positive. Items will be represented as a
-list of pairs, `wi` and `vi`, where the first element `wi` is the weight of
-the *i*th item and `vi` is the value for that item.
+All values given will be strictly positive.
+Items will be represented as a list of pairs, `wi` and `vi`, where the first element `wi` is the weight of the *i*th item and `vi` is the value for that item.
 
 For example:
 
@@ -29,9 +26,7 @@ Items: [
 
 Knapsack Limit: 10
 
-For the above, the first item has weight 5 and value 10, the second item has
-weight 4 and value 40, and so on.
+For the above, the first item has weight 5 and value 10, the second item has weight 4 and value 40, and so on.
 
-In this example, Bob should take the second and fourth item to maximize his
-value, which, in this case, is 90. He cannot get more than 90 as his
-knapsack has a weight limit of 10.
+In this example, Bob should take the second and fourth item to maximize his value, which, in this case, is 90.
+He cannot get more than 90 as his knapsack has a weight limit of 10.

--- a/exercises/largest-series-product/description.md
+++ b/exercises/largest-series-product/description.md
@@ -1,14 +1,10 @@
 # Description
 
-Given a string of digits, calculate the largest product for a contiguous
-substring of digits of length n.
+Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.
 
-For example, for the input `'1027839564'`, the largest product for a
-series of 3 digits is 270 `(9 * 5 * 6)`, and the largest product for a
-series of 5 digits is 7560 `(7 * 8 * 3 * 9 * 5)`.
+For example, for the input `'1027839564'`, the largest product for a series of 3 digits is 270 `(9 * 5 * 6)`, and the largest product for a series of 5 digits is 7560 `(7 * 8 * 3 * 9 * 5)`.
 
-Note that these series are only required to occupy *adjacent positions*
-in the input; the digits need not be *numerically consecutive*.
+Note that these series are only required to occupy *adjacent positions* in the input; the digits need not be *numerically consecutive*.
 
 For the input `'73167176531330624919225119674426574742355349194934'`,
 the largest product for a series of 6 digits is 23520.

--- a/exercises/leap/description.md
+++ b/exercises/leap/description.md
@@ -10,8 +10,8 @@ on every year that is evenly divisible by 4
     unless the year is also evenly divisible by 400
 ```
 
-For example, 1997 is not a leap year, but 1996 is.  1900 is not a leap
-year, but 2000 is.
+For example, 1997 is not a leap year, but 1996 is.
+1900 is not a leap year, but 2000 is.
 
 ## Notes
 

--- a/exercises/ledger/description.md
+++ b/exercises/ledger/description.md
@@ -2,14 +2,13 @@
 
 Refactor a ledger printer.
 
-The ledger exercise is a refactoring exercise. There is code that prints a
-nicely formatted ledger, given a locale (American or Dutch) and a currency (US
-dollar or euro). The code however is rather badly written, though (somewhat
-surprisingly) it consistently passes the test suite.
+The ledger exercise is a refactoring exercise.
+There is code that prints a nicely formatted ledger, given a locale (American or Dutch) and a currency (US dollar or euro).
+The code however is rather badly written, though (somewhat surprisingly) it consistently passes the test suite.
 
-Rewrite this code. Remember that in refactoring the trick is to make small steps
-that keep the tests passing. That way you can always quickly go back to a
-working version.  Version control tools like git can help here as well.
+Rewrite this code.
+Remember that in refactoring the trick is to make small steps that keep the tests passing.
+That way you can always quickly go back to a working version.
+Version control tools like git can help here as well.
 
-Please keep a log of what changes you've made and make a comment on the exercise
-containing that log, this will help reviewers.
+Please keep a log of what changes you've made and make a comment on the exercise containing that log, this will help reviewers.

--- a/exercises/linked-list/description.md
+++ b/exercises/linked-list/description.md
@@ -2,28 +2,24 @@
 
 Implement a doubly linked list.
 
-Like an array, a linked list is a simple linear data structure. Several
-common data types can be implemented using linked lists, like queues,
-stacks, and associative arrays.
+Like an array, a linked list is a simple linear data structure.
+Several common data types can be implemented using linked lists, like queues, stacks, and associative arrays.
 
-A linked list is a collection of data elements called *nodes*. In a
-*singly linked list* each node holds a value and a link to the next node.
-In a *doubly linked list* each node also holds a link to the previous
-node.
+A linked list is a collection of data elements called *nodes*.
+In a *singly linked list* each node holds a value and a link to the next node.
+In a *doubly linked list* each node also holds a link to the previous node.
 
-You will write an implementation of a doubly linked list. Implement a
-Node to hold a value and pointers to the next and previous nodes. Then
-implement a List which holds references to the first and last node and
-offers an array-like interface for adding and removing items:
+You will write an implementation of a doubly linked list.
+Implement a Node to hold a value and pointers to the next and previous nodes.
+Then implement a List which holds references to the first and last node and offers an array-like interface for adding and removing items:
 
 * `push` (*insert value at back*);
 * `pop` (*remove value at back*);
 * `shift` (*remove value at front*).
 * `unshift` (*insert value at front*);
 
-To keep your implementation simple, the tests will not cover error
-conditions. Specifically: `pop` or `shift` will never be called on an
-empty list.
+To keep your implementation simple, the tests will not cover error conditions.
+Specifically: `pop` or `shift` will never be called on an empty list.
 
 Read more about [linked lists on Wikipedia][linked-lists].
 

--- a/exercises/list-ops/description.md
+++ b/exercises/list-ops/description.md
@@ -2,13 +2,10 @@
 
 Implement basic list operations.
 
-In functional languages list operations like `length`, `map`, and
-`reduce` are very common. Implement a series of basic list operations,
-without using existing functions.
+In functional languages list operations like `length`, `map`, and `reduce` are very common.
+Implement a series of basic list operations, without using existing functions.
 
-The precise number and names of the operations to be implemented will be
-track dependent to avoid conflicts with existing names, but the general
-operations you will implement include:
+The precise number and names of the operations to be implemented will be track dependent to avoid conflicts with existing names, but the general operations you will implement include:
 
 * `append` (*given two lists, add all items in the second list to the end of the first list*);
 * `concatenate` (*given a series of lists, combine all items in all lists into one flattened list*);

--- a/exercises/luhn/description.md
+++ b/exercises/luhn/description.md
@@ -2,18 +2,15 @@
 
 Given a number determine whether or not it is valid per the Luhn formula.
 
-The [Luhn algorithm][luhn] is
-a simple checksum formula used to validate a variety of identification
-numbers, such as credit card numbers and Canadian Social Insurance
-Numbers.
+The [Luhn algorithm][luhn] is a simple checksum formula used to validate a variety of identification numbers, such as credit card numbers and Canadian Social Insurance Numbers.
 
 The task is to check if a given string is valid.
 
 ## Validating a Number
 
-Strings of length 1 or less are not valid. Spaces are allowed in the input,
-but they should be stripped before checking. All other non-digit characters
-are disallowed.
+Strings of length 1 or less are not valid.
+Spaces are allowed in the input, but they should be stripped before checking.
+All other non-digit characters are disallowed.
 
 ### Example 1: valid credit card number
 
@@ -21,15 +18,15 @@ are disallowed.
 4539 3195 0343 6467
 ```
 
-The first step of the Luhn algorithm is to double every second digit,
-starting from the right. We will be doubling
+The first step of the Luhn algorithm is to double every second digit, starting from the right.
+We will be doubling
 
 ```text
 4_3_ 3_9_ 0_4_ 6_6_
 ```
 
-If doubling the number results in a number greater than 9 then subtract 9
-from the product. The results of our doubling:
+If doubling the number results in a number greater than 9 then subtract 9 from the product.
+The results of our doubling:
 
 ```text
 8569 6195 0383 3437
@@ -41,7 +38,8 @@ Then sum all of the digits:
 8+5+6+9+6+1+9+5+0+3+8+3+3+4+3+7 = 80
 ```
 
-If the sum is evenly divisible by 10, then the number is valid. This number is valid!
+If the sum is evenly divisible by 10, then the number is valid.
+This number is valid!
 
 ### Example 2: invalid credit card number
 

--- a/exercises/markdown/description.md
+++ b/exercises/markdown/description.md
@@ -2,15 +2,12 @@
 
 Refactor a Markdown parser.
 
-The markdown exercise is a refactoring exercise. There is code that parses a
-given string with [Markdown syntax][markdown] and returns the
-associated HTML for that string. Even though this code is confusingly written
-and hard to follow, somehow it works and all the tests are passing! Your
-challenge is to re-write this code to make it easier to read and maintain
-while still making sure that all the tests keep passing.
+The markdown exercise is a refactoring exercise.
+There is code that parses a given string with [Markdown syntax][markdown] and returns the associated HTML for that string.
+Even though this code is confusingly written and hard to follow, somehow it works and all the tests are passing!
+Your challenge is to re-write this code to make it easier to read and maintain while still making sure that all the tests keep passing.
 
-It would be helpful if you made notes of what you did in your refactoring in
-comments so reviewers can see that, but it isn't strictly necessary. The most
-important thing is to make the code better!
+It would be helpful if you made notes of what you did in your refactoring in comments so reviewers can see that, but it isn't strictly necessary.
+The most important thing is to make the code better!
 
 [markdown]: https://guides.github.com/features/mastering-markdown/

--- a/exercises/matching-brackets/description.md
+++ b/exercises/matching-brackets/description.md
@@ -1,5 +1,3 @@
 # Description
 
-Given a string containing brackets `[]`, braces `{}`, parentheses `()`,
-or any combination thereof, verify that any and all pairs are matched
-and nested correctly.
+Given a string containing brackets `[]`, braces `{}`, parentheses `()`, or any combination thereof, verify that any and all pairs are matched and nested correctly.

--- a/exercises/matrix/description.md
+++ b/exercises/matrix/description.md
@@ -1,7 +1,6 @@
 # Description
 
-Given a string representing a matrix of numbers, return the rows and columns of
-that matrix.
+Given a string representing a matrix of numbers, return the rows and columns of that matrix.
 
 So given a string with embedded newlines like:
 
@@ -23,10 +22,8 @@ representing this matrix:
 
 your code should be able to spit out:
 
-- A list of the rows, reading each row left-to-right while moving
-  top-to-bottom across the rows,
-- A list of the columns, reading each column top-to-bottom while moving
-  from left-to-right.
+- A list of the rows, reading each row left-to-right while moving top-to-bottom across the rows,
+- A list of the columns, reading each column top-to-bottom while moving from left-to-right.
 
 The rows for our example matrix:
 

--- a/exercises/micro-blog/description.md
+++ b/exercises/micro-blog/description.md
@@ -1,16 +1,13 @@
 # Description
 
-You have identified a gap in the social media market for very very short
-posts. Now that Twitter allows 280 character posts, people wanting quick
-social media updates aren't being served. You decide to create your own
-social media network.
+You have identified a gap in the social media market for very very short posts.
+Now that Twitter allows 280 character posts, people wanting quick social media updates aren't being served.
+You decide to create your own social media network.
 
-To make your product noteworthy, you make it extreme and only allow posts
-of 5 or less characters. Any posts of more than 5 characters should be
-truncated to 5.
+To make your product noteworthy, you make it extreme and only allow posts of 5 or less characters.
+Any posts of more than 5 characters should be truncated to 5.
 
-To allow your users to express themselves fully, you allow Emoji and
-other Unicode.
+To allow your users to express themselves fully, you allow Emoji and other Unicode.
 
 The task is to truncate input strings to 5 characters.
 
@@ -19,25 +16,22 @@ The task is to truncate input strings to 5 characters.
 Text stored digitally has to be converted to a series of bytes.
 There are 3 ways to map characters to bytes in common use.
 
-* **ASCII** can encode English language characters. All
-characters are precisely 1 byte long.
-* **UTF-8** is a Unicode text encoding. Characters take between 1
-and 4 bytes.
-* **UTF-16** is a Unicode text encoding. Characters are either 2 or
-4 bytes long.
+* **ASCII** can encode English language characters.
+  All characters are precisely 1 byte long.
+* **UTF-8** is a Unicode text encoding.
+  Characters take between 1 and 4 bytes.
+* **UTF-16** is a Unicode text encoding.
+  Characters are either 2 or 4 bytes long.
 
-UTF-8 and UTF-16 are both Unicode encodings which means they're capable of
-representing a massive range of characters including:
+UTF-8 and UTF-16 are both Unicode encodings which means they're capable of representing a massive range of characters including:
 
 * Text in most of the world's languages and scripts
 * Historic text
 * Emoji
 
-UTF-8 and UTF-16 are both variable length encodings, which means that
-different characters take up different amounts of space.
+UTF-8 and UTF-16 are both variable length encodings, which means that different characters take up different amounts of space.
 
-Consider the letter 'a' and the emoji '😛'. In UTF-16 the letter takes
-2 bytes but the emoji takes 4 bytes.
+Consider the letter 'a' and the emoji '😛'.
+In UTF-16 the letter takes 2 bytes but the emoji takes 4 bytes.
 
-The trick to this exercise is to use APIs designed around Unicode
-characters (codepoints) instead of Unicode codeunits.
+The trick to this exercise is to use APIs designed around Unicode characters (codepoints) instead of Unicode codeunits.

--- a/exercises/minesweeper/description.md
+++ b/exercises/minesweeper/description.md
@@ -2,23 +2,18 @@
 
 Add the mine counts to a completed Minesweeper board.
 
-Minesweeper is a popular game where the user has to find the mines using
-numeric hints that indicate how many mines are directly adjacent
-(horizontally, vertically, diagonally) to a square.
+Minesweeper is a popular game where the user has to find the mines using numeric hints that indicate how many mines are directly adjacent (horizontally, vertically, diagonally) to a square.
 
-In this exercise you have to create some code that counts the number of
-mines adjacent to a given empty square and replaces that square with the
-count.
+In this exercise you have to create some code that counts the number of mines adjacent to a given empty square and replaces that square with the count.
 
-The board is a rectangle composed of blank space (' ') characters. A mine
-is represented by an asterisk (`*`) character.
+The board is a rectangle composed of blank space (' ') characters.
+A mine is represented by an asterisk (`*`) character.
 
 If a given space has no adjacent mines at all, leave that square blank.
 
 ## Examples
 
-For example you may receive a 5 x 4 board like this (empty spaces are
-represented here with the '·' character for display on screen):
+For example you may receive a 5 x 4 board like this (empty spaces are represented here with the '·' character for display on screen):
 
 ```text
 ·*·*·

--- a/exercises/nth-prime/description.md
+++ b/exercises/nth-prime/description.md
@@ -2,8 +2,6 @@
 
 Given a number n, determine what the nth prime is.
 
-By listing the first six prime numbers: 2, 3, 5, 7, 11, and 13, we can see that
-the 6th prime is 13.
+By listing the first six prime numbers: 2, 3, 5, 7, 11, and 13, we can see that the 6th prime is 13.
 
-If your language provides methods in the standard library to deal with prime
-numbers, pretend they don't exist and implement them yourself.
+If your language provides methods in the standard library to deal with prime numbers, pretend they don't exist and implement them yourself.

--- a/exercises/nucleotide-codons/description.md
+++ b/exercises/nucleotide-codons/description.md
@@ -1,20 +1,17 @@
 # Description
 
-Write a function that returns the name of an amino acid a particular codon,
-possibly using shorthand, encodes for.
+Write a function that returns the name of an amino acid a particular codon, possibly using shorthand, encodes for.
 
-In DNA sequences of 3 nucleotides, called codons, encode for amino acids. Often
-several codons encode for the same amino acid. The International Union of Pure
-and Applied Chemistry developed a shorthand system for designating groups of
-codons that encode for the same amino acid.
+In DNA sequences of 3 nucleotides, called codons, encode for amino acids.
+Often several codons encode for the same amino acid.
+The International Union of Pure and Applied Chemistry developed a shorthand system for designating groups of codons that encode for the same amino acid.
 
-Simply put they've expanded the four letters A, C, G and T with a bunch of
-letters that stand for different possibilities. For example R means A and G.
+Simply put they've expanded the four letters A, C, G and T with a bunch of letters that stand for different possibilities.
+For example R means A and G.
 So TAR stands for TAA and TAG (think of "TAR" as "TA[AG]" in regex notation).
 
-Write some code that given a codon, which may use shorthand, returns the
-name of the amino acid that that codon encodes for. You will be given
-a list of non-shorthand-codon/name pairs to base your computation on.
+Write some code that given a codon, which may use shorthand, returns the name of the amino acid that that codon encodes for.
+You will be given a list of non-shorthand-codon/name pairs to base your computation on.
 
 See: [wikipedia][codon-table].
 

--- a/exercises/nucleotide-count/description.md
+++ b/exercises/nucleotide-count/description.md
@@ -1,10 +1,12 @@
 # Description
 
-Each of us inherits from our biological parents a set of chemical instructions known as DNA that influence how our bodies are constructed. All known life depends on DNA!
+Each of us inherits from our biological parents a set of chemical instructions known as DNA that influence how our bodies are constructed.
+All known life depends on DNA!
 
 > Note: You do not need to understand anything about nucleotides or DNA to complete this exercise.
 
-DNA is a long chain of other chemicals and the most important are the four nucleotides, adenine, cytosine, guanine and thymine. A single DNA chain can contain billions of these four nucleotides and the order in which they occur is important!
+DNA is a long chain of other chemicals and the most important are the four nucleotides, adenine, cytosine, guanine and thymine.
+A single DNA chain can contain billions of these four nucleotides and the order in which they occur is important!
 We call the order of these nucleotides in a bit of DNA a "DNA sequence".
 
 We represent a DNA sequence as an ordered collection of these four nucleotides and a common way to do that is with a string of characters such as "ATTACG" for a DNA sequence of 6 nucleotides.

--- a/exercises/ocr-numbers/description.md
+++ b/exercises/ocr-numbers/description.md
@@ -1,7 +1,6 @@
 # Description
 
-Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is
-represented, or whether it is garbled.
+Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is represented, or whether it is garbled.
 
 ## Step One
 
@@ -59,7 +58,8 @@ Is converted to "1234567890"
 
 ## Step Four
 
-Update your program to handle multiple numbers, one per line. When converting several lines, join the lines with commas.
+Update your program to handle multiple numbers, one per line.
+When converting several lines, join the lines with commas.
 
 ```text
     _  _
@@ -76,4 +76,4 @@ Update your program to handle multiple numbers, one per line. When converting se
 
 ```
 
-Is converted to "123,456,789"
+Is converted to "123,456,789".

--- a/exercises/octal/description.md
+++ b/exercises/octal/description.md
@@ -1,11 +1,9 @@
 # Description
 
-Convert an octal number, represented as a string (e.g. '1735263'), to its
-decimal equivalent using first principles (i.e. no, you may not use built-in or
-external libraries to accomplish the conversion).
+Convert an octal number, represented as a string (e.g. '1735263'), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).
 
-Implement octal to decimal conversion.  Given an octal input
-string, your program should produce a decimal output.
+Implement octal to decimal conversion.
+Given an octal input string, your program should produce a decimal output.
 
 ## Note
 

--- a/exercises/paasio/description.md
+++ b/exercises/paasio/description.md
@@ -2,11 +2,10 @@
 
 Report network IO statistics.
 
-You are writing a [PaaS][paas], and you need a way to bill customers based
-on network and filesystem usage.
+You are writing a [PaaS][paas], and you need a way to bill customers based on network and filesystem usage.
 
-Create a wrapper for network connections and files that can report IO
-statistics. The wrapper must report:
+Create a wrapper for network connections and files that can report IO statistics.
+The wrapper must report:
 
 - The total number of bytes read/written.
 - The total number of read/write operations.

--- a/exercises/palindrome-products/description.md
+++ b/exercises/palindrome-products/description.md
@@ -2,15 +2,14 @@
 
 Detect palindrome products in a given range.
 
-A palindromic number is a number that remains the same when its digits are
-reversed. For example, `121` is a palindromic number but `112` is not.
+A palindromic number is a number that remains the same when its digits are reversed.
+For example, `121` is a palindromic number but `112` is not.
 
 Given a range of numbers, find the largest and smallest palindromes which
 are products of two numbers within that range.
 
-Your solution should return the largest and smallest palindromes, along with the
-factors of each within the range. If the largest or smallest palindrome has more
-than one pair of factors within the range, then return all the pairs.
+Your solution should return the largest and smallest palindromes, along with the factors of each within the range.
+If the largest or smallest palindrome has more than one pair of factors within the range, then return all the pairs.
 
 ## Example 1
 
@@ -22,12 +21,16 @@ And given the list of all possible products within this range:
 The palindrome products are all single digit numbers (in this case):
 `[1, 2, 3, 4, 5, 6, 7, 8, 9]`
 
-The smallest palindrome product is `1`. Its factors are `(1, 1)`.
-The largest palindrome product is `9`. Its factors are `(1, 9)` and `(3, 3)`.
+The smallest palindrome product is `1`.
+Its factors are `(1, 1)`.
+The largest palindrome product is `9`.
+Its factors are `(1, 9)` and `(3, 3)`.
 
 ## Example 2
 
 Given the range `[10, 99]` (both inclusive)...
 
-The smallest palindrome product is `121`. Its factors are `(11, 11)`.
-The largest palindrome product is `9009`. Its factors are `(91, 99)`.
+The smallest palindrome product is `121`.
+Its factors are `(11, 11)`.
+The largest palindrome product is `9009`.
+Its factors are `(91, 99)`.

--- a/exercises/pangram/description.md
+++ b/exercises/pangram/description.md
@@ -1,9 +1,9 @@
 # Description
 
-Determine if a sentence is a pangram. A pangram (Greek: παν γράμμα, pan gramma,
-"every letter") is a sentence using every letter of the alphabet at least once.
+Determine if a sentence is a pangram.
+A pangram (Greek: παν γράμμα, pan gramma, "every letter") is a sentence using every letter of the alphabet at least once.
 The best known English pangram is:
+
 > The quick brown fox jumps over the lazy dog.
 
-The alphabet used consists of letters `a` to `z`, inclusive, and is case
-insensitive.
+The alphabet used consists of letters `a` to `z`, inclusive, and is case insensitive.

--- a/exercises/parallel-letter-frequency/description.md
+++ b/exercises/parallel-letter-frequency/description.md
@@ -2,7 +2,6 @@
 
 Count the frequency of letters in texts using parallel computation.
 
-Parallelism is about doing things in parallel that can also be done
-sequentially. A common example is counting the frequency of letters.
-Create a function that returns the total frequency of each letter in a
-list of texts and that employs parallelism.
+Parallelism is about doing things in parallel that can also be done sequentially.
+A common example is counting the frequency of letters.
+Create a function that returns the total frequency of each letter in a list of texts and that employs parallelism.

--- a/exercises/pascals-triangle/description.md
+++ b/exercises/pascals-triangle/description.md
@@ -2,8 +2,7 @@
 
 Compute Pascal's triangle up to a given number of rows.
 
-In Pascal's Triangle each number is computed by adding the numbers to
-the right and left of the current position in the previous row.
+In Pascal's Triangle each number is computed by adding the numbers to the right and left of the current position in the previous row.
 
 ```text
     1

--- a/exercises/perfect-numbers/description.md
+++ b/exercises/perfect-numbers/description.md
@@ -3,7 +3,9 @@
 Determine if a number is perfect, abundant, or deficient based on
 Nicomachus' (60 - 120 CE) classification scheme for positive integers.
 
-The Greek mathematician [Nicomachus][nicomachus] devised a classification scheme for positive integers, identifying each as belonging uniquely to the categories of **perfect**, **abundant**, or **deficient** based on their [aliquot sum][aliquot-sum]. The aliquot sum is defined as the sum of the factors of a number not including the number itself. For example, the aliquot sum of 15 is (1 + 3 + 5) = 9
+The Greek mathematician [Nicomachus][nicomachus] devised a classification scheme for positive integers, identifying each as belonging uniquely to the categories of **perfect**, **abundant**, or **deficient** based on their [aliquot sum][aliquot-sum].
+The aliquot sum is defined as the sum of the factors of a number not including the number itself.
+For example, the aliquot sum of 15 is (1 + 3 + 5) = 9
 
 - **Perfect**: aliquot sum = number
   - 6 is a perfect number because (1 + 2 + 3) = 6
@@ -15,7 +17,8 @@ The Greek mathematician [Nicomachus][nicomachus] devised a classification scheme
   - 8 is a deficient number because (1 + 2 + 4) = 7
   - Prime numbers are deficient
 
-Implement a way to determine whether a given number is **perfect**. Depending on your language track, you may also need to implement a way to determine whether a given number is **abundant** or **deficient**.
+Implement a way to determine whether a given number is **perfect**.
+Depending on your language track, you may also need to implement a way to determine whether a given number is **abundant** or **deficient**.
 
 [nicomachus]: https://en.wikipedia.org/wiki/Nicomachus
 [aliquot-sum]: https://en.wikipedia.org/wiki/Aliquot_sum

--- a/exercises/phone-number/description.md
+++ b/exercises/phone-number/description.md
@@ -2,9 +2,11 @@
 
 Clean up user-entered phone numbers so that they can be sent SMS messages.
 
-The **North American Numbering Plan (NANP)** is a telephone numbering system used by many countries in North America like the United States, Canada or Bermuda. All NANP-countries share the same international country code: `1`.
+The **North American Numbering Plan (NANP)** is a telephone numbering system used by many countries in North America like the United States, Canada or Bermuda.
+All NANP-countries share the same international country code: `1`.
 
-NANP numbers are ten-digit numbers consisting of a three-digit Numbering Plan Area code, commonly known as *area code*, followed by a seven-digit local number. The first three digits of the local number represent the *exchange code*, followed by the unique four-digit number which is the *subscriber number*.
+NANP numbers are ten-digit numbers consisting of a three-digit Numbering Plan Area code, commonly known as *area code*, followed by a seven-digit local number.
+The first three digits of the local number represent the *exchange code*, followed by the unique four-digit number which is the *subscriber number*.
 
 The format is usually represented as
 

--- a/exercises/pig-latin/description.md
+++ b/exercises/pig-latin/description.md
@@ -2,18 +2,17 @@
 
 Implement a program that translates from English to Pig Latin.
 
-Pig Latin is a made-up children's language that's intended to be
-confusing. It obeys a few simple rules (below), but when it's spoken
-quickly it's really difficult for non-children (and non-native speakers)
-to understand.
+Pig Latin is a made-up children's language that's intended to be confusing.
+It obeys a few simple rules (below), but when it's spoken quickly it's really difficult for non-children (and non-native speakers) to understand.
 
-- **Rule 1**: If a word begins with a vowel sound, add an "ay" sound to the end of the word. Please note that "xr" and "yt" at the beginning of a word make vowel sounds (e.g. "xray" -> "xrayay", "yttria" -> "yttriaay").
-- **Rule 2**: If a word begins with a consonant sound, move it to the end of the word and then add an "ay" sound to the end of the word. Consonant sounds can be made up of multiple consonants, a.k.a. a consonant cluster (e.g. "chair" -> "airchay").
+- **Rule 1**: If a word begins with a vowel sound, add an "ay" sound to the end of the word.
+  Please note that "xr" and "yt" at the beginning of a word make vowel sounds (e.g. "xray" -> "xrayay", "yttria" -> "yttriaay").
+- **Rule 2**: If a word begins with a consonant sound, move it to the end of the word and then add an "ay" sound to the end of the word.
+  Consonant sounds can be made up of multiple consonants, a.k.a. a consonant cluster (e.g. "chair" -> "airchay").
 - **Rule 3**: If a word starts with a consonant sound followed by "qu", move it to the end of the word, and then add an "ay" sound to the end of the word (e.g. "square" -> "aresquay").
 - **Rule 4**: If a word contains a "y" after a consonant cluster or as the second letter in a two letter word it makes a vowel sound (e.g. "rhythm" -> "ythmrhay", "my" -> "ymay").
 
-There are a few more rules for edge cases, and there are regional
-variants too.
+There are a few more rules for edge cases, and there are regional variants too.
 
 Read more about [Pig Latin on Wikipedia][pig-latin].
 

--- a/exercises/pov/description.md
+++ b/exercises/pov/description.md
@@ -2,13 +2,11 @@
 
 Reparent a tree on a selected node.
 
-A [tree][wiki-tree] is a special type of [graph][wiki-graph] where all nodes
-are connected but there are no cycles. That means, there is exactly one path to
-get from one node to another for any pair of nodes.
+A [tree][wiki-tree] is a special type of [graph][wiki-graph] where all nodes are connected but there are no cycles.
+That means, there is exactly one path to get from one node to another for any pair of nodes.
 
-This exercise is all about re-orientating a tree to see things from a different
-point of view. For example family trees are usually presented from the
-ancestor's perspective:
+This exercise is all about re-orientating a tree to see things from a different point of view.
+For example family trees are usually presented from the ancestor's perspective:
 
 ```text
     +------0------+
@@ -18,10 +16,9 @@ ancestor's perspective:
   4   5  6   7  8   9
 ```
 
-But there is no inherent direction in a tree. The same information can be
-presented from the perspective of any other node in the tree, by pulling it up
-to the root and dragging its relationships along with it. So the same tree
-from 6's perspective would look like:
+But there is no inherent direction in a tree.
+The same information can be presented from the perspective of any other node in the tree, by pulling it up to the root and dragging its relationships along with it.
+So the same tree from 6's perspective would look like:
 
 ```text
         6
@@ -35,12 +32,10 @@ from 6's perspective would look like:
       4   5       8   9
 ```
 
-This lets us more simply describe the paths between two nodes. So for example
-the path from 6-9 (which in the first tree goes up to the root and then down to
-a different leaf node) can be seen to follow the path 6-2-0-3-9.
+This lets us more simply describe the paths between two nodes.
+So for example the path from 6-9 (which in the first tree goes up to the root and then down to a different leaf node) can be seen to follow the path 6-2-0-3-9.
 
-This exercise involves taking an input tree and re-orientating it from the point
-of view of one of the nodes.
+This exercise involves taking an input tree and re-orientating it from the point of view of one of the nodes.
 
 [wiki-graph]: https://en.wikipedia.org/wiki/Tree_(graph_theory)
 [wiki-tree]: https://en.wikipedia.org/wiki/Graph_(discrete_mathematics)

--- a/exercises/prime-factors/description.md
+++ b/exercises/prime-factors/description.md
@@ -10,17 +10,20 @@ Note that 1 is not a prime number.
 
 What are the prime factors of 60?
 
-- Our first divisor is 2. 2 goes into 60, leaving 30.
+- Our first divisor is 2.
+  2 goes into 60, leaving 30.
 - 2 goes into 30, leaving 15.
-  - 2 doesn't go cleanly into 15. So let's move on to our next divisor, 3.
+  - 2 doesn't go cleanly into 15.
+    So let's move on to our next divisor, 3.
 - 3 goes cleanly into 15, leaving 5.
-  - 3 does not go cleanly into 5. The next possible factor is 4.
-  - 4 does not go cleanly into 5. The next possible factor is 5.
+  - 3 does not go cleanly into 5.
+    The next possible factor is 4.
+  - 4 does not go cleanly into 5.
+    The next possible factor is 5.
 - 5 does go cleanly into 5.
 - We're left only with 1, so now, we're done.
 
-Our successful divisors in that computation represent the list of prime
-factors of 60: 2, 2, 3, and 5.
+Our successful divisors in that computation represent the list of prime factors of 60: 2, 2, 3, and 5.
 
 You can check this yourself:
 

--- a/exercises/protein-translation/description.md
+++ b/exercises/protein-translation/description.md
@@ -11,7 +11,8 @@ Codons: `"AUG", "UUU", "UCU"`
 
 Protein: `"Methionine", "Phenylalanine", "Serine"`
 
-There are 64 codons which in turn correspond to 20 amino acids; however, all of the codon sequences and resulting amino acids are not important in this exercise.  If it works for one codon, the program should work for all of them.
+There are 64 codons which in turn correspond to 20 amino acids; however, all of the codon sequences and resulting amino acids are not important in this exercise.
+If it works for one codon, the program should work for all of them.
 However, feel free to expand the list in the test suite to include them all.
 
 There are also three terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the protein is terminated.

--- a/exercises/proverb/description.md
+++ b/exercises/proverb/description.md
@@ -2,7 +2,8 @@
 
 For want of a horseshoe nail, a kingdom was lost, or so the saying goes.
 
-Given a list of inputs, generate the relevant proverb. For example, given the list `["nail", "shoe", "horse", "rider", "message", "battle", "kingdom"]`, you will output the full text of this proverbial rhyme:
+Given a list of inputs, generate the relevant proverb.
+For example, given the list `["nail", "shoe", "horse", "rider", "message", "battle", "kingdom"]`, you will output the full text of this proverbial rhyme:
 
 ```text
 For want of a nail the shoe was lost.
@@ -14,4 +15,5 @@ For want of a battle the kingdom was lost.
 And all for the want of a nail.
 ```
 
-Note that the list of inputs may vary; your solution should be able to handle lists of arbitrary length and content. No line of the output text should be a static, unchanging string; all should vary according to the input given.
+Note that the list of inputs may vary; your solution should be able to handle lists of arbitrary length and content.
+No line of the output text should be a static, unchanging string; all should vary according to the input given.

--- a/exercises/pythagorean-triplet/description.md
+++ b/exercises/pythagorean-triplet/description.md
@@ -1,7 +1,6 @@
 # Description
 
-A Pythagorean triplet is a set of three natural numbers, {a, b, c}, for
-which,
+A Pythagorean triplet is a set of three natural numbers, {a, b, c}, for which,
 
 ```text
 a² + b² = c²

--- a/exercises/rail-fence-cipher/description.md
+++ b/exercises/rail-fence-cipher/description.md
@@ -2,15 +2,13 @@
 
 Implement encoding and decoding for the rail fence cipher.
 
-The Rail Fence cipher is a form of transposition cipher that gets its name from
-the way in which it's encoded. It was already used by the ancient Greeks.
+The Rail Fence cipher is a form of transposition cipher that gets its name from the way in which it's encoded.
+It was already used by the ancient Greeks.
 
-In the Rail Fence cipher, the message is written downwards on successive "rails"
-of an imaginary fence, then moving up when we get to the bottom (like a zig-zag).
+In the Rail Fence cipher, the message is written downwards on successive "rails" of an imaginary fence, then moving up when we get to the bottom (like a zig-zag).
 Finally the message is then read off in rows.
 
-For example, using three "rails" and the message "WE ARE DISCOVERED FLEE AT ONCE",
-the cipherer writes out:
+For example, using three "rails" and the message "WE ARE DISCOVERED FLEE AT ONCE", the cipherer writes out:
 
 ```text
 W . . . E . . . C . . . R . . . L . . . T . . . E

--- a/exercises/raindrops/description.md
+++ b/exercises/raindrops/description.md
@@ -1,6 +1,8 @@
 # Description
 
-Your task is to convert a number into a string that contains raindrop sounds corresponding to certain potential factors. A factor is a number that evenly divides into another number, leaving no remainder. The simplest way to test if one number is a factor of another is to use the [modulo operation][modulo].
+Your task is to convert a number into a string that contains raindrop sounds corresponding to certain potential factors.
+A factor is a number that evenly divides into another number, leaving no remainder.
+The simplest way to test if one number is a factor of another is to use the [modulo operation][modulo].
 
 The rules of `raindrops` are that if a given number:
 

--- a/exercises/rational-numbers/description.md
+++ b/exercises/rational-numbers/description.md
@@ -31,7 +31,12 @@ Implement the following operations:
 - addition, subtraction, multiplication and division of two rational numbers,
 - absolute value, exponentiation of a given rational number to an integer power, exponentiation of a given rational number to a real (floating-point) power, exponentiation of a real number to a rational number.
 
-Your implementation of rational numbers should always be reduced to lowest terms. For example, `4/4` should reduce to `1/1`, `30/60` should reduce to `1/2`, `12/8` should reduce to `3/2`, etc. To reduce a rational number `r = a/b`, divide `a` and `b` by the greatest common divisor (gcd) of `a` and `b`. So, for example, `gcd(12, 8) = 4`, so `r = 12/8` can be reduced to `(12/4)/(8/4) = 3/2`.
-The reduced form of a rational number should be in "standard form" (the denominator should always be a positive integer). If a denominator with a negative integer is present, multiply both numerator and denominator by `-1` to ensure standard form is reached. For example, `3/-4` should be reduced to `-3/4`
+Your implementation of rational numbers should always be reduced to lowest terms.
+For example, `4/4` should reduce to `1/1`, `30/60` should reduce to `1/2`, `12/8` should reduce to `3/2`, etc.
+To reduce a rational number `r = a/b`, divide `a` and `b` by the greatest common divisor (gcd) of `a` and `b`.
+So, for example, `gcd(12, 8) = 4`, so `r = 12/8` can be reduced to `(12/4)/(8/4) = 3/2`.
+The reduced form of a rational number should be in "standard form" (the denominator should always be a positive integer).
+If a denominator with a negative integer is present, multiply both numerator and denominator by `-1` to ensure standard form is reached.
+For example, `3/-4` should be reduced to `-3/4`
 
 Assume that the programming language you are using does not have an implementation of rational numbers.

--- a/exercises/react/description.md
+++ b/exercises/react/description.md
@@ -2,15 +2,10 @@
 
 Implement a basic reactive system.
 
-Reactive programming is a programming paradigm that focuses on how values
-are computed in terms of each other to allow a change to one value to
-automatically propagate to other values, like in a spreadsheet.
+Reactive programming is a programming paradigm that focuses on how values are computed in terms of each other to allow a change to one value to automatically propagate to other values, like in a spreadsheet.
 
-Implement a basic reactive system with cells with settable values ("input"
-cells) and cells with values computed in terms of other cells ("compute"
-cells). Implement updates so that when an input value is changed, values
-propagate to reach a new stable system state.
+Implement a basic reactive system with cells with settable values ("input" cells) and cells with values computed in terms of other cells ("compute" cells).
+Implement updates so that when an input value is changed, values propagate to reach a new stable system state.
 
-In addition, compute cells should allow for registering change notification
-callbacks.  Call a cell’s callbacks when the cell’s value in a new stable
-state has changed from the previous stable state.
+In addition, compute cells should allow for registering change notification callbacks.
+Call a cell’s callbacks when the cell’s value in a new stable state has changed from the previous stable state.

--- a/exercises/rectangles/description.md
+++ b/exercises/rectangles/description.md
@@ -60,5 +60,4 @@ The above diagram contains these 6 rectangles:
 
 ```
 
-You may assume that the input is always a proper rectangle (i.e. the length of
-every line equals the length of the first line).
+You may assume that the input is always a proper rectangle (i.e. the length of every line equals the length of the first line).

--- a/exercises/resistor-color-trio/description.md
+++ b/exercises/resistor-color-trio/description.md
@@ -1,12 +1,15 @@
 # Description
 
-If you want to build something using a Raspberry Pi, you'll probably use _resistors_. For this exercise, you need to know only three things about them:
+If you want to build something using a Raspberry Pi, you'll probably use _resistors_.
+For this exercise, you need to know only three things about them:
 
 - Each resistor has a resistance value.
 - Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
   To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
-- Each band acts as a digit of a number. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
-  In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take 3 colors as input, and outputs the correct value, in ohms.
+- Each band acts as a digit of a number.
+  For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
+  In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands.
+  The program will take 3 colors as input, and outputs the correct value, in ohms.
   The color bands are encoded as follows:
 
 - Black: 0
@@ -20,8 +23,10 @@ If you want to build something using a Raspberry Pi, you'll probably use _resist
 - Grey: 8
 - White: 9
 
-In `resistor-color duo` you decoded the first two colors. For instance: orange-orange got the main value `33`.
-The third color stands for how many zeros need to be added to the main value. The main value plus the zeros gives us a value in ohms.
+In `resistor-color duo` you decoded the first two colors.
+For instance: orange-orange got the main value `33`.
+The third color stands for how many zeros need to be added to the main value.
+The main value plus the zeros gives us a value in ohms.
 For the exercise it doesn't matter what ohms really are.
 For example:
 
@@ -29,7 +34,9 @@ For example:
 - orange-orange-red would be 33 and 2 zeros, which becomes 3300 ohms.
 - orange-orange-orange would be 33 and 3 zeros, which becomes 33000 ohms.
 
-(If Math is your thing, you may want to think of the zeros as exponents of 10. If Math is not your thing, go with the zeros. It really is the same thing, just in plain English instead of Math lingo.)
+(If Math is your thing, you may want to think of the zeros as exponents of 10.
+If Math is not your thing, go with the zeros.
+It really is the same thing, just in plain English instead of Math lingo.)
 
 This exercise is about translating the colors into a label:
 
@@ -39,7 +46,9 @@ So an input of `"orange", "orange", "black"` should return:
 
 > "33 ohms"
 
-When we get more than a thousand ohms, we say "kiloohms". That's similar to saying "kilometer" for 1000 meters, and "kilograms" for 1000 grams.
+When we get more than a thousand ohms, we say "kiloohms".
+That's similar to saying "kilometer" for 1000 meters, and "kilograms" for 1000 grams.
+
 So an input of `"orange", "orange", "orange"` should return:
 
 > "33 kiloohms"

--- a/exercises/resistor-color/description.md
+++ b/exercises/resistor-color/description.md
@@ -31,7 +31,8 @@ The goal of this exercise is to create a way:
 - to look up the numerical value associated with a particular color band
 - to list the different band colors
 
-Mnemonics map the colors to the numbers, that, when stored as an array, happen to map to their index in the array: Better Be Right Or Your Great Big Values Go Wrong.
+Mnemonics map the colors to the numbers, that, when stored as an array, happen to map to their index in the array:
+Better Be Right Or Your Great Big Values Go Wrong.
 
 More information on the color encoding of resistors can be found in the [Electronic color code Wikipedia article][e-color-code].
 

--- a/exercises/rna-transcription/description.md
+++ b/exercises/rna-transcription/description.md
@@ -4,14 +4,11 @@ Given a DNA strand, return its RNA complement (per RNA transcription).
 
 Both DNA and RNA strands are a sequence of nucleotides.
 
-The four nucleotides found in DNA are adenine (**A**), cytosine (**C**),
-guanine (**G**) and thymine (**T**).
+The four nucleotides found in DNA are adenine (**A**), cytosine (**C**), guanine (**G**) and thymine (**T**).
 
-The four nucleotides found in RNA are adenine (**A**), cytosine (**C**),
-guanine (**G**) and uracil (**U**).
+The four nucleotides found in RNA are adenine (**A**), cytosine (**C**), guanine (**G**) and uracil (**U**).
 
-Given a DNA strand, its transcribed RNA strand is formed by replacing
-each nucleotide with its complement:
+Given a DNA strand, its transcribed RNA strand is formed by replacing each nucleotide with its complement:
 
 * `G` -> `C`
 * `C` -> `G`

--- a/exercises/robot-name/description.md
+++ b/exercises/robot-name/description.md
@@ -4,13 +4,11 @@ Manage robot factory settings.
 
 When a robot comes off the factory floor, it has no name.
 
-The first time you turn on a robot, a random name is generated in the format
-of two uppercase letters followed by three digits, such as RX837 or BC811.
+The first time you turn on a robot, a random name is generated in the format of two uppercase letters followed by three digits, such as RX837 or BC811.
 
-Every once in a while we need to reset a robot to its factory settings,
-which means that its name gets wiped. The next time you ask, that robot will
-respond with a new random name.
+Every once in a while we need to reset a robot to its factory settings, which means that its name gets wiped.
+The next time you ask, that robot will respond with a new random name.
 
 The names must be random: they should not follow a predictable sequence.
-Using random names means a risk of collisions. Your solution must ensure that
-every existing robot has a unique name.
+Using random names means a risk of collisions.
+Your solution must ensure that every existing robot has a unique name.

--- a/exercises/robot-simulator/description.md
+++ b/exercises/robot-simulator/description.md
@@ -10,13 +10,10 @@ The robots have three possible movements:
 - turn left
 - advance
 
-Robots are placed on a hypothetical infinite grid, facing a particular
-direction (north, east, south, or west) at a set of {x,y} coordinates,
+Robots are placed on a hypothetical infinite grid, facing a particular direction (north, east, south, or west) at a set of {x,y} coordinates,
 e.g., {3,8}, with coordinates increasing to the north and east.
 
-The robot then receives a number of instructions, at which point the
-testing facility verifies the robot's new position, and in which
-direction it is pointing.
+The robot then receives a number of instructions, at which point the testing facility verifies the robot's new position, and in which direction it is pointing.
 
 - The letter-string "RAALAL" means:
   - Turn right
@@ -24,5 +21,5 @@ direction it is pointing.
   - Turn left
   - Advance once
   - Turn left yet again
-- Say a robot starts at {7, 3} facing north. Then running this stream
-  of instructions should leave it at {9, 4} facing west.
+- Say a robot starts at {7, 3} facing north.
+  Then running this stream of instructions should leave it at {9, 4} facing west.

--- a/exercises/roman-numerals/description.md
+++ b/exercises/roman-numerals/description.md
@@ -2,17 +2,15 @@
 
 Write a function to convert from normal numbers to Roman Numerals.
 
-The Romans were a clever bunch. They conquered most of Europe and ruled
-it for hundreds of years. They invented concrete and straight roads and
-even bikinis. One thing they never discovered though was the number
-zero. This made writing and dating extensive histories of their exploits
-slightly more challenging, but the system of numbers they came up with
-is still in use today. For example the BBC uses Roman numerals to date
-their programs.
+The Romans were a clever bunch.
+They conquered most of Europe and ruled it for hundreds of years.
+They invented concrete and straight roads and even bikinis.
+One thing they never discovered though was the number zero.
+This made writing and dating extensive histories of their exploits slightly more challenging, but the system of numbers they came up with is still in use today.
+For example the BBC uses Roman numerals to date their programs.
 
-The Romans wrote numbers using letters - I, V, X, L, C, D, M. (notice
-these letters have lots of straight lines and are hence easy to hack
-into stone tablets).
+The Romans wrote numbers using letters - I, V, X, L, C, D, M.
+(notice these letters have lots of straight lines and are hence easy to hack into stone tablets).
 
 ```text
  1  => I
@@ -23,8 +21,7 @@ into stone tablets).
 The maximum number supported by this notation is 3,999.
 (The Romans themselves didn't tend to go any higher)
 
-Wikipedia says: Modern Roman numerals ... are written by expressing each
-digit separately starting with the left most digit and skipping any
+Wikipedia says: Modern Roman numerals ... are written by expressing each digit separately starting with the left most digit and skipping any
 digit with a value of zero.
 
 To see this in practice, consider the example of 1990.

--- a/exercises/rotational-cipher/description.md
+++ b/exercises/rotational-cipher/description.md
@@ -2,11 +2,9 @@
 
 Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.
 
-The Caesar cipher is a simple shift cipher that relies on
-transposing all the letters in the alphabet using an integer key
-between `0` and `26`. Using a key of `0` or `26` will always yield
-the same output due to modular arithmetic. The letter is shifted
-for as many values as the value of the key.
+The Caesar cipher is a simple shift cipher that relies on transposing all the letters in the alphabet using an integer key between `0` and `26`.
+Using a key of `0` or `26` will always yield the same output due to modular arithmetic.
+The letter is shifted for as many values as the value of the key.
 
 The general notation for rotational ciphers is `ROT + <key>`.
 The most commonly used rotational cipher is `ROT13`.

--- a/exercises/run-length-encoding/description.md
+++ b/exercises/run-length-encoding/description.md
@@ -2,8 +2,7 @@
 
 Implement run-length encoding and decoding.
 
-Run-length encoding (RLE) is a simple form of data compression, where runs
-(consecutive data elements) are replaced by just one data value and count.
+Run-length encoding (RLE) is a simple form of data compression, where runs (consecutive data elements) are replaced by just one data value and count.
 
 For example we can represent the original 53 characters with only 13.
 
@@ -11,14 +10,11 @@ For example we can represent the original 53 characters with only 13.
 "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB"  ->  "12WB12W3B24WB"
 ```
 
-RLE allows the original data to be perfectly reconstructed from
-the compressed data, which makes it a lossless data compression.
+RLE allows the original data to be perfectly reconstructed from the compressed data, which makes it a lossless data compression.
 
 ```text
 "AABCCCDEEEE"  ->  "2AB3CD4E"  ->  "AABCCCDEEEE"
 ```
 
-For simplicity, you can assume that the unencoded string will only contain
-the letters A through Z (either lower or upper case) and whitespace. This way
-data to be encoded will never contain any numbers and numbers inside data to
-be decoded always represent the count for the following character.
+For simplicity, you can assume that the unencoded string will only contain the letters A through Z (either lower or upper case) and whitespace.
+This way data to be encoded will never contain any numbers and numbers inside data to be decoded always represent the count for the following character.

--- a/exercises/saddle-points/description.md
+++ b/exercises/saddle-points/description.md
@@ -14,16 +14,12 @@ So say you have a matrix like so:
 
 It has a saddle point at row 2, column 1.
 
-It's called a "saddle point" because it is greater than or equal to
-every element in its row and less than or equal to every element in
-its column.
+It's called a "saddle point" because it is greater than or equal to every element in its row and less than or equal to every element in its column.
 
 A matrix may have zero or more saddle points.
 
-Your code should be able to provide the (possibly empty) list of all the
-saddle points for any given matrix.
+Your code should be able to provide the (possibly empty) list of all the saddle points for any given matrix.
 
 The matrix can have a different number of rows and columns (Non square).
 
-Note that you may find other definitions of matrix saddle points online,
-but the tests for this exercise follow the above unambiguous definition.
+Note that you may find other definitions of matrix saddle points online, but the tests for this exercise follow the above unambiguous definition.

--- a/exercises/satellite/description.md
+++ b/exercises/satellite/description.md
@@ -1,17 +1,15 @@
 # Description
 
-Imagine you need to transmit a binary tree to a satellite approaching Alpha
-Centauri and you have limited bandwidth. Since the tree has no repeating
-items it can be uniquely represented by its [pre-order and in-order traversals][wiki].
+Imagine you need to transmit a binary tree to a satellite approaching Alpha Centauri and you have limited bandwidth.
+Since the tree has no repeating items it can be uniquely represented by its [pre-order and in-order traversals][wiki].
 
 Write the software for the satellite to rebuild the tree from the traversals.
 
-A pre-order traversal reads the value of the current node before (hence "pre")
-reading the left subtree in pre-order. Afterwards the right subtree is read
-in pre-order.
+A pre-order traversal reads the value of the current node before (hence "pre") reading the left subtree in pre-order.
+Afterwards the right subtree is read in pre-order.
 
-An in-order traversal reads the left subtree in-order then the current node and
-finally the right subtree in-order. So in order from left to right.
+An in-order traversal reads the left subtree in-order then the current node and finally the right subtree in-order.
+So in order from left to right.
 
 For example the pre-order traversal of this tree is [a, i, x, f, r].
 The in-order traversal of this tree is [i, a, f, x, r]

--- a/exercises/say/description.md
+++ b/exercises/say/description.md
@@ -6,11 +6,9 @@ Given a number from 0 to 999,999,999,999, spell out that number in English.
 
 Handle the basic case of 0 through 99.
 
-If the input to the program is `22`, then the output should be
-`'twenty-two'`.
+If the input to the program is `22`, then the output should be `'twenty-two'`.
 
-Your program should complain loudly if given a number outside the
-blessed range.
+Your program should complain loudly if given a number outside the blessed range.
 
 Some good test cases for this program are:
 
@@ -23,15 +21,14 @@ Some good test cases for this program are:
 
 ### Extension
 
-If you're on a Mac, shell out to Mac OS X's `say` program to talk out
-loud. If you're on Linux or Windows, eSpeakNG may be available with the command `espeak`.
+If you're on a Mac, shell out to Mac OS X's `say` program to talk out loud.
+If you're on Linux or Windows, eSpeakNG may be available with the command `espeak`.
 
 ## Step 2
 
 Implement breaking a number up into chunks of thousands.
 
-So `1234567890` should yield a list like 1, 234, 567, and 890, while the
-far simpler `1000` should yield just 1 and 0.
+So `1234567890` should yield a list like 1, 234, 567, and 890, while the far simpler `1000` should yield just 1 and 0.
 
 The program must also report any values that are out of range.
 
@@ -41,8 +38,8 @@ Now handle inserting the appropriate scale word between those chunks.
 
 So `1234567890` should yield `'1 billion 234 million 567 thousand 890'`
 
-The program must also report any values that are out of range.  It's
-fine to stop at "trillion".
+The program must also report any values that are out of range.
+It's fine to stop at "trillion".
 
 ## Step 4
 

--- a/exercises/scale-generator/description.md
+++ b/exercises/scale-generator/description.md
@@ -2,23 +2,19 @@
 
 ## Chromatic Scales
 
-Scales in Western music are based on the chromatic (12-note) scale. This
-scale can be expressed as the following group of pitches:
+Scales in Western music are based on the chromatic (12-note) scale.
+This scale can be expressed as the following group of pitches:
 
 > A, A♯, B, C, C♯, D, D♯, E, F, F♯, G, G♯
 
-A given sharp note (indicated by a ♯) can also be expressed as the flat
-of the note above it (indicated by a ♭) so the chromatic scale can also be
-written like this:
+A given sharp note (indicated by a ♯) can also be expressed as the flat of the note above it (indicated by a ♭) so the chromatic scale can also be written like this:
 
 > A, B♭, B, C, D♭, D, E♭, E, F, G♭, G, A♭
 
-The major and minor scale and modes are subsets of this twelve-pitch
-collection. They have seven pitches, and are called diatonic scales.
-The collection of notes in these scales is written with either sharps or
-flats, depending on the tonic (starting note). Here is a table indicating
-whether the flat expression or sharp expression of the scale would be used for
-a given tonic:
+The major and minor scale and modes are subsets of this twelve-pitch collection.
+They have seven pitches, and are called diatonic scales.
+The collection of notes in these scales is written with either sharps or flats, depending on the tonic (starting note).
+Here is a table indicating whether the flat expression or sharp expression of the scale would be used for a given tonic:
 
 | Key Signature | Major                 | Minor                |
 | ------------- | --------------------- | -------------------- |
@@ -26,46 +22,35 @@ a given tonic:
 | Sharp         | G, D, A, E, B, F♯     | e, b, f♯, c♯, g♯, d♯ |
 | Flat          | F, B♭, E♭, A♭, D♭, G♭ | d, g, c, f, b♭, e♭   |
 
-Note that by common music theory convention the natural notes "C" and "a"
-follow the sharps scale when ascending and the flats scale when descending.
+Note that by common music theory convention the natural notes "C" and "a" follow the sharps scale when ascending and the flats scale when descending.
 For the scope of this exercise the scale is only ascending.
 
 ### Task
 
 Given a tonic, generate the 12 note chromatic scale starting with the tonic.
 
-- Shift the base scale appropriately so that all 12 notes are returned
-starting with the given tonic.
-- For the given tonic, determine if the scale is to be returned with flats
-or sharps.
-- Return all notes in uppercase letters (except for the `b` for flats)
-irrespective of the casing of the given tonic.
+- Shift the base scale appropriately so that all 12 notes are returned starting with the given tonic.
+- For the given tonic, determine if the scale is to be returned with flats or sharps.
+- Return all notes in uppercase letters (except for the `b` for flats) irrespective of the casing of the given tonic.
 
 ## Diatonic Scales
 
-The diatonic scales, and all other scales that derive from the
-chromatic scale, are built upon intervals. An interval is the space
-between two pitches.
+The diatonic scales, and all other scales that derive from the chromatic scale, are built upon intervals.
+An interval is the space between two pitches.
 
-The simplest interval is between two adjacent notes, and is called a
-"half step", or "minor second" (sometimes written as a lower-case "m").
-The interval between two notes that have an interceding note is called
-a "whole step" or "major second" (written as an upper-case "M"). The
-diatonic scales are built using only these two intervals between
-adjacent notes.
+The simplest interval is between two adjacent notes, and is called a "half step", or "minor second" (sometimes written as a lower-case "m").
+The interval between two notes that have an interceding note is called a "whole step" or "major second" (written as an upper-case "M").
+The diatonic scales are built using only these two intervals between adjacent notes.
 
-Non-diatonic scales can contain other intervals.  An "augmented second"
-interval, written "A", has two interceding notes (e.g., from A to C or D♭ to E)
-or a "whole step" plus a "half step". There are also smaller and larger
-intervals, but they will not figure into this exercise.
+Non-diatonic scales can contain other intervals.
+An "augmented second" interval, written "A", has two interceding notes (e.g., from A to C or D♭ to E) or a "whole step" plus a "half step".
+There are also smaller and larger intervals, but they will not figure into this exercise.
 
 ### Task
 
-Given a tonic and a set of intervals, generate the musical scale starting with
-the tonic and following the specified interval pattern.
+Given a tonic and a set of intervals, generate the musical scale starting with the tonic and following the specified interval pattern.
 
-This is similar to generating chromatic scales except that instead of returning
-12 notes, you will return N+1 notes for N intervals.
+This is similar to generating chromatic scales except that instead of returning 12 notes, you will return N+1 notes for N intervals.
 The first note is always the given tonic.
 Then, for each interval in the pattern, the next note is determined by starting from the previous note and skipping the number of notes indicated by the interval.
 

--- a/exercises/secret-handshake/description.md
+++ b/exercises/secret-handshake/description.md
@@ -3,15 +3,13 @@
 > There are 10 types of people in the world: Those who understand
 > binary, and those who don't.
 
-You and your fellow cohort of those in the "know" when it comes to
-binary decide to come up with a secret "handshake".
+You and your fellow cohort of those in the "know" when it comes to binary decide to come up with a secret "handshake".
 
 ```text
 00001 = wink
 00010 = double blink
 00100 = close your eyes
 01000 = jump
-
 
 10000 = Reverse the order of the operations in the secret handshake.
 ```
@@ -20,8 +18,7 @@ Given a decimal number, convert it to the appropriate sequence of events for a s
 
 Here's a couple of examples:
 
-Given the decimal input 3, the function would return the array
-["wink", "double blink"] because the decimal number 3 is 2+1 in powers of two and thus `11` in binary.
+Given the decimal input 3, the function would return the array ["wink", "double blink"] because the decimal number 3 is 2+1 in powers of two and thus `11` in binary.
 
 Let's now examine the input 19 which is 16+2+1 in powers of two and thus `10011` in binary.
 Recalling that the addition of 16 (`10000` in binary) reverses an array and that we already know what array is returned given input 3, the array returned for input 19 is ["double blink", "wink"].

--- a/exercises/series/description.md
+++ b/exercises/series/description.md
@@ -1,7 +1,6 @@
 # Description
 
-Given a string of digits, output all the contiguous substrings of length `n` in
-that string in the order that they appear.
+Given a string of digits, output all the contiguous substrings of length `n` in that string in the order that they appear.
 
 For example, the string "49142" has the following 3-digit series:
 
@@ -14,8 +13,7 @@ And the following 4-digit series:
 - "4914"
 - "9142"
 
-And if you ask for a 6-digit series from a 5-digit string, you deserve
-whatever you get.
+And if you ask for a 6-digit series from a 5-digit string, you deserve whatever you get.
 
-Note that these series are only required to occupy *adjacent positions*
-in the input; the digits need not be *numerically consecutive*.
+Note that these series are only required to occupy *adjacent positions* in the input;
+the digits need not be *numerically consecutive*.

--- a/exercises/sieve/description.md
+++ b/exercises/sieve/description.md
@@ -3,12 +3,12 @@
 Use the Sieve of Eratosthenes to find all the primes from 2 up to a given
 number.
 
-The Sieve of Eratosthenes is a simple, ancient algorithm for finding all
-prime numbers up to any given limit. It does so by iteratively marking as
-composite (i.e. not prime) the multiples of each prime, starting with the
-multiples of 2. It does not use any division or remainder operation.
+The Sieve of Eratosthenes is a simple, ancient algorithm for finding all prime numbers up to any given limit.
+It does so by iteratively marking as composite (i.e. not prime) the multiples of each prime, starting with the multiples of 2.
+It does not use any division or remainder operation.
 
-Create your range, starting at two and continuing up to and including the given limit. (i.e. [2, limit])
+Create your range, starting at two and continuing up to and including the given limit.
+(i.e. [2, limit])
 
 The algorithm consists of repeating the following over and over:
 
@@ -22,10 +22,7 @@ been marked are prime.
 
 [This wikipedia article][eratosthenes] has a useful graphic that explains the algorithm.
 
-Notice that this is a very specific algorithm, and the tests don't check
-that you've implemented the algorithm, only that you've come up with the
-correct list of primes. A good first test is to check that you do not use
-division or remainder operations (div, /, mod or % depending on the
-language).
+Notice that this is a very specific algorithm, and the tests don't check that you've implemented the algorithm, only that you've come up with the correct list of primes.
+A good first test is to check that you do not use division or remainder operations (div, /, mod or % depending on the language).
 
 [eratosthenes]: https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes

--- a/exercises/simple-cipher/description.md
+++ b/exercises/simple-cipher/description.md
@@ -4,23 +4,16 @@ Implement a simple shift cipher like Caesar and a more secure substitution ciphe
 
 ## Step 1
 
-"If he had anything confidential to say, he wrote it in cipher, that is,
-by so changing the order of the letters of the alphabet, that not a word
-could be made out. If anyone wishes to decipher these, and get at their
-meaning, he must substitute the fourth letter of the alphabet, namely D,
-for A, and so with the others."
+"If he had anything confidential to say, he wrote it in cipher, that is, by so changing the order of the letters of the alphabet, that not a word could be made out.
+If anyone wishes to decipher these, and get at their meaning, he must substitute the fourth letter of the alphabet, namely D, for A, and so with the others."
 —Suetonius, Life of Julius Caesar
 
-Ciphers are very straight-forward algorithms that allow us to render
-text less readable while still allowing easy deciphering. They are
-vulnerable to many forms of cryptanalysis, but we are lucky that
-generally our little sisters are not cryptanalysts.
+Ciphers are very straight-forward algorithms that allow us to render text less readable while still allowing easy deciphering.
+They are vulnerable to many forms of cryptanalysis, but we are lucky that generally our little sisters are not cryptanalysts.
 
-The Caesar Cipher was used for some messages from Julius Caesar that
-were sent afield. Now Caesar knew that the cipher wasn't very good, but
-he had one ally in that respect: almost nobody could read well. So even
-being a couple letters off was sufficient so that people couldn't
-recognize the few words that they did know.
+The Caesar Cipher was used for some messages from Julius Caesar that were sent afield.
+Now Caesar knew that the cipher wasn't very good, but he had one ally in that respect: almost nobody could read well.
+So even being a couple letters off was sufficient so that people couldn't recognize the few words that they did know.
 
 Your task is to create a simple shift cipher like the Caesar Cipher.
 This image is a great example of the Caesar Cipher:
@@ -29,17 +22,16 @@ This image is a great example of the Caesar Cipher:
 
 For example:
 
-Giving "iamapandabear" as input to the encode function returns the cipher "ldpdsdqgdehdu". Obscure enough to keep our message secret in transit.
+Giving "iamapandabear" as input to the encode function returns the cipher "ldpdsdqgdehdu".
+Obscure enough to keep our message secret in transit.
 
-When "ldpdsdqgdehdu" is put into the decode function it would return
-the original "iamapandabear" letting your friend read your original
-message.
+When "ldpdsdqgdehdu" is put into the decode function it would return the original "iamapandabear" letting your friend read your original message.
 
 ## Step 2
 
-Shift ciphers are no fun though when your kid sister figures it out. Try
-amending the code to allow us to specify a key and use that for the
-shift distance. This is called a substitution cipher.
+Shift ciphers are no fun though when your kid sister figures it out.
+Try amending the code to allow us to specify a key and use that for the shift distance.
+This is called a substitution cipher.
 
 Here's an example:
 
@@ -49,31 +41,26 @@ would return the original "iamapandabear".
 Given the key "ddddddddddddddddd", encoding our string "iamapandabear"
 would return the obscured "ldpdsdqgdehdu"
 
-In the example above, we've set a = 0 for the key value. So when the
-plaintext is added to the key, we end up with the same message coming
-out. So "aaaa" is not an ideal key. But if we set the key to "dddd", we
-would get the same thing as the Caesar Cipher.
+In the example above, we've set a = 0 for the key value.
+So when the plaintext is added to the key, we end up with the same message coming out.
+So "aaaa" is not an ideal key.
+But if we set the key to "dddd", we would get the same thing as the Caesar Cipher.
 
 ## Step 3
 
-The weakest link in any cipher is the human being. Let's make your
-substitution cipher a little more fault tolerant by providing a source
-of randomness and ensuring that the key contains only lowercase letters.
+The weakest link in any cipher is the human being.
+Let's make your substitution cipher a little more fault tolerant by providing a source of randomness and ensuring that the key contains only lowercase letters.
 
-If someone doesn't submit a key at all, generate a truly random key of
-at least 100 lowercase characters in length.
+If someone doesn't submit a key at all, generate a truly random key of at least 100 lowercase characters in length.
 
 ## Extensions
 
-Shift ciphers work by making the text slightly odd, but are vulnerable
-to frequency analysis. Substitution ciphers help that, but are still
-very vulnerable when the key is short or if spaces are preserved. Later
-on you'll see one solution to this problem in the exercise
-"crypto-square".
+Shift ciphers work by making the text slightly odd, but are vulnerable to frequency analysis.
+Substitution ciphers help that, but are still very vulnerable when the key is short or if spaces are preserved.
+Later on you'll see one solution to this problem in the exercise "crypto-square".
 
-If you want to go farther in this field, the questions begin to be about
-how we can exchange keys in a secure way. Take a look at [Diffie-Hellman
-on Wikipedia][dh] for one of the first implementations of this scheme.
+If you want to go farther in this field, the questions begin to be about how we can exchange keys in a secure way.
+Take a look at [Diffie-Hellman on Wikipedia][dh] for one of the first implementations of this scheme.
 
 [img-caesar-cipher]: https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Caesar_cipher_left_shift_of_3.svg/320px-Caesar_cipher_left_shift_of_3.svg.png
 [dh]: http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange

--- a/exercises/simple-linked-list/description.md
+++ b/exercises/simple-linked-list/description.md
@@ -2,21 +2,14 @@
 
 Write a simple linked list implementation that uses Elements and a List.
 
-The linked list is a fundamental data structure in computer science,
-often used in the implementation of other data structures. They're
-pervasive in functional programming languages, such as Clojure, Erlang,
-or Haskell, but far less common in imperative languages such as Ruby or
-Python.
+The linked list is a fundamental data structure in computer science, often used in the implementation of other data structures.
+They're pervasive in functional programming languages, such as Clojure, Erlang, or Haskell, but far less common in imperative languages such as Ruby or Python.
 
-The simplest kind of linked list is a singly linked list. Each element in the
-list contains data and a "next" field pointing to the next element in the list
-of elements.
+The simplest kind of linked list is a singly linked list.
+Each element in the list contains data and a "next" field pointing to the next element in the list of elements.
 
-This variant of linked lists is often used to represent sequences or
-push-down stacks (also called a LIFO stack; Last In, First Out).
+This variant of linked lists is often used to represent sequences or push-down stacks (also called a LIFO stack; Last In, First Out).
 
-As a first take, lets create a singly linked list to contain the range (1..10),
-and provide functions to reverse a linked list and convert to and from arrays.
+As a first take, lets create a singly linked list to contain the range (1..10), and provide functions to reverse a linked list and convert to and from arrays.
 
-When implementing this in a language with built-in linked lists,
-implement your own abstract data type.
+When implementing this in a language with built-in linked lists, implement your own abstract data type.

--- a/exercises/spiral-matrix/description.md
+++ b/exercises/spiral-matrix/description.md
@@ -2,9 +2,7 @@
 
 Given the size, return a square matrix of numbers in spiral order.
 
-The matrix should be filled with natural numbers, starting from 1
-in the top-left corner, increasing in an inward, clockwise spiral order,
-like these examples:
+The matrix should be filled with natural numbers, starting from 1 in the top-left corner, increasing in an inward, clockwise spiral order, like these examples:
 
 ## Examples
 

--- a/exercises/square-root/description.md
+++ b/exercises/square-root/description.md
@@ -2,7 +2,8 @@
 
 Given a natural radicand, return its square root.
 
-Note that the term "radicand" refers to the number for which the root is to be determined. That is, it is the number under the root symbol.
+Note that the term "radicand" refers to the number for which the root is to be determined.
+That is, it is the number under the root symbol.
 
 Check out the Wikipedia pages on [square root][square-root] and [methods of computing square roots][computing-square-roots].
 

--- a/exercises/strain/description.md
+++ b/exercises/strain/description.md
@@ -1,9 +1,7 @@
 # Description
 
-Implement the `keep` and `discard` operation on collections. Given a collection
-and a predicate on the collection's elements, `keep` returns a new collection
-containing those elements where the predicate is true, while `discard` returns
-a new collection containing those elements where the predicate is false.
+Implement the `keep` and `discard` operation on collections.
+Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.
 
 For example, given the collection of numbers:
 
@@ -23,12 +21,9 @@ While your discard operation should produce:
 
 Note that the union of keep and discard is all the elements.
 
-The functions may be called `keep` and `discard`, or they may need different
-names in order to not clash with existing functions or concepts in your
-language.
+The functions may be called `keep` and `discard`, or they may need different names in order to not clash with existing functions or concepts in your language.
 
 ## Restrictions
 
-Keep your hands off that filter/reject/whatchamacallit functionality
-provided by your standard library!  Solve this one yourself using other
-basic tools instead.
+Keep your hands off that filter/reject/whatchamacallit functionality provided by your standard library!
+Solve this one yourself using other basic tools instead.

--- a/exercises/sum-of-multiples/description.md
+++ b/exercises/sum-of-multiples/description.md
@@ -1,9 +1,7 @@
 # Description
 
-Given a number, find the sum of all the unique multiples of particular numbers up to
-but not including that number.
+Given a number, find the sum of all the unique multiples of particular numbers up to but not including that number.
 
-If we list all the natural numbers below 20 that are multiples of 3 or 5,
-we get 3, 5, 6, 9, 10, 12, 15, and 18.
+If we list all the natural numbers below 20 that are multiples of 3 or 5, we get 3, 5, 6, 9, 10, 12, 15, and 18.
 
 The sum of these multiples is 78.

--- a/exercises/tournament/description.md
+++ b/exercises/tournament/description.md
@@ -2,8 +2,7 @@
 
 Tally the results of a small football competition.
 
-Based on an input file containing which team played against which and what the
-outcome was, create a file with a table like this:
+Based on an input file containing which team played against which and what the outcome was, create a file with a table like this:
 
 ```text
 Team                           | MP |  W |  D |  L |  P
@@ -21,9 +20,12 @@ What do those abbreviations mean?
 - L: Matches Lost
 - P: Points
 
-A win earns a team 3 points. A draw earns 1. A loss earns 0.
+A win earns a team 3 points.
+A draw earns 1.
+A loss earns 0.
 
-The outcome should be ordered by points, descending. In case of a tie, teams are ordered alphabetically.
+The outcome should be ordered by points, descending.
+In case of a tie, teams are ordered alphabetically.
 
 ## Input
 
@@ -38,7 +40,8 @@ Blithering Badgers;Devastating Donkeys;loss
 Allegoric Alaskans;Courageous Californians;win
 ```
 
-The result of the match refers to the first team listed. So this line:
+The result of the match refers to the first team listed.
+So this line:
 
 ```text
 Allegoric Alaskans;Blithering Badgers;win

--- a/exercises/transpose/description.md
+++ b/exercises/transpose/description.md
@@ -17,7 +17,8 @@ BE
 CF
 ```
 
-Rows become columns and columns become rows. See [transpose][].
+Rows become columns and columns become rows.
+See [transpose][].
 
 If the input has rows of different lengths, this is to be solved as follows:
 
@@ -55,7 +56,6 @@ BE
 ```
 
 In general, all characters from the input should also be present in the transposed output.
-That means that if a column in the input text contains only spaces on its bottom-most row(s),
-the corresponding output row should contain the spaces in its right-most column(s).
+That means that if a column in the input text contains only spaces on its bottom-most row(s), the corresponding output row should contain the spaces in its right-most column(s).
 
 [transpose]: https://en.wikipedia.org/wiki/Transpose

--- a/exercises/tree-building/description.md
+++ b/exercises/tree-building/description.md
@@ -2,17 +2,14 @@
 
 Refactor a tree building algorithm.
 
-Some web-forums have a tree layout, so posts are presented as a tree. However
-the posts are typically stored in a database as an unsorted set of records. Thus
-when presenting the posts to the user the tree structure has to be
-reconstructed.
+Some web-forums have a tree layout, so posts are presented as a tree.
+However the posts are typically stored in a database as an unsorted set of records.
+Thus when presenting the posts to the user the tree structure has to be reconstructed.
 
-Your job will be to refactor a working but slow and ugly piece of code that
-implements the tree building logic for highly abstracted records. The records
-only contain an ID number and a parent ID number. The ID number is always
-between 0 (inclusive) and the length of the record list (exclusive). All records
-have a parent ID lower than their own ID, except for the root record, which has
-a parent ID that's equal to its own ID.
+Your job will be to refactor a working but slow and ugly piece of code that implements the tree building logic for highly abstracted records.
+The records only contain an ID number and a parent ID number.
+The ID number is always between 0 (inclusive) and the length of the record list (exclusive).
+All records have a parent ID lower than their own ID, except for the root record, which has a parent ID that's equal to its own ID.
 
 An example tree:
 

--- a/exercises/triangle/description.md
+++ b/exercises/triangle/description.md
@@ -4,9 +4,8 @@ Determine if a triangle is equilateral, isosceles, or scalene.
 
 An _equilateral_ triangle has all three sides the same length.
 
-An _isosceles_ triangle has at least two sides the same length. (It is sometimes
-specified as having exactly two sides the same length, but for the purposes of
-this exercise we'll say at least two.)
+An _isosceles_ triangle has at least two sides the same length.
+(It is sometimes specified as having exactly two sides the same length, but for the purposes of this exercise we'll say at least two.)
 
 A _scalene_ triangle has all sides of different lengths.
 
@@ -16,7 +15,8 @@ For a shape to be a triangle at all, all sides have to be of length > 0, and the
 
 In equations:
 
-Let `a`, `b`, and `c` be sides of the triangle. Then all three of the following expressions must be true:
+Let `a`, `b`, and `c` be sides of the triangle.
+Then all three of the following expressions must be true:
 
 ```text
 a + b ≥ c

--- a/exercises/trinary/description.md
+++ b/exercises/trinary/description.md
@@ -1,15 +1,13 @@
 # Description
 
-Convert a trinary number, represented as a string (e.g. '102012'), to its
-decimal equivalent using first principles.
+Convert a trinary number, represented as a string (e.g. '102012'), to its decimal equivalent using first principles.
 
-The program should consider strings specifying an invalid trinary as the
-value 0.
+The program should consider strings specifying an invalid trinary as the value 0.
 
 Trinary numbers contain three symbols: 0, 1, and 2.
 
-The last place in a trinary number is the 1's place. The second to last
-is the 3's place, the third to last is the 9's place, etc.
+The last place in a trinary number is the 1's place.
+The second to last is the 3's place, the third to last is the 9's place, etc.
 
 ```shell
 # "102012"
@@ -18,5 +16,4 @@ is the 3's place, the third to last is the 9's place, etc.
   243 +     0 +    54 +     0 +     3 +     2 =  302
 ```
 
-If your language provides a method in the standard library to perform the
-conversion, pretend it doesn't exist and implement it yourself.
+If your language provides a method in the standard library to perform the conversion, pretend it doesn't exist and implement it yourself.

--- a/exercises/twelve-days/description.md
+++ b/exercises/twelve-days/description.md
@@ -2,7 +2,8 @@
 
 Your task in this exercise is to write code that returns the lyrics of the song: "The Twelve Days of Christmas."
 
-"The Twelve Days of Christmas" is a common English Christmas carol. Each subsequent verse of the song builds on the previous verse.
+"The Twelve Days of Christmas" is a common English Christmas carol.
+Each subsequent verse of the song builds on the previous verse.
 
 The lyrics your code returns should _exactly_ match the full song text shown below.
 

--- a/exercises/two-bucket/description.md
+++ b/exercises/two-bucket/description.md
@@ -29,10 +29,17 @@ Your program should determine:
 Note: any time a change is made to either or both buckets counts as one (1) action.
 
 Example:
-Bucket one can hold up to 7 liters, and bucket two can hold up to 11 liters. Let's say at a given step, bucket one is holding 7 liters and bucket two is holding 8 liters (7,8). If you empty bucket one and make no change to bucket two, leaving you with 0 liters and 8 liters respectively (0,8), that counts as one action. Instead, if you had poured from bucket one into bucket two until bucket two was full, resulting in 4 liters in bucket one and 11 liters in bucket two (4,11), that would also only count as one action.
+Bucket one can hold up to 7 liters, and bucket two can hold up to 11 liters.
+Let's say at a given step, bucket one is holding 7 liters and bucket two is holding 8 liters (7,8).
+If you empty bucket one and make no change to bucket two, leaving you with 0 liters and 8 liters respectively (0,8), that counts as one action.
+Instead, if you had poured from bucket one into bucket two until bucket two was full, resulting in 4 liters in bucket one and 11 liters in bucket two (4,11), that would also only count as one action.
 
 Another Example:
-Bucket one can hold 3 liters, and bucket two can hold up to 5 liters.  You are told you must start with bucket one.  So your first action is to fill bucket one.  You choose to empty bucket one for your second action.  For your third action, you may not fill bucket two, because this violates the third rule -- you may not end up in a state after any action where the starting bucket is empty and the other bucket is full.
+Bucket one can hold 3 liters, and bucket two can hold up to 5 liters.
+You are told you must start with bucket one.
+So your first action is to fill bucket one.
+You choose to empty bucket one for your second action.
+For your third action, you may not fill bucket two, because this violates the third rule -- you may not end up in a state after any action where the starting bucket is empty and the other bucket is full.
 
 Written with <3 at [Fullstack Academy][fulstack] by Lindsay Levine.
 

--- a/exercises/two-fer/description.md
+++ b/exercises/two-fer/description.md
@@ -1,6 +1,7 @@
 # Description
 
-`Two-fer` or `2-fer` is short for two for one. One for you and one for me.
+`Two-fer` or `2-fer` is short for two for one.
+One for you and one for me.
 
 Given a name, return a string with the message:
 

--- a/exercises/word-search/description.md
+++ b/exercises/word-search/description.md
@@ -1,7 +1,6 @@
 # Description
 
-In word search puzzles you get a square of letters and have to find specific
-words in them.
+In word search puzzles you get a square of letters and have to find specific words in them.
 
 For example:
 
@@ -20,8 +19,6 @@ clojurermt
 
 There are several programming languages hidden in the above square.
 
-Words can be hidden in all kinds of directions: left-to-right, right-to-left,
-vertical and diagonal.
+Words can be hidden in all kinds of directions: left-to-right, right-to-left, vertical and diagonal.
 
-Given a puzzle and a list of words return the location of the first and last
-letter of each word.
+Given a puzzle and a list of words return the location of the first and last letter of each word.

--- a/exercises/wordy/description.md
+++ b/exercises/wordy/description.md
@@ -40,8 +40,7 @@ Now, perform the other three operations.
 
 Handle a set of operations, in sequence.
 
-Since these are verbal word problems, evaluate the expression from
-left-to-right, _ignoring the typical order of operations._
+Since these are verbal word problems, evaluate the expression from left-to-right, _ignoring the typical order of operations._
 
 > What is 5 plus 13 plus 6?
 

--- a/exercises/yacht/description.md
+++ b/exercises/yacht/description.md
@@ -1,10 +1,8 @@
 # Description
 
-The dice game [Yacht][yacht] is from
-the same family as Poker Dice, Generala and particularly Yahtzee, of which it
-is a precursor. In the game, five dice are rolled and the result can be entered
-in any of twelve categories. The score of a throw of the dice depends on
-category chosen.
+The dice game [Yacht][yacht] is from the same family as Poker Dice, Generala and particularly Yahtzee, of which it is a precursor.
+In the game, five dice are rolled and the result can be entered in any of twelve categories.
+The score of a throw of the dice depends on category chosen.
 
 ## Scores in Yacht
 
@@ -24,15 +22,14 @@ category chosen.
 | Yacht | 50 points | All five dice showing the same face | 4 4 4 4 4 scores 50 |
 
 If the dice do not satisfy the requirements of a category, the score is zero.
-If, for example, *Four Of A Kind* is entered in the *Yacht* category, zero
-points are scored. A *Yacht* scores zero if entered in the *Full House* category.
+If, for example, *Four Of A Kind* is entered in the *Yacht* category, zero points are scored.
+A *Yacht* scores zero if entered in the *Full House* category.
 
 ## Task
 
-Given a list of values for five dice and a category, your solution should return
-the score of the dice for that category. If the dice do not satisfy the requirements
-of the category your solution should return 0. You can assume that five values
-will always be presented, and the value of each will be between one and six
-inclusively. You should not assume that the dice are ordered.
+Given a list of values for five dice and a category, your solution should return the score of the dice for that category.
+If the dice do not satisfy the requirements of the category your solution should return 0.
+You can assume that five values will always be presented, and the value of each will be between one and six inclusively.
+You should not assume that the dice are ordered.
 
 [yacht]: https://en.wikipedia.org/wiki/Yacht_(dice_game)

--- a/exercises/zebra-puzzle/description.md
+++ b/exercises/zebra-puzzle/description.md
@@ -18,9 +18,7 @@ Solve the zebra puzzle.
 14. The Japanese smokes Parliaments.
 15. The Norwegian lives next to the blue house.
 
-Each of the five houses is painted a different color, and their
-inhabitants are of different national extractions, own different pets,
-drink different beverages and smoke different brands of cigarettes.
+Each of the five houses is painted a different color, and their inhabitants are of different national extractions, own different pets, drink different beverages and smoke different brands of cigarettes.
 
 Which of the residents drinks water?
 Who owns the zebra?

--- a/exercises/zipper/description.md
+++ b/exercises/zipper/description.md
@@ -2,13 +2,10 @@
 
 Creating a zipper for a binary tree.
 
-[Zippers][zipper] are
-a purely functional way of navigating within a data structure and
-manipulating it.  They essentially contain a data structure and a
-pointer into that data structure (called the focus).
+[Zippers][zipper] are a purely functional way of navigating within a data structure and manipulating it.
+They essentially contain a data structure and a pointer into that data structure (called the focus).
 
-For example given a rose tree (where each node contains a value and a
-list of child nodes) a zipper might support these operations:
+For example given a rose tree (where each node contains a value and a list of child nodes) a zipper might support these operations:
 
 - `from_tree` (get a zipper out of a rose tree, the focus is on the root node)
 - `to_tree` (get the rose tree out of the zipper)


### PR DESCRIPTION
This updates the exercise descriptions to have one sentence per line, to conform to the Exerism Markdown Specification.

There are a couple of deprecated exercises that I didn't touch. There are also a couple of files that have open PRs that are fixing the one sentence per line thing as part of a bigger overhaul, so I didn't touch those either.

There's a chance that I missed a spot here and there, as this task was too messy to automate properly. (I could have done so, but then it would have been roughly the same amount of work as doing it manually, and it still probably would have gone wrong. So I didn't bother with a script).