### PR TITLE
[palindrome-products ]: Added test case which test edge case

### DIFF
--- a/exercises/palindrome-products/canonical-data.json
+++ b/exercises/palindrome-products/canonical-data.json
@@ -157,6 +157,19 @@
       "expected": {
         "error": "min must be <= max"
       }
+    },
+    {
+      "uuid": "16481711-26c4-42e0-9180-e2e4e8b29c23",
+      "description": "find the actual smallest palindrome",
+      "property": "smallest",
+      "input": {
+        "min": 3215,
+        "max": 4000
+      },
+      "expected": {
+        "value": 10988901,
+        "factors": [[3297, 3333]]
+      }
     }
   ]
 }

--- a/exercises/palindrome-products/canonical-data.json
+++ b/exercises/palindrome-products/canonical-data.json
@@ -160,7 +160,7 @@
     },
     {
       "uuid": "16481711-26c4-42e0-9180-e2e4e8b29c23",
-      "description": "find the actual smallest palindrome",
+      "description": "smallest product does not use the smallest factor",
       "property": "smallest",
       "input": {
         "min": 3215,

--- a/exercises/palindrome-products/canonical-data.json
+++ b/exercises/palindrome-products/canonical-data.json
@@ -161,6 +161,11 @@
     {
       "uuid": "16481711-26c4-42e0-9180-e2e4e8b29c23",
       "description": "smallest product does not use the smallest factor",
+      "comments": [
+        "This test catches code which assumes the smallest product is the product which uses the smallest factor.",
+        "e.g. `for x in (min_factor .. max_factor) for y in (min_factor .. max_factor) if palindrome(x, y) return [x * y, [x, y]]`",
+        "All the other tests pass when using logic like that, i.e. the other tests check for palindrome product but do not always test for the _smallest_ product"
+      ],
       "property": "smallest",
       "input": {
         "min": 3215,


### PR DESCRIPTION
### Why?

When I played around with palindrome-products I noticed an edge case where you could program in a particular way that would generate incorrect answers but there were no cases testing that.

To be more specific here is the solution that passes all tests for python:

```python
def smallest(min_factor, max_factor):
    """Given a range of numbers, find the smallest palindromes which
    are products of two numbers within that range.
 
    :param min_factor: int with a default value of 0
    :param max_factor: int
    :return: tuple of (palindrome, iterable).
    Iterable should contain both factors of the palindrome in an arbitrary order.
    """
    if min_factor > max_factor:
        raise ValueError("min must be <= max")
    result = 0
    answer = []
    for number_a in range(min_factor, max_factor+1):
        for number_b in range(min_factor, max_factor+1):
            if number_a * number_b <= result or result == 0:
                multipled_number_string = str(number_a * number_b)
                if multipled_number_string == multipled_number_string[::-1]:
                    if number_a * number_b < result:
                        answer = []
                    result = int(multipled_number_string)
                    answer.append([number_a, number_b])
            if result != 0:
                break
        if result != 0:
            break
    if result == 0:
        result = None
    return (result, answer)
```

In the code, you can see that as fast as I found a "result", I can make the code end.
This test case I added will prevent that from happening.