### PR TITLE
Remove stray space in spiral-matrix metadata

### DIFF
--- a/exercises/spiral-matrix/metadata.toml
+++ b/exercises/spiral-matrix/metadata.toml
@@ -1,4 +1,4 @@
-title = "Spiral Matrix"
-blurb = " Given the size, return a square matrix of numbers in spiral order."
+blurb = "Given the size, return a square matrix of numbers in spiral order."
 source = "Reddit r/dailyprogrammer challenge #320 [Easy] Spiral Ascension."
 source_url = "https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/"
+title = "Spiral Matrix"


### PR DESCRIPTION
I checked all the metadata files for stray spaces.
The only one I found is the blurb in spiral-matrix.

This strips the unnecessary leading space.
