### PR TITLE
custom-set: metadata: add title

### DIFF
--- a/exercises/custom-set/metadata.toml
+++ b/exercises/custom-set/metadata.toml
@@ -1,1 +1,2 @@
+title = "Custom Set"
 blurb = "Create a custom set type."


### PR DESCRIPTION
Commit 6e57ab4490d9 (#2122) intended to add the `title` key to every exercise that lacked one, but custom-set was omitted.