### PR TITLE
Fix broken link in poker metadata

### DIFF
--- a/exercises/poker/metadata.toml
+++ b/exercises/poker/metadata.toml
@@ -1,4 +1,4 @@
 title = "Poker"
 blurb = "Pick the best hand(s) from a list of poker hands."
 source = "Inspired by the training course from Udacity."
-source_url = "https://www.udacity.com/course/viewer#!/c-cs212/"
+source_url = "https://www.udacity.com/course/design-of-computer-programs--cs212"


### PR DESCRIPTION
The original link started responding with a 404.

This was discovered by @resnickmicah, who submitted a PR
to fix this in the Rust track:
https://github.com/exercism/rust/pull/1591

I've given co-author credit to Micah here.