### PR TITLE
Use `ubuntu-22.04` instead of `ubuntu-latest` in GitHub Actions workflows.

### DIFF
--- a/.github/workflows/action-format.yml
+++ b/.github/workflows/action-format.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   format:
     name: 'Format JSON'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/format')
     steps:
       - name: 'Post acknowledgement that it will format code'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   required-files:
     name: All required files are present
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
 
@@ -37,7 +37,7 @@ jobs:
 
   schema-validation:
     name: Schema validation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
 
@@ -121,7 +121,7 @@ jobs:
 
   markdown-lint:
     name: Lint markdown files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
 
@@ -132,7 +132,7 @@ jobs:
 
   json-lint:
     name: Lint json files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
 

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -8,7 +8,7 @@ jobs:
   rebase:
     name: Rebase
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8


### PR DESCRIPTION
With CI it is good practice to pin your dependencies to a specific
version, as not doing could result in builds suddenly breaking when a
"latest" version is upgraded.
