### PR TITLE
Resistor Color Trio: extend tests, borrowing from awk

### DIFF
--- a/exercises/resistor-color-trio/canonical-data.json
+++ b/exercises/resistor-color-trio/canonical-data.json
@@ -60,6 +60,78 @@
         "value": 470,
         "unit": "kiloohms"
       }
+    },
+    {
+      "uuid": "ee7a1b79-8848-4b1a-bf50-498c6fab7f27",
+      "description": "Brown and red and red",
+      "property": "label",
+      "input": {
+        "colors": ["brown", "red", "red"]
+      },
+      "expected": {
+        "value": 1200,
+        "unit": "ohms"
+      }
+    },
+    {
+      "uuid": "5f6404a7-5bb3-4283-877d-3d39bcc33854",
+      "description": "Blue and violet and grey",
+      "property": "label",
+      "input": {
+        "colors": ["blue", "violet", "grey"]
+      },
+      "expected": {
+        "value": 6700,
+        "unit": "megaohms"
+      }
+    },
+    {
+      "uuid": "7d3a6ab8-e40e-46c3-98b1-91639fff2344",
+      "description": "Minimum possible value",
+      "property": "label",
+      "input": {
+        "colors": ["black", "black", "black"]
+      },
+      "expected": {
+        "value": 0,
+        "unit": "ohms"
+      }
+    },
+    {
+      "uuid": "ca0aa0ac-3825-42de-9f07-dac68cc580fd",
+      "description": "Maximum possible value",
+      "property": "label",
+      "input": {
+        "colors": ["white", "white", "white"]
+      },
+      "expected": {
+        "value": 99,
+        "unit": "gigaohms"
+      }
+    },
+    {
+      "uuid": "0061a76c-903a-4714-8ce2-f26ce23b0e09",
+      "description": "First two colors make an invalid octal number",
+      "property": "label",
+      "input": {
+        "colors": ["black", "grey", "black"]
+      },
+      "expected": {
+        "value": 8,
+        "unit": "ohms"
+      }
+    },
+    {
+      "uuid": "30872c92-f567-4b69-a105-8455611c10c4",
+      "description": "Ignore extra colors",
+      "property": "label",
+      "input": {
+        "colors": ["blue", "green", "yellow", "orange"]
+      },
+      "expected": {
+        "value": 650,
+        "unit": "kiloohms"
+      }
     }
   ]
 }

--- a/exercises/resistor-color-trio/canonical-data.json
+++ b/exercises/resistor-color-trio/canonical-data.json
@@ -62,26 +62,14 @@
       }
     },
     {
-      "uuid": "ee7a1b79-8848-4b1a-bf50-498c6fab7f27",
-      "description": "Brown and red and red",
-      "property": "label",
-      "input": {
-        "colors": ["brown", "red", "red"]
-      },
-      "expected": {
-        "value": 1200,
-        "unit": "ohms"
-      }
-    },
-    {
       "uuid": "5f6404a7-5bb3-4283-877d-3d39bcc33854",
-      "description": "Blue and violet and grey",
+      "description": "Blue and violet and blue",
       "property": "label",
       "input": {
-        "colors": ["blue", "violet", "grey"]
+        "colors": ["blue", "violet", "blue"]
       },
       "expected": {
-        "value": 6700,
+        "value": 67,
         "unit": "megaohms"
       }
     },

--- a/exercises/resistor-color-trio/description.md
+++ b/exercises/resistor-color-trio/description.md
@@ -46,9 +46,16 @@ So an input of `"orange", "orange", "black"` should return:
 
 > "33 ohms"
 
-When we get more than a thousand ohms, we say "kiloohms".
-That's similar to saying "kilometer" for 1000 meters, and "kilograms" for 1000 grams.
+When we get to larger resistors, a [metric prefix][metric-prefix] is used to indicate a larger magnitude of ohms, such as "kiloohms".
+That is similar to saying "2 kilometers" instead of "2000 meters", or "2 kilograms" for "2000 grams".
 
-So an input of `"orange", "orange", "orange"` should return:
+For example, an input of `"orange", "orange", "orange"` should return:
 
 > "33 kiloohms"
+
+The metric prefixes used in this exercise are "kilo", "mega", and "giga".
+Those give the units of "kiloohms", "megaohms", and "gigaohms" respectively.
+
+Note, the quantity should remain a whole number, so an input of `"orange", "orange", "green"` should return "3300 kiloohms" and not "3.3 megaohms".
+
+[metric-prefix]: https://en.wikipedia.org/wiki/Metric_prefix

--- a/exercises/resistor-color-trio/description.md
+++ b/exercises/resistor-color-trio/description.md
@@ -53,7 +53,4 @@ For example, an input of `"orange", "orange", "orange"` should return:
 
 > "33 kiloohms"
 
-The metric prefixes used in this exercise are "kilo", "mega", and "giga".
-Those give the units of "kiloohms", "megaohms", and "gigaohms" respectively.
-
 [metric-prefix]: https://en.wikipedia.org/wiki/Metric_prefix

--- a/exercises/resistor-color-trio/description.md
+++ b/exercises/resistor-color-trio/description.md
@@ -56,6 +56,4 @@ For example, an input of `"orange", "orange", "orange"` should return:
 The metric prefixes used in this exercise are "kilo", "mega", and "giga".
 Those give the units of "kiloohms", "megaohms", and "gigaohms" respectively.
 
-Note, the quantity should remain a whole number, so an input of `"orange", "orange", "green"` should return "3300 kiloohms" and not "3.3 megaohms".
-
 [metric-prefix]: https://en.wikipedia.org/wiki/Metric_prefix


### PR DESCRIPTION
[See here](https://forum.exercism.org/t/canonical-resistor-color-trio-testing-gap-values-over-1000-which-are-not-kiloohms/) for forum discussion