### PR TITLE
Add `random` scenario

### DIFF
--- a/SCENARIOS.txt
+++ b/SCENARIOS.txt
@@ -6,5 +6,6 @@ immutable
 input-validation
 library-test
 local-scope
+random
 runtime-validation
 unicode

--- a/canonical-data.schema.json
+++ b/canonical-data.schema.json
@@ -127,6 +127,7 @@
         "input-validation",
         "library-test",
         "local-scope",
+        "random",
         "runtime-validation",
         "unicode"
       ]

--- a/exercises/diffie-hellman/canonical-data.json
+++ b/exercises/diffie-hellman/canonical-data.json
@@ -20,6 +20,7 @@
     {
       "uuid": "1b97bf38-4307-418e-bfd2-446ffc77588d",
       "description": "private key is greater than 1 and less than p",
+      "scenarios": ["random"],
       "property": "privateKeyIsInRange",
       "input": {},
       "expected": {
@@ -30,6 +31,7 @@
     {
       "uuid": "68b2a5f7-7755-44c3-97b2-d28d21f014a9",
       "description": "private key is random",
+      "scenarios": ["random"],
       "property": "privateKeyIsRandom",
       "input": {},
       "expected": {

--- a/exercises/dnd-character/canonical-data.json
+++ b/exercises/dnd-character/canonical-data.json
@@ -170,6 +170,7 @@
     {
       "uuid": "4f28f19c-2e47-4453-a46a-c0d365259c14",
       "description": "random ability is within range",
+      "scenarios": ["random"],
       "property": "ability",
       "input": {},
       "expected": "score >= 3 && score <= 18"
@@ -177,6 +178,7 @@
     {
       "uuid": "385d7e72-864f-4e88-8279-81a7d75b04ad",
       "description": "random character is valid",
+      "scenarios": ["random"],
       "property": "character",
       "input": {},
       "expected": {

--- a/exercises/simple-cipher/canonical-data.json
+++ b/exercises/simple-cipher/canonical-data.json
@@ -14,6 +14,7 @@
         {
           "uuid": "b8bdfbe1-bea3-41bb-a999-b41403f2b15d",
           "description": "Can encode",
+          "scenarios": ["random"],
           "property": "encode",
           "input": {
             "plaintext": "aaaaaaaaaa"
@@ -23,6 +24,7 @@
         {
           "uuid": "3dff7f36-75db-46b4-ab70-644b3f38b81c",
           "description": "Can decode",
+          "scenarios": ["random"],
           "property": "decode",
           "input": {
             "ciphertext": "cipher.key.substring(0, expected.length)"
@@ -32,6 +34,7 @@
         {
           "uuid": "8143c684-6df6-46ba-bd1f-dea8fcb5d265",
           "description": "Is reversible. I.e., if you apply decode in a encoded result, you must see the same plaintext encode parameter as a result of the decode method",
+          "scenarios": ["random"],
           "property": "decode",
           "input": {
             "plaintext": "abcdefghij",
@@ -42,6 +45,7 @@
         {
           "uuid": "defc0050-e87d-4840-85e4-51a1ab9dd6aa",
           "description": "Key is made only of lowercase letters",
+          "scenarios": ["random"],
           "property": "key",
           "input": {},
           "expected": {


### PR DESCRIPTION
This PR adds the `random` scenario to identifying test cases that deal with randomness.

- scenarios: add 'random' scenario
- dnd-character: add 'random' scenario
- diffie-hellman: add 'random' scenario
- simple-cipher: add 'random' scenario
