### PR TITLE
Clarify description of meetup

### DIFF
--- a/exercises/meetup/description.md
+++ b/exercises/meetup/description.md
@@ -9,10 +9,10 @@ In other words, you need to determine the date of the first Monday of January 20
 
 Similarly, you might be asked to find:
 
-- the third Tuesday of August 2019
-- the teenth Wednesday of May 2020
-- the fourth Sunday of July 2021
-- the last Thursday of November 2022
+- the third Tuesday of August 2019 (20 August 2019)
+- the teenth Wednesday of May 2020 (13 May 2020)
+- the fourth Sunday of July 2021 (25 July 2021)
+- the last Thursday of November 2022 (24 November 2022)
 
 The descriptors you are expected to process are: `first`, `second`, `third`, `fourth`, `last`, `teenth`.
 

--- a/exercises/meetup/description.md
+++ b/exercises/meetup/description.md
@@ -9,10 +9,10 @@ In other words, you need to determine the date of the first Monday of January 20
 
 Similarly, you might be asked to find:
 
-- the third Tuesday of August 2019 (20 August 2019)
-- the teenth Wednesday of May 2020 (13 May 2020)
-- the fourth Sunday of July 2021 (25 July 2021)
-- the last Thursday of November 2022 (24 November 2022)
+- the third Tuesday of August 2019 (August 20, 2019)
+- the teenth Wednesday of May 2020 (May 13, 2020)
+- the fourth Sunday of July 2021 (July 25, 2021)
+- the last Thursday of November 2022 (November 24, 2022)
 
 The descriptors you are expected to process are: `first`, `second`, `third`, `fourth`, `last`, `teenth`.
 

--- a/exercises/meetup/description.md
+++ b/exercises/meetup/description.md
@@ -35,7 +35,7 @@ So there are seven numbers ending in '-teen'.
 And there are also seven weekdays (Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday).
 Therefore, it is guaranteed that each day of the week (Monday, Tuesday, ...) will have exactly one numbered day ending with "teen" each month.
 
-If given the teenth Saturday of August, 1953 (or, alternately the "Saturteenth" of August, 1953), we need to look at the calendar for August 1953:
+If asked to find the teenth Saturday of August, 1953 (or, alternately the "Saturteenth" of August, 1953), we need to look at the calendar for August 1953:
 
 ```plaintext
     August 1953
@@ -48,4 +48,4 @@ Su Mo Tu We Th Fr Sa
 30 31
 ```
 
-The Saturday that has a number ending in '-teen' is August 15, 1954.
+The Saturday that has a number ending in '-teen' is August 15, 1953.

--- a/exercises/meetup/description.md
+++ b/exercises/meetup/description.md
@@ -33,9 +33,7 @@ For the numbers ending in '-teen', that becomes:
 
 So there are seven numbers ending in '-teen'.
 And there are also seven weekdays (Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday).
-Therefore, it is guaranteed that each day of the week (Monday, Tuesday, ...) will have exactly one numbered day ending with "teenth" each month.
-
-For example, if given "First Monday of January 2022", the correct meetup date is January 3, 2022.
+Therefore, it is guaranteed that each day of the week (Monday, Tuesday, ...) will have exactly one numbered day ending with "teen" each month.
 
 If given the teenth Saturday of August, 1953 (or, alternately the "Saturteenth" of August, 1953), we need to look at the calendar for August 1953:
 

--- a/exercises/meetup/description.md
+++ b/exercises/meetup/description.md
@@ -1,19 +1,53 @@
 # Description
 
-In this exercise, you will be given a general description of a meetup date and then asked to find the actual meetup date.
+Recurring monthly meetups are generally scheduled on the given weekday of a given week each month.
+In this exercise you will be given the recurring schedule, along with a month and year, and then asked to find the exact date of the meetup.
 
-Examples of general descriptions are:
+For example a meetup might be scheduled on the _first Monday_ of every month.
+You might then be asked to find the date that this meetup will happen in January 2018.
+In other words, you need to determine the date of the first Monday of January 2018.
 
-- First Monday of January 2022
-- Third Tuesday of August 2021
-- Teenth Wednesday of May 2022
-- Teenth Sunday of July 2021
-- Last Thursday of November 2021
+Similarly, you might be asked to find:
+
+- the third Tuesday of August 2019
+- the teenth Wednesday of May 2020
+- the fourth Sunday of July 2021
+- the last Thursday of November 2022
 
 The descriptors you are expected to process are: `first`, `second`, `third`, `fourth`, `last`, `teenth`.
 
 Note that descriptor `teenth` is a made-up word.
-There are exactly seven numbered days in a month that end with "teenth" ("thirteenth" to "nineteenth").
+
+It refers to the seven numbers that end in '-teen' in English: 13, 14, 15, 16, 17, 18, and 19.
+But general descriptions of dates use ordinal numbers, e.g. the _first_ Monday, the _third_ Tuesday.
+
+For the numbers ending in '-teen', that becomes:
+
+- 13th (thirteenth)
+- 14th (fourteenth)
+- 15th (fifteenth)
+- 16th (sixteenth)
+- 17th (seventeenth)
+- 18th (eighteenth)
+- 19th (nineteenth)
+
+So there are seven numbers ending in '-teen'.
+And there are also seven weekdays (Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday).
 Therefore, it is guaranteed that each day of the week (Monday, Tuesday, ...) will have exactly one numbered day ending with "teenth" each month.
 
 For example, if given "First Monday of January 2022", the correct meetup date is January 3, 2022.
+
+If given the teenth Saturday of August, 1953 (or, alternately the "Saturteenth" of August, 1953), we need to look at the calendar for August 1953:
+
+```plaintext
+    August 1953
+Su Mo Tu We Th Fr Sa
+                   1
+ 2  3  4  5  6  7  8
+ 9 10 11 12 13 14 15
+16 17 18 19 20 21 22
+23 24 25 26 27 28 29
+30 31
+```
+
+The Saturday that has a number ending in '-teen' is August 15, 1954.


### PR DESCRIPTION
There has been a lot of confusion around this exercise, especially
for people who don't speak English as their native language.

This attempts to explain very clearly where 'teenth' comes from,
and how it pertains to recurring monthly meetup schedules.

In doing this I have also made an executive decision to _not_
change the structure of the inputs (see #1069).
This is because I don't believe that adding string parsing to
get the pieces of the general description makes this exercise
more interesting or fun.

In order to keep the exercise focused on just the date munging,
this instead changes the description to match more closely how
the inputs are given.

Closes #1786.
Closes #1069.
