### PR TITLE
Lower case resistor colors in instructions

### DIFF
--- a/exercises/resistor-color/description.md
+++ b/exercises/resistor-color/description.md
@@ -15,16 +15,16 @@ In this exercise you are going to create a helpful program so that you don't hav
 
 These colors are encoded as follows:
 
-- Black: 0
-- Brown: 1
-- Red: 2
-- Orange: 3
-- Yellow: 4
-- Green: 5
-- Blue: 6
-- Violet: 7
-- Grey: 8
-- White: 9
+- black: 0
+- brown: 1
+- red: 2
+- orange: 3
+- yellow: 4
+- green: 5
+- blue: 6
+- violet: 7
+- grey: 8
+- white: 9
 
 The goal of this exercise is to create a way:
 


### PR DESCRIPTION
For me "The band colors are encoded as follows:" implies the keys might be uppercase. I tried copy pasting "Black", "Brown"... into my program and then on execution saw the keys are actually lowercase like "black", "brown". As you can see in the [canonical-data](https://github.com/exercism/problem-specifications/blob/main/exercises/resistor-color/canonical-data.json#L41) they are lowercase. Its a small change, but might reduce one more error!