### PR TITLE
ci: simplify yarn caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,23 +41,11 @@ jobs:
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
 
-      - uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516
+      - name: Setup nodejs
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516
         with:
-          node-version: "12"
-
-      # https://github.com/actions/cache/blob/main/examples.md#node---yarn
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache yarn
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          node-version: 16
+          cache: "yarn"
 
       - name: Install dependencies
         run: yarn install
@@ -136,18 +124,11 @@ jobs:
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache yarn
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
-        id: yarn-cache
+      - name: Setup nodejs
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          node-version: 16
+          cache: "yarn"
 
       - name: Install dependencies
         run: yarn install


### PR DESCRIPTION
The `actions/setup-node` action has caching support built-in nowadays: https://github.com/actions/setup-node#caching-global-packages-data
This PR removes the custom yarn caching logic in favor of the built-in caching support.

See https://github.com/exercism/blog/pull/155 for an example where this is used.