### PR TITLE
Add titles to the metadata for all exercises

### DIFF
--- a/exercises/accumulate/metadata.toml
+++ b/exercises/accumulate/metadata.toml
@@ -1,3 +1,4 @@
+title = "Accumulate"
 blurb = "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection."
 source = "Conversation with James Edward Gray II"
 source_url = "https://twitter.com/jeg2"

--- a/exercises/acronym/metadata.toml
+++ b/exercises/acronym/metadata.toml
@@ -1,3 +1,4 @@
+title = "Acronym"
 blurb = "Convert a long phrase to its acronym."
 source = "Julien Vanier"
 source_url = "https://github.com/monkbroc"

--- a/exercises/affine-cipher/metadata.toml
+++ b/exercises/affine-cipher/metadata.toml
@@ -1,3 +1,4 @@
+title = "Affine Cipher"
 blurb = "Create an implementation of the Affine cipher, an ancient encryption algorithm from the Middle East."
 source = "Wikipedia"
 source_url = "http://en.wikipedia.org/wiki/Affine_cipher"

--- a/exercises/all-your-base/metadata.toml
+++ b/exercises/all-your-base/metadata.toml
@@ -1,1 +1,2 @@
+title = "All Your Base"
 blurb = "Convert a number, represented as a sequence of digits in one base, to any other base."

--- a/exercises/allergies/metadata.toml
+++ b/exercises/allergies/metadata.toml
@@ -1,3 +1,4 @@
+title = "Allergies"
 blurb = "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies."
 source = "Jumpstart Lab Warm-up"
 source_url = "http://jumpstartlab.com"

--- a/exercises/alphametics/metadata.toml
+++ b/exercises/alphametics/metadata.toml
@@ -1,1 +1,2 @@
+title = "Alphametics"
 blurb = "Write a function to solve alphametics puzzles."

--- a/exercises/anagram/metadata.toml
+++ b/exercises/anagram/metadata.toml
@@ -1,3 +1,4 @@
+title = "Anagram"
 blurb = "Given a word and a list of possible anagrams, select the correct sublist."
 source = "Inspired by the Extreme Startup game"
 source_url = "https://github.com/rchatley/extreme_startup"

--- a/exercises/armstrong-numbers/metadata.toml
+++ b/exercises/armstrong-numbers/metadata.toml
@@ -1,3 +1,4 @@
+title = "Armstrong Numbers"
 blurb = "Determine if a number is an Armstrong number."
 source = "Wikipedia"
 source_url = "https://en.wikipedia.org/wiki/Narcissistic_number"

--- a/exercises/atbash-cipher/metadata.toml
+++ b/exercises/atbash-cipher/metadata.toml
@@ -1,3 +1,4 @@
+title = "Atbash Cipher"
 blurb = "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East."
 source = "Wikipedia"
 source_url = "http://en.wikipedia.org/wiki/Atbash"

--- a/exercises/bank-account/metadata.toml
+++ b/exercises/bank-account/metadata.toml
@@ -1,1 +1,2 @@
+title = "Bank Account"
 blurb = "Simulate a bank account supporting opening/closing, withdraws, and deposits of money. Watch out for concurrent transactions!"

--- a/exercises/beer-song/metadata.toml
+++ b/exercises/beer-song/metadata.toml
@@ -1,3 +1,4 @@
+title = "Beer Song"
 blurb = "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall."
 source = "Learn to Program by Chris Pine"
 source_url = "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/binary-search-tree/metadata.toml
+++ b/exercises/binary-search-tree/metadata.toml
@@ -1,3 +1,4 @@
+title = "Binary Search Tree"
 blurb = "Insert and search for numbers in a binary tree."
 source = "Josh Cheek"
 source_url = "https://twitter.com/josh_cheek"

--- a/exercises/binary-search/metadata.toml
+++ b/exercises/binary-search/metadata.toml
@@ -1,3 +1,4 @@
+title = "Binary Search"
 blurb = "Implement a binary search algorithm."
 source = "Wikipedia"
 source_url = "http://en.wikipedia.org/wiki/Binary_search_algorithm"

--- a/exercises/binary/metadata.toml
+++ b/exercises/binary/metadata.toml
@@ -1,3 +1,4 @@
+title = "Binary"
 blurb = "Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles."
 source = "All of Computer Science"
 source_url = "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"

--- a/exercises/bob/metadata.toml
+++ b/exercises/bob/metadata.toml
@@ -1,3 +1,4 @@
+title = "Bob"
 blurb = "Bob is a lackadaisical teenager. In conversation, his responses are very limited."
 source = "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial."
 source_url = "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/book-store/metadata.toml
+++ b/exercises/book-store/metadata.toml
@@ -1,3 +1,4 @@
+title = "Book Store"
 blurb = "To try and encourage more sales of different books from a popular 5 book series, a bookshop has decided to offer discounts of multiple-book purchases."
 source = "Inspired by the harry potter kata from Cyber-Dojo."
 source_url = "http://cyber-dojo.org"

--- a/exercises/bottle-song/metadata.toml
+++ b/exercises/bottle-song/metadata.toml
@@ -1,3 +1,4 @@
+title = "Bottle Song"
 blurb = "Produce the lyrics to the popular children's repetitive song: Ten Green Bottles."
 source = "Wikipedia"
 source_url = "https://en.wikipedia.org/wiki/Ten_Green_Bottles"

--- a/exercises/bowling/metadata.toml
+++ b/exercises/bowling/metadata.toml
@@ -1,3 +1,4 @@
+title = "Bowling"
 blurb = "Score a bowling game."
 source = "The Bowling Game Kata from UncleBob"
 source_url = "http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata"

--- a/exercises/change/metadata.toml
+++ b/exercises/change/metadata.toml
@@ -1,3 +1,4 @@
+title = "Change"
 blurb = "Correctly determine change to be given using the least number of coins."
 source = "Software Craftsmanship - Coin Change Kata"
 source_url = "https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata"

--- a/exercises/circular-buffer/metadata.toml
+++ b/exercises/circular-buffer/metadata.toml
@@ -1,3 +1,4 @@
+title = "Circular Buffer"
 blurb = "A data structure that uses a single, fixed-size buffer as if it were connected end-to-end."
 source = "Wikipedia"
 source_url = "http://en.wikipedia.org/wiki/Circular_buffer"

--- a/exercises/clock/metadata.toml
+++ b/exercises/clock/metadata.toml
@@ -1,3 +1,4 @@
+title = "Clock"
 blurb = "Implement a clock that handles times without dates."
 source = "Pairing session with Erin Drummond"
 source_url = "https://twitter.com/ebdrummond"

--- a/exercises/collatz-conjecture/metadata.toml
+++ b/exercises/collatz-conjecture/metadata.toml
@@ -1,3 +1,4 @@
+title = "Collatz Conjecture"
 blurb = "Calculate the number of steps to reach 1 using the Collatz conjecture."
 source = "An unsolved problem in mathematics named after mathematician Lothar Collatz"
 source_url = "https://en.wikipedia.org/wiki/3x_%2B_1_problem"

--- a/exercises/complex-numbers/metadata.toml
+++ b/exercises/complex-numbers/metadata.toml
@@ -1,3 +1,4 @@
+title = "Complex Numbers"
 blurb = "Implement complex numbers."
 source = "Wikipedia"
 source_url = "https://en.wikipedia.org/wiki/Complex_number"

--- a/exercises/connect/metadata.toml
+++ b/exercises/connect/metadata.toml
@@ -1,1 +1,2 @@
+title = "Connect"
 blurb = "Compute the result for a game of Hex / Polygon."

--- a/exercises/counter/metadata.toml
+++ b/exercises/counter/metadata.toml
@@ -1,1 +1,2 @@
+title = "Counter"
 blurb = "Design a test suite for a line/letter/character counter tool."

--- a/exercises/crypto-square/metadata.toml
+++ b/exercises/crypto-square/metadata.toml
@@ -1,3 +1,4 @@
+title = "Crypto Square"
 blurb = "Implement the classic method for composing secret messages called a square code."
 source = "J Dalbey's Programming Practice problems"
 source_url = "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/darts/metadata.toml
+++ b/exercises/darts/metadata.toml
@@ -1,2 +1,3 @@
+title = "Darts"
 blurb = "Write a function that returns the earned points in a single toss of a Darts game."
 source = "Inspired by an exercise created by a professor Della Paolera in Argentina"

--- a/exercises/diamond/metadata.toml
+++ b/exercises/diamond/metadata.toml
@@ -1,3 +1,4 @@
+title = "Diamond"
 blurb = "Given a letter, print a diamond starting with 'A' with the supplied letter at the widest point."
 source = "Seb Rose"
 source_url = "http://claysnow.co.uk/recycling-tests-in-tdd/"

--- a/exercises/difference-of-squares/metadata.toml
+++ b/exercises/difference-of-squares/metadata.toml
@@ -1,3 +1,4 @@
+title = "Difference of Squares"
 blurb = "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers."
 source = "Problem 6 at Project Euler"
 source_url = "http://projecteuler.net/problem=6"

--- a/exercises/diffie-hellman/metadata.toml
+++ b/exercises/diffie-hellman/metadata.toml
@@ -1,3 +1,4 @@
+title = "Diffie-Hellman"
 blurb = "Diffie-Hellman key exchange."
 source = "Wikipedia, 1024 bit key from www.cryptopp.com/wiki."
 source_url = "http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange"

--- a/exercises/dominoes/metadata.toml
+++ b/exercises/dominoes/metadata.toml
@@ -1,1 +1,2 @@
+title = "Dominoes"
 blurb = "Make a chain of dominoes."

--- a/exercises/error-handling/metadata.toml
+++ b/exercises/error-handling/metadata.toml
@@ -1,1 +1,2 @@
+title = "Error Handling"
 blurb = "Implement various kinds of error handling and resource management."

--- a/exercises/flatten-array/metadata.toml
+++ b/exercises/flatten-array/metadata.toml
@@ -1,3 +1,4 @@
+title = "Flatten Array"
 blurb = "Take a nested list and return a single list with all values except nil/null."
 source = "Interview Question"
 source_url = "https://reference.wolfram.com/language/ref/Flatten.html"

--- a/exercises/food-chain/metadata.toml
+++ b/exercises/food-chain/metadata.toml
@@ -1,3 +1,4 @@
+title = "Food Chain"
 blurb = "Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'."
 source = "Wikipedia"
 source_url = "http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly"

--- a/exercises/forth/metadata.toml
+++ b/exercises/forth/metadata.toml
@@ -1,1 +1,2 @@
+title = "Forth"
 blurb = "Implement an evaluator for a very simple subset of Forth."

--- a/exercises/gigasecond/metadata.toml
+++ b/exercises/gigasecond/metadata.toml
@@ -1,3 +1,4 @@
+title = "Gigasecond"
 blurb = "Given a moment, determine the moment that would be after a gigasecond has passed."
 source = "Chapter 9 in Chris Pine's online Learn to Program tutorial."
 source_url = "http://pine.fm/LearnToProgram/?Chapter=09"

--- a/exercises/go-counting/metadata.toml
+++ b/exercises/go-counting/metadata.toml
@@ -1,1 +1,2 @@
+title = "Go Counting"
 blurb = "Count the scored points on a Go board."

--- a/exercises/grade-school/metadata.toml
+++ b/exercises/grade-school/metadata.toml
@@ -1,2 +1,3 @@
+title = "Grade School"
 blurb = "Given students' names along with the grade that they are in, create a roster for the school."
 source = "A pairing session with Phil Battos at gSchool"

--- a/exercises/grains/metadata.toml
+++ b/exercises/grains/metadata.toml
@@ -1,3 +1,4 @@
+title = "Grains"
 blurb = "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles."
 source = "JavaRanch Cattle Drive, exercise 6"
 source_url = "http://www.javaranch.com/grains.jsp"

--- a/exercises/grep/metadata.toml
+++ b/exercises/grep/metadata.toml
@@ -1,3 +1,4 @@
+title = "Grep"
 blurb = "Search a file for lines matching a regular expression pattern. Return the line number and contents of each matching line."
 source = "Conversation with Nate Foster."
 source_url = "http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf"

--- a/exercises/hamming/metadata.toml
+++ b/exercises/hamming/metadata.toml
@@ -1,3 +1,4 @@
+title = "Hamming"
 blurb = "Calculate the Hamming difference between two DNA strands."
 source = "The Calculating Point Mutations problem at Rosalind"
 source_url = "http://rosalind.info/problems/hamm/"

--- a/exercises/hangman/metadata.toml
+++ b/exercises/hangman/metadata.toml
@@ -1,1 +1,2 @@
+title = "Hangman"
 blurb = "Implement the logic of the hangman game using functional reactive programming."

--- a/exercises/hello-world/metadata.toml
+++ b/exercises/hello-world/metadata.toml
@@ -1,3 +1,4 @@
+title = "Hello World"
 blurb = "The classical introductory exercise. Just say \"Hello, World!\"."
 source = "This is an exercise to introduce users to using Exercism"
 source_url = "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"

--- a/exercises/hexadecimal/metadata.toml
+++ b/exercises/hexadecimal/metadata.toml
@@ -1,3 +1,4 @@
+title = "Hexadecimal"
 blurb = "Convert a hexadecimal number, represented as a string (e.g. \"10af8c\"), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion)."
 source = "All of Computer Science"
 source_url = "http://www.wolframalpha.com/examples/NumberBases.html"

--- a/exercises/high-scores/metadata.toml
+++ b/exercises/high-scores/metadata.toml
@@ -1,2 +1,3 @@
+title = "High Scores"
 blurb = "Manage a player's High Score list."
 source = "Tribute to the eighties' arcade game Frogger"

--- a/exercises/house/metadata.toml
+++ b/exercises/house/metadata.toml
@@ -1,3 +1,4 @@
+title = "House"
 blurb = "Output the nursery rhyme 'This is the House that Jack Built'."
 source = "British nursery rhyme"
 source_url = "http://en.wikipedia.org/wiki/This_Is_The_House_That_Jack_Built"

--- a/exercises/isogram/metadata.toml
+++ b/exercises/isogram/metadata.toml
@@ -1,3 +1,4 @@
+title = "Isogram"
 blurb = "Determine if a word or phrase is an isogram."
 source = "Wikipedia"
 source_url = "https://en.wikipedia.org/wiki/Isogram"

--- a/exercises/killer-sudoku-helper/metadata.toml
+++ b/exercises/killer-sudoku-helper/metadata.toml
@@ -1,3 +1,4 @@
+title = "Killer Sudoku Helper"
 blurb = "Write a tool that makes it easier to solve Killer Sudokus"
 source = "Created by Sascha Mann, Jeremy Walker, and BethanyG for the Julia track on Exercism."
 source_url = "https://github.com/exercism/julia/pull/413"

--- a/exercises/kindergarten-garden/metadata.toml
+++ b/exercises/kindergarten-garden/metadata.toml
@@ -1,3 +1,4 @@
+title = "Kindergarten Garden"
 blurb = "Given a diagram, determine which plants each child in the kindergarten class is responsible for."
 source = "Random musings during airplane trip."
 source_url = "http://jumpstartlab.com"

--- a/exercises/knapsack/metadata.toml
+++ b/exercises/knapsack/metadata.toml
@@ -1,3 +1,4 @@
+title = "Knapsack"
 blurb = "Given a knapsack that can only carry a certain weight, determine which items to put in the knapsack in order to maximize their combined value."
 source = "Wikipedia"
 source_url = "https://en.wikipedia.org/wiki/Knapsack_problem"

--- a/exercises/largest-series-product/metadata.toml
+++ b/exercises/largest-series-product/metadata.toml
@@ -1,3 +1,4 @@
+title = "Largest Series Product"
 blurb = "Given a string of digits, calculate the largest product for a contiguous substring of digits of length n."
 source = "A variation on Problem 8 at Project Euler"
 source_url = "http://projecteuler.net/problem=8"

--- a/exercises/leap/metadata.toml
+++ b/exercises/leap/metadata.toml
@@ -1,3 +1,4 @@
+title = "Leap"
 blurb = "Given a year, report if it is a leap year."
 source = "JavaRanch Cattle Drive, exercise 3"
 source_url = "http://www.javaranch.com/leap.jsp"

--- a/exercises/ledger/metadata.toml
+++ b/exercises/ledger/metadata.toml
@@ -1,1 +1,2 @@
+title = "Ledger"
 blurb = "Refactor a ledger printer."

--- a/exercises/lens-person/metadata.toml
+++ b/exercises/lens-person/metadata.toml
@@ -1,1 +1,2 @@
+title = "Lens Person"
 blurb = "Use lenses to update nested records (specific to languages with immutable data)."

--- a/exercises/linked-list/metadata.toml
+++ b/exercises/linked-list/metadata.toml
@@ -1,2 +1,3 @@
+title = "Linked List"
 blurb = "Implement a doubly linked list."
 source = "Classic computer science topic"

--- a/exercises/list-ops/metadata.toml
+++ b/exercises/list-ops/metadata.toml
@@ -1,1 +1,2 @@
+title = "List Ops"
 blurb = "Implement basic list operations."

--- a/exercises/luhn/metadata.toml
+++ b/exercises/luhn/metadata.toml
@@ -1,3 +1,4 @@
+title = "Luhn"
 blurb = "Given a number determine whether or not it is valid per the Luhn formula."
 source = "The Luhn Algorithm on Wikipedia"
 source_url = "http://en.wikipedia.org/wiki/Luhn_algorithm"

--- a/exercises/markdown/metadata.toml
+++ b/exercises/markdown/metadata.toml
@@ -1,1 +1,2 @@
+title = "Markdown"
 blurb = "Refactor a Markdown parser."

--- a/exercises/matching-brackets/metadata.toml
+++ b/exercises/matching-brackets/metadata.toml
@@ -1,2 +1,3 @@
+title = "Matching Brackets"
 blurb = "Make sure the brackets and braces all match."
 source = "Ginna Baker"

--- a/exercises/matrix/metadata.toml
+++ b/exercises/matrix/metadata.toml
@@ -1,3 +1,4 @@
+title = "Matrix"
 blurb = "Given a string representing a matrix of numbers, return the rows and columns of that matrix."
 source = "Warmup to the `saddle-points` warmup."
 source_url = "http://jumpstartlab.com"

--- a/exercises/meetup/metadata.toml
+++ b/exercises/meetup/metadata.toml
@@ -1,3 +1,4 @@
+title = "Meetup"
 blurb = "Calculate the date of meetups."
 source = "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month"
 source_url = "https://twitter.com/copiousfreetime"

--- a/exercises/minesweeper/metadata.toml
+++ b/exercises/minesweeper/metadata.toml
@@ -1,1 +1,2 @@
+title = "Minesweeper"
 blurb = "Add the numbers to a minesweeper board."

--- a/exercises/nth-prime/metadata.toml
+++ b/exercises/nth-prime/metadata.toml
@@ -1,3 +1,4 @@
+title = "Nth Prime"
 blurb = "Given a number n, determine what the nth prime is."
 source = "A variation on Problem 7 at Project Euler"
 source_url = "http://projecteuler.net/problem=7"

--- a/exercises/nucleotide-codons/metadata.toml
+++ b/exercises/nucleotide-codons/metadata.toml
@@ -1,1 +1,2 @@
+title = "Nucleotide Codons"
 blurb = "Write a function that returns the name of an amino acid a particular codon, possibly using shorthand, encodes for."

--- a/exercises/nucleotide-count/metadata.toml
+++ b/exercises/nucleotide-count/metadata.toml
@@ -1,3 +1,4 @@
+title = "Nucleotide Count"
 blurb = "Given a DNA string, compute how many times each nucleotide occurs in the string."
 source = "The Calculating DNA Nucleotides_problem at Rosalind"
 source_url = "http://rosalind.info/problems/dna/"

--- a/exercises/octal/metadata.toml
+++ b/exercises/octal/metadata.toml
@@ -1,3 +1,4 @@
+title = "Octal"
 blurb = "Convert a octal number, represented as a string (e.g. '1735263'), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion)."
 source = "All of Computer Science"
 source_url = "http://www.wolframalpha.com/input/?i=base+8"

--- a/exercises/palindrome-products/metadata.toml
+++ b/exercises/palindrome-products/metadata.toml
@@ -1,3 +1,4 @@
+title = "Palindrome Products"
 blurb = "Detect palindrome products in a given range."
 source = "Problem 4 at Project Euler"
 source_url = "http://projecteuler.net/problem=4"

--- a/exercises/pangram/metadata.toml
+++ b/exercises/pangram/metadata.toml
@@ -1,3 +1,4 @@
+title = "Pangram"
 blurb = "Determine if a sentence is a pangram."
 source = "Wikipedia"
 source_url = "https://en.wikipedia.org/wiki/Pangram"

--- a/exercises/parallel-letter-frequency/metadata.toml
+++ b/exercises/parallel-letter-frequency/metadata.toml
@@ -1,1 +1,2 @@
+title = "Parallel Letter Frequency"
 blurb = "Count the frequency of letters in texts using parallel computation."

--- a/exercises/perfect-numbers/metadata.toml
+++ b/exercises/perfect-numbers/metadata.toml
@@ -1,3 +1,4 @@
+title = "Perfect Numbers"
 blurb = "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers."
 source = "Taken from Chapter 2 of Functional Thinking by Neal Ford."
 source_url = "http://shop.oreilly.com/product/0636920029687.do"

--- a/exercises/phone-number/metadata.toml
+++ b/exercises/phone-number/metadata.toml
@@ -1,3 +1,4 @@
+title = "Phone Number"
 blurb = "Clean up user-entered phone numbers so that they can be sent SMS messages."
 source = "Event Manager by JumpstartLab"
 source_url = "http://tutorials.jumpstartlab.com/projects/eventmanager.html"

--- a/exercises/pig-latin/metadata.toml
+++ b/exercises/pig-latin/metadata.toml
@@ -1,3 +1,4 @@
+title = "Pig Latin"
 blurb = "Implement a program that translates from English to Pig Latin."
 source = "The Pig Latin exercise at Test First Teaching by Ultrasaurus"
 source_url = "https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/"

--- a/exercises/point-mutations/metadata.toml
+++ b/exercises/point-mutations/metadata.toml
@@ -1,3 +1,4 @@
+title = "Point Mutations"
 blurb = "Calculate the Hamming difference between two DNA strands."
 source = "The Calculating Point Mutations problem at Rosalind"
 source_url = "http://rosalind.info/problems/hamm/"

--- a/exercises/poker/metadata.toml
+++ b/exercises/poker/metadata.toml
@@ -1,3 +1,4 @@
+title = "Poker"
 blurb = "Pick the best hand(s) from a list of poker hands."
 source = "Inspired by the training course from Udacity."
 source_url = "https://www.udacity.com/course/viewer#!/c-cs212/"

--- a/exercises/prime-factors/metadata.toml
+++ b/exercises/prime-factors/metadata.toml
@@ -1,3 +1,4 @@
+title = "Prime Factors"
 blurb = "Compute the prime factors of a given natural number."
 source = "The Prime Factors Kata by Uncle Bob"
 source_url = "http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata"

--- a/exercises/protein-translation/metadata.toml
+++ b/exercises/protein-translation/metadata.toml
@@ -1,2 +1,3 @@
+title = "Protein Translation"
 blurb = "Translate RNA sequences into proteins."
 source = "Tyler Long"

--- a/exercises/proverb/metadata.toml
+++ b/exercises/proverb/metadata.toml
@@ -1,3 +1,4 @@
+title = "Proverb"
 blurb = "For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output the full text of this proverbial rhyme."
 source = "Wikipedia"
 source_url = "http://en.wikipedia.org/wiki/For_Want_of_a_Nail"

--- a/exercises/pythagorean-triplet/metadata.toml
+++ b/exercises/pythagorean-triplet/metadata.toml
@@ -1,3 +1,4 @@
+title = "Pythagorean Triplet"
 blurb = "There exists exactly one Pythagorean triplet for which a + b + c = 1000. Find the product a * b * c."
 source = "Problem 9 at Project Euler"
 source_url = "http://projecteuler.net/problem=9"

--- a/exercises/queen-attack/metadata.toml
+++ b/exercises/queen-attack/metadata.toml
@@ -1,3 +1,4 @@
+title = "Queen Attack"
 blurb = "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other."
 source = "J Dalbey's Programming Practice problems"
 source_url = "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/rail-fence-cipher/metadata.toml
+++ b/exercises/rail-fence-cipher/metadata.toml
@@ -1,3 +1,4 @@
+title = "Rail Fence Cipher"
 blurb = "Implement encoding and decoding for the rail fence cipher."
 source = "Wikipedia"
 source_url = "https://en.wikipedia.org/wiki/Transposition_cipher#Rail_Fence_cipher"

--- a/exercises/raindrops/metadata.toml
+++ b/exercises/raindrops/metadata.toml
@@ -1,3 +1,4 @@
+title = "Raindrops"
 blurb = "Convert a number to a string, the content of which depends on the number's factors."
 source = "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division."
 source_url = "https://en.wikipedia.org/wiki/Fizz_buzz"

--- a/exercises/rational-numbers/metadata.toml
+++ b/exercises/rational-numbers/metadata.toml
@@ -1,3 +1,4 @@
+title = "Rational Numbers"
 blurb = "Implement rational numbers."
 source = "Wikipedia"
 source_url = "https://en.wikipedia.org/wiki/Rational_number"

--- a/exercises/react/metadata.toml
+++ b/exercises/react/metadata.toml
@@ -1,1 +1,2 @@
+title = "React"
 blurb = "Implement a basic reactive system."

--- a/exercises/rectangles/metadata.toml
+++ b/exercises/rectangles/metadata.toml
@@ -1,1 +1,2 @@
+title = "Rectangles"
 blurb = "Count the rectangles in an ASCII diagram."

--- a/exercises/resistor-color-duo/metadata.toml
+++ b/exercises/resistor-color-duo/metadata.toml
@@ -1,3 +1,4 @@
+title = "Resistor Color Duo"
 blurb = "Convert color codes, as used on resistors, to a numeric value."
 source = "Maud de Vries, Erik Schierboom"
 source_url = "https://github.com/exercism/problem-specifications/issues/1464"

--- a/exercises/resistor-color-trio/metadata.toml
+++ b/exercises/resistor-color-trio/metadata.toml
@@ -1,3 +1,4 @@
+title = "Resistor Color Trio"
 blurb = "Convert color codes, as used on resistors, to a human-readable label."
 source = "Maud de Vries, Erik Schierboom"
 source_url = "https://github.com/exercism/problem-specifications/issues/1549"

--- a/exercises/resistor-color/metadata.toml
+++ b/exercises/resistor-color/metadata.toml
@@ -1,3 +1,4 @@
+title = "Resistor Color"
 blurb = "Convert a resistor band's color to its numeric representation."
 source = "Maud de Vries, Erik Schierboom"
 source_url = "https://github.com/exercism/problem-specifications/issues/1458"

--- a/exercises/rest-api/metadata.toml
+++ b/exercises/rest-api/metadata.toml
@@ -1,1 +1,2 @@
+title = "REST API"
 blurb = "Implement a RESTful API for tracking IOUs."

--- a/exercises/reverse-string/metadata.toml
+++ b/exercises/reverse-string/metadata.toml
@@ -1,3 +1,4 @@
+title = "Reverse String"
 blurb = "Reverse a string."
 source = "Introductory challenge to reverse an input string"
 source_url = "https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb"

--- a/exercises/robot-name/metadata.toml
+++ b/exercises/robot-name/metadata.toml
@@ -1,2 +1,3 @@
+title = "Robot Name"
 blurb = "Manage robot factory settings."
 source = "A debugging session with Paul Blackwell at gSchool."

--- a/exercises/robot-simulator/metadata.toml
+++ b/exercises/robot-simulator/metadata.toml
@@ -1,2 +1,3 @@
+title = "Robot Simulator"
 blurb = "Write a robot simulator."
 source = "Inspired by an interview question at a famous company."

--- a/exercises/roman-numerals/metadata.toml
+++ b/exercises/roman-numerals/metadata.toml
@@ -1,3 +1,4 @@
+title = "Roman Numerals"
 blurb = "Write a function to convert from normal numbers to Roman Numerals."
 source = "The Roman Numeral Kata"
 source_url = "http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals"

--- a/exercises/rotational-cipher/metadata.toml
+++ b/exercises/rotational-cipher/metadata.toml
@@ -1,3 +1,4 @@
+title = "Rotational Cipher"
 blurb = "Create an implementation of the rotational cipher, also sometimes called the Caesar cipher."
 source = "Wikipedia"
 source_url = "https://en.wikipedia.org/wiki/Caesar_cipher"

--- a/exercises/run-length-encoding/metadata.toml
+++ b/exercises/run-length-encoding/metadata.toml
@@ -1,3 +1,4 @@
+title = "Run-Length Encoding"
 blurb = "Implement run-length encoding and decoding."
 source = "Wikipedia"
 source_url = "https://en.wikipedia.org/wiki/Run-length_encoding"

--- a/exercises/saddle-points/metadata.toml
+++ b/exercises/saddle-points/metadata.toml
@@ -1,3 +1,4 @@
+title = "Saddle Points"
 blurb = "Detect saddle points in a matrix."
 source = "J Dalbey's Programming Practice problems"
 source_url = "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/say/metadata.toml
+++ b/exercises/say/metadata.toml
@@ -1,3 +1,4 @@
+title = "Say"
 blurb = "Given a number from 0 to 999,999,999,999, spell out that number in English."
 source = "A variation on JavaRanch CattleDrive, exercise 4a"
 source_url = "http://www.javaranch.com/say.jsp"

--- a/exercises/scale-generator/metadata.toml
+++ b/exercises/scale-generator/metadata.toml
@@ -1,1 +1,2 @@
+title = "Scale Generator"
 blurb = "Generate musical scales, given a starting note and a set of intervals."

--- a/exercises/scrabble-score/metadata.toml
+++ b/exercises/scrabble-score/metadata.toml
@@ -1,3 +1,4 @@
+title = "Scrabble Score"
 blurb = "Given a word, compute the Scrabble score for that word."
 source = "Inspired by the Extreme Startup game"
 source_url = "https://github.com/rchatley/extreme_startup"

--- a/exercises/secret-handshake/metadata.toml
+++ b/exercises/secret-handshake/metadata.toml
@@ -1,3 +1,4 @@
+title = "Secret Handshake"
 blurb = "Given a decimal number, convert it to the appropriate sequence of events for a secret handshake."
 source = "Bert, in Mary Poppins"
 source_url = "http://www.imdb.com/title/tt0058331/quotes/qt0437047"

--- a/exercises/series/metadata.toml
+++ b/exercises/series/metadata.toml
@@ -1,3 +1,4 @@
+title = "Series"
 blurb = "Given a string of digits, output all the contiguous substrings of length `n` in that string."
 source = "A subset of the Problem 8 at Project Euler"
 source_url = "http://projecteuler.net/problem=8"

--- a/exercises/sieve/metadata.toml
+++ b/exercises/sieve/metadata.toml
@@ -1,3 +1,4 @@
+title = "Sieve"
 blurb = "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number."
 source = "Sieve of Eratosthenes at Wikipedia"
 source_url = "http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes"

--- a/exercises/simple-cipher/metadata.toml
+++ b/exercises/simple-cipher/metadata.toml
@@ -1,3 +1,4 @@
+title = "Simple Cipher"
 blurb = "Implement a simple shift cipher like Caesar and a more secure substitution cipher."
 source = "Substitution Cipher at Wikipedia"
 source_url = "http://en.wikipedia.org/wiki/Substitution_cipher"

--- a/exercises/simple-linked-list/metadata.toml
+++ b/exercises/simple-linked-list/metadata.toml
@@ -1,3 +1,4 @@
+title = "Simple Linked List"
 blurb = "Write a simple linked list implementation that uses Elements and a List."
 source = "Inspired by 'Data Structures and Algorithms with Object-Oriented Design Patterns in Ruby', singly linked-lists."
 source_url = "https://web.archive.org/web/20160731005714/http://brpreiss.com/books/opus8/html/page96.html"

--- a/exercises/space-age/metadata.toml
+++ b/exercises/space-age/metadata.toml
@@ -1,3 +1,4 @@
+title = "Space Age"
 blurb = "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years."
 source = "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial."
 source_url = "http://pine.fm/LearnToProgram/?Chapter=01"

--- a/exercises/spiral-matrix/metadata.toml
+++ b/exercises/spiral-matrix/metadata.toml
@@ -1,3 +1,4 @@
+title = "Spiral Matrix"
 blurb = " Given the size, return a square matrix of numbers in spiral order."
 source = "Reddit r/dailyprogrammer challenge #320 [Easy] Spiral Ascension."
 source_url = "https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/"

--- a/exercises/square-root/metadata.toml
+++ b/exercises/square-root/metadata.toml
@@ -1,3 +1,4 @@
+title = "Square Root"
 blurb = "Given a natural radicand, return its square root."
 source = "wolf99"
 source_url = "https://github.com/exercism/problem-specifications/pull/1582"

--- a/exercises/state-of-tic-tac-toe/metadata.toml
+++ b/exercises/state-of-tic-tac-toe/metadata.toml
@@ -1,3 +1,4 @@
-blurb = "Determine the game state of a match of Tic Tac Toe."
+title = "State of Tic-Tac-Toe"
+blurb = "Determine the game state of a match of Tic-Tac-Toe."
 source = "Created by Sascha Mann for the Julia track of the Exercism Research Experiment."
 source_url = "https://github.com/exercism/research_experiment_1/tree/julia-dev/exercises/julia-1-a"

--- a/exercises/strain/metadata.toml
+++ b/exercises/strain/metadata.toml
@@ -1,3 +1,4 @@
+title = "Strain"
 blurb = "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false."
 source = "Conversation with James Edward Gray II"
 source_url = "https://twitter.com/jeg2"

--- a/exercises/sublist/metadata.toml
+++ b/exercises/sublist/metadata.toml
@@ -1,1 +1,2 @@
+title = "Sublist"
 blurb = "Write a function to determine if a list is a sublist of another list."

--- a/exercises/sum-of-multiples/metadata.toml
+++ b/exercises/sum-of-multiples/metadata.toml
@@ -1,3 +1,4 @@
+title = "Sum of Multiples"
 blurb = "Given a number, find the sum of all the multiples of particular numbers up to but not including that number."
 source = "A variation on Problem 1 at Project Euler"
 source_url = "http://projecteuler.net/problem=1"

--- a/exercises/tournament/metadata.toml
+++ b/exercises/tournament/metadata.toml
@@ -1,1 +1,2 @@
+title = "Tournament"
 blurb = "Tally the results of a small football competition."

--- a/exercises/transpose/metadata.toml
+++ b/exercises/transpose/metadata.toml
@@ -1,3 +1,4 @@
+title = "Transpose"
 blurb = "Take input text and output it transposed."
 source = "Reddit r/dailyprogrammer challenge #270 [Easy]."
 source_url = "https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text"

--- a/exercises/tree-building/metadata.toml
+++ b/exercises/tree-building/metadata.toml
@@ -1,1 +1,2 @@
+title = "Tree Building"
 blurb = "Refactor a tree building algorithm."

--- a/exercises/triangle/metadata.toml
+++ b/exercises/triangle/metadata.toml
@@ -1,3 +1,4 @@
+title = "Triangle"
 blurb = "Determine if a triangle is equilateral, isosceles, or scalene."
 source = "The Ruby Koans triangle project, parts 1 & 2"
 source_url = "http://rubykoans.com"

--- a/exercises/trinary/metadata.toml
+++ b/exercises/trinary/metadata.toml
@@ -1,3 +1,4 @@
+title = "Trinary"
 blurb = "Convert a trinary number, represented as a string (e.g. '102012'), to its decimal equivalent using first principles."
 source = "All of Computer Science"
 source_url = "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"

--- a/exercises/twelve-days/metadata.toml
+++ b/exercises/twelve-days/metadata.toml
@@ -1,3 +1,4 @@
+title = "Twelve Days"
 blurb = "Output the lyrics to 'The Twelve Days of Christmas'."
 source = "Wikipedia"
 source_url = "http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)"

--- a/exercises/two-bucket/metadata.toml
+++ b/exercises/two-bucket/metadata.toml
@@ -1,3 +1,4 @@
+title = "Two Buckets"
 blurb = "Given two buckets of different size, demonstrate how to measure an exact number of liters."
 source = "Water Pouring Problem"
 source_url = "http://demonstrations.wolfram.com/WaterPouringProblem/"

--- a/exercises/two-fer/metadata.toml
+++ b/exercises/two-fer/metadata.toml
@@ -1,3 +1,3 @@
-title = "Two-fer"
+title = "Two Fer"
 blurb = "Create a sentence of the form \"One for X, one for me.\"."
 source_url = "https://github.com/exercism/problem-specifications/issues/757"

--- a/exercises/variable-length-quantity/metadata.toml
+++ b/exercises/variable-length-quantity/metadata.toml
@@ -1,3 +1,4 @@
+title = "Variable Length Quantity"
 blurb = "Implement variable length quantity encoding and decoding."
 source = "A poor Splice developer having to implement MIDI encoding/decoding."
 source_url = "https://splice.com"

--- a/exercises/word-count/metadata.toml
+++ b/exercises/word-count/metadata.toml
@@ -1,2 +1,3 @@
+title = "Word Count"
 blurb = "Given a phrase, count the occurrences of each word in that phrase."
 source = "This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour."

--- a/exercises/word-search/metadata.toml
+++ b/exercises/word-search/metadata.toml
@@ -1,1 +1,2 @@
+title = "Word Search"
 blurb = "Create a program to solve a word search puzzle."

--- a/exercises/wordy/metadata.toml
+++ b/exercises/wordy/metadata.toml
@@ -1,3 +1,4 @@
+title = "Wordy"
 blurb = "Parse and evaluate simple math word problems returning the answer as an integer."
 source = "Inspired by one of the generated questions in the Extreme Startup game."
 source_url = "https://github.com/rchatley/extreme_startup"

--- a/exercises/yacht/metadata.toml
+++ b/exercises/yacht/metadata.toml
@@ -1,3 +1,4 @@
+title = "Yacht"
 blurb = "Score a single throw of dice in the game Yacht."
 source = "James Kilfiger, using wikipedia"
 source_url = "https://en.wikipedia.org/wiki/Yacht_(dice_game)"

--- a/exercises/zebra-puzzle/metadata.toml
+++ b/exercises/zebra-puzzle/metadata.toml
@@ -1,3 +1,4 @@
+title = "Zebra Puzzle"
 blurb = "Solve the zebra puzzle."
 source = "Wikipedia"
 source_url = "https://en.wikipedia.org/wiki/Zebra_Puzzle"

--- a/exercises/zipper/metadata.toml
+++ b/exercises/zipper/metadata.toml
@@ -1,1 +1,2 @@
+title = "Zipper"
 blurb = "Creating a zipper for a binary tree."


### PR DESCRIPTION
Only a handful of exercises had titles.
These were typically exercises where the correct title would be difficult to guess based on the slug (e.g. D&D Characters).

However, it turns out that many exercises have variations on the titles across different tracks.

This hard-codes titles for all the exercises, even if they would technically be fairly straight forward to derive from the slug.

This will make it easier for Configlet to do normalization on the track `config.json`.