### PR TITLE
Change wording in tournament instructions

### DIFF
--- a/exercises/tournament/description.md
+++ b/exercises/tournament/description.md
@@ -24,7 +24,7 @@ A win earns a team 3 points.
 A draw earns 1.
 A loss earns 0.
 
-The outcome should be ordered by points, descending.
+The outcome is ordered by points, descending.
 In case of a tie, teams are ordered alphabetically.
 
 ## Input


### PR DESCRIPTION
There was a new test added in #1802 that enforced the behavior of the ordering. A downstream maintainer pointed out that when there is a test enforcing behavior, then the instructions ~should~ must read *must* rather than *should*.