### PR TITLE
Change name of two-fer to Two-Fer

### DIFF
--- a/exercises/two-fer/metadata.toml
+++ b/exercises/two-fer/metadata.toml
@@ -1,3 +1,3 @@
-title = "Two Fer"
+title = "Two-Fer"
 blurb = "Create a sentence of the form \"One for X, one for me.\"."
 source_url = "https://github.com/exercism/problem-specifications/issues/757"


### PR DESCRIPTION
There was a whole discussion about whether this should be Two-fer, Two Fer, or Two-Fer.

Without the hyphenation the implication is that `fer` is a word, which it is not. And if it were a word, then we could have a whole discussion around whether or not it should be pluralized, because (clearly) there are two of them.

According to Google Ngram, `two-fer` is more common than `two fer`.

So that left us with the choice between Two-fer and Two-Fer.

The Chicago style guide suggests:

> In hyphenated compounds, capitalize the first element and
> subsequent words that are not articles, prepositions,
> coordinating conjunctions, or modifiers following musical
> key symbols (e.g., “Symphony in F-sharp Major”); however
> do not capitalize the second word if the first element is
> a prefix that could not stand by itself (e.g., “Ex-wife”),
> unless it is a proper noun or proper adjective.

We sort of mostly follow the Chicago style guide. Kind of. So, yeah. That seems like a vote in the direction of `Two-Fer`.

My thanks to @ee7 for rigorous research :-)