### PR TITLE
Crypto Square: adding test for empty text after normalized

### DIFF
--- a/exercises/crypto-square/canonical-data.json
+++ b/exercises/crypto-square/canonical-data.json
@@ -11,6 +11,15 @@
       "expected": ""
     },
     {
+      "uuid": "aad04a25-b8bb-4304-888b-581bea8e0040",
+      "description": "empty plaintext after normalized",
+      "property": "ciphertext",
+      "input": {
+        "plaintext": "... --- ..."
+      },
+      "expected": ""
+    },
+    {
       "uuid": "64131d65-6fd9-4f58-bdd8-4a2370fb481d",
       "description": "Lowercase",
       "property": "ciphertext",

--- a/exercises/crypto-square/canonical-data.json
+++ b/exercises/crypto-square/canonical-data.json
@@ -12,7 +12,7 @@
     },
     {
       "uuid": "aad04a25-b8bb-4304-888b-581bea8e0040",
-      "description": "empty plaintext after normalized",
+      "description": "normalization results in empty plaintext",
       "property": "ciphertext",
       "input": {
         "plaintext": "... --- ..."


### PR DESCRIPTION
There is no test case for plaintext made up of just spaces and punctuation.
Mentored someone with code that pass all tests, but have a bug in this case, so wanted to add this.

This is my fires PR for exercism, hope I'm going it OK.

Closes #2130