### PR TITLE
Add tests for matching-brackets for multiple groups

### DIFF
--- a/exercises/matching-brackets/canonical-data.json
+++ b/exercises/matching-brackets/canonical-data.json
@@ -183,6 +183,42 @@
         "value": "\\left(\\begin{array}{cc} \\frac{1}{3} & x\\\\ \\mathrm{e}^{x} &... x^2 \\end{array}\\right)"
       },
       "expected": true
+    },
+    {
+      "uuid": "8d525481-b5a0-4f1e-8b8b-f0cc3c123d85",
+      "description": "two closed bracket pairs back to back",
+      "property": "isPaired",
+      "input": {
+        "value": "{}()"
+      },
+      "expected": true
+    },
+    {
+      "uuid": "6156696f-17e4-4db6-ad6a-0a8d609240e4",
+      "description": "two balanced bracket groups back to back",
+      "property": "isPaired",
+      "input": {
+        "value": "[({}[])]([{}])"
+      },
+      "expected": true
+    },
+    {
+      "uuid": "ffbe0d1b-e08f-48a0-a0e7-2e3a90f268b9",
+      "description": "two balanced bracket groups with text between",
+      "property": "isPaired",
+      "input": {
+        "value": "[({}[])]foo([{}])"
+      },
+      "expected": true
+    },
+    {
+      "uuid": "6bb82254-5d8d-482e-b230-38380bb3afe7",
+      "description": "two balanced bracket groups with text anywhere",
+      "property": "isPaired",
+      "input": {
+        "value": "foo[foo({x}x[x]x)]bar([{}baz])baz"
+      },
+      "expected": true
     }
   ]
 }


### PR DESCRIPTION
This exercise could be solved using recursive regular expressions (see [PCRE RECURSIVE PATTERNS](https://www.pcre.org/current/doc/html/pcre2pattern.html#SEC25) or [Perl regular expressions - Extended Patterns](https://perldoc.perl.org/perlre#(?PARNO)-(?-PARNO)-(?+PARNO)-(?R)-(?0)) for more details). Some of the wrong solutions pass all current tests. This patch adds cases that catch some of them.