### PR TITLE
Fix an accidental split line in exercise description

### DIFF
--- a/exercises/dot-dsl/description.md
+++ b/exercises/dot-dsl/description.md
@@ -1,7 +1,6 @@
 # Description
 
-A [Domain Specific Language (DSL)][dsl] is a
-small language optimized for a specific domain.
+A [Domain Specific Language (DSL)][dsl] is a small language optimized for a specific domain.
 Since a DSL is targeted, it can greatly impact productivity/understanding by allowing the writer to declare *what* they want rather than *how*.
 
 One problem area where they are applied are complex customizations/configurations.

--- a/exercises/roman-numerals/description.md
+++ b/exercises/roman-numerals/description.md
@@ -21,8 +21,7 @@ The Romans wrote numbers using letters - I, V, X, L, C, D, M.
 The maximum number supported by this notation is 3,999.
 (The Romans themselves didn't tend to go any higher)
 
-Wikipedia says: Modern Roman numerals ... are written by expressing each digit separately starting with the left most digit and skipping any
-digit with a value of zero.
+Wikipedia says: Modern Roman numerals ... are written by expressing each digit separately starting with the left most digit and skipping any digit with a value of zero.
 
 To see this in practice, consider the example of 1990.
 


### PR DESCRIPTION
In #2118 we normalized the descriptions to follow the one sentence per line directive in the Exercism
Markdown Specification.

I missed a couple of spots and this fixes those.