### PR TITLE
Delete extensions in say

### DIFF
--- a/exercises/say/description.md
+++ b/exercises/say/description.md
@@ -48,13 +48,3 @@ Put it all together to get nothing but plain English.
 `12345` should give `twelve thousand three hundred forty-five`.
 
 The program must also report any values that are out of range.
-
-### Extensions
-
-Use _and_ (correctly) when spelling out the number in English:
-
-- 14 becomes "fourteen".
-- 100 becomes "one hundred".
-- 120 becomes "one hundred and twenty".
-- 1002 becomes "one thousand and two".
-- 1323 becomes "one thousand three hundred and twenty-three".


### PR DESCRIPTION
The extensions described in the instructions
are not part of the spec.

Since we don't specify tests for these in the canonical-data.json
it makes more sense to delete the section.
