### PR TITLE
Add date and datetime scenarios to gigasecond

### DIFF
--- a/SCENARIOS.txt
+++ b/SCENARIOS.txt
@@ -1,4 +1,6 @@
 big-integer
+date
+datetime
 floating-point
 immutable
 input-validation

--- a/SCENARIOS.txt
+++ b/SCENARIOS.txt
@@ -1,8 +1,8 @@
 big-integer
 floating-point
 immutable
+input-validation
 library-test
 local-scope
-unicode
-input-validation
 runtime-validation
+unicode

--- a/canonical-data.schema.json
+++ b/canonical-data.schema.json
@@ -122,11 +122,11 @@
         "big-integer",
         "floating-point",
         "immutable",
+        "input-validation",
         "library-test",
         "local-scope",
-        "unicode",
-        "input-validation",
-        "runtime-validation"
+        "runtime-validation",
+        "unicode"
       ]
     },
 

--- a/canonical-data.schema.json
+++ b/canonical-data.schema.json
@@ -120,6 +120,8 @@
       "type": "string",
       "enum": [
         "big-integer",
+        "date",
+        "datetime",
         "floating-point",
         "immutable",
         "input-validation",

--- a/exercises/gigasecond/canonical-data.json
+++ b/exercises/gigasecond/canonical-data.json
@@ -18,6 +18,7 @@
     {
       "uuid": "92fbe71c-ea52-4fac-bd77-be38023cacf7",
       "description": "date only specification of time",
+      "scenarios": ["date"],
       "property": "add",
       "input": {
         "moment": "2011-04-25"
@@ -27,6 +28,7 @@
     {
       "uuid": "6d86dd16-6f7a-47be-9e58-bb9fb2ae1433",
       "description": "second test for date only specification of time",
+      "scenarios": ["date"],
       "property": "add",
       "input": {
         "moment": "1977-06-13"
@@ -36,6 +38,7 @@
     {
       "uuid": "77eb8502-2bca-4d92-89d9-7b39ace28dd5",
       "description": "third test for date only specification of time",
+      "scenarios": ["date"],
       "property": "add",
       "input": {
         "moment": "1959-07-19"
@@ -45,6 +48,7 @@
     {
       "uuid": "c9d89a7d-06f8-4e28-a305-64f1b2abc693",
       "description": "full time specified",
+      "scenarios": ["datetime"],
       "property": "add",
       "input": {
         "moment": "2015-01-24T22:00:00"
@@ -54,6 +58,7 @@
     {
       "uuid": "09d4e30e-728a-4b52-9005-be44a58d9eba",
       "description": "full time with day roll-over",
+      "scenarios": ["datetime"],
       "property": "add",
       "input": {
         "moment": "2015-01-24T23:59:59"


### PR DESCRIPTION
The gigasecond test suite is a bit odd in that there are two different types for the same input.
    
Another oddity of the gigasecond test suite is that most of the tests don't actually add any value. If you get one passing, you get them all passing.
    
This adds a date scenario to the inputs that have only a date, and datetime to the ones that also include a time element.

Am I missing anything important here?