### PR TITLE
Switch schema reference URL to HTTPS

### DIFF
--- a/canonical-data.schema.json
+++ b/canonical-data.schema.json
@@ -22,7 +22,7 @@
     " slightly reducing the amount of manually generated code.   "
   ],
 
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "https://json-schema.org/draft-04/schema#",
 
   "self": {
     "vendor": "io.exercism",


### PR DESCRIPTION
Seems missed from the recent switchover in #2137.