### PR TITLE
Fix incorrect source url for nth-prime

### DIFF
--- a/exercises/nth-prime/metadata.toml
+++ b/exercises/nth-prime/metadata.toml
@@ -1,4 +1,4 @@
 title = "Nth Prime"
 blurb = "Given a number n, determine what the nth prime is."
 source = "A variation on Problem 7 at Project Euler"
-source_url = "https://projecteuler.net/problem=8"
+source_url = "https://projecteuler.net/problem=7"


### PR DESCRIPTION
The nth-prime exercise is inspired by problem 7 at Euler, not Problem 8. This got messed up in the http-to-https conversion in #2137.