### PR TITLE
Add book-store test case

### DIFF
--- a/exercises/book-store/canonical-data.json
+++ b/exercises/book-store/canonical-data.json
@@ -90,6 +90,16 @@
       "expected": 5120
     },
     {
+      "uuid": "ac8f31ef-e2ee-412c-abfc-545820f193b3",
+      "description": "Check that solution doesn't try to maximize only single size group(of five or four).",
+      "comments": ["Suggested grouping, [[1,2,3,4,5],[1,2,3,4],[1,2,3,5]]."],
+      "property": "total",
+      "input": {
+        "basket": [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5]
+      },
+      "expected": 8120
+    },
+    {
       "uuid": "f808b5a4-e01f-4c0d-881f-f7b90d9739da",
       "description": "Two groups of four is cheaper than groups of five and three",
       "comments": [


### PR DESCRIPTION
While checking other solutions I found, that some solutions tries to maximize single size group count. Or remove one size of group and calculates result without using that group(or by maximizing that size group). These solutions pass all current tests. E.g.
`    {
      "uuid": "78cacb57-911a-45f1-be52-2a5bd428c634",
      "description": "Two groups of four is cheaper than group of five plus group of three",
      "comments": ["Suggested grouping, [[1,2,3,4],[1,2,3,5]]."],
      "property": "total",
      "input": {
        "basket": [1, 1, 2, 2, 3, 3, 4, 5]
      },
      "expected": 5120
    },`
This test is passed by trying solve without using 5 size group. Example of solution, that passes all current tests:
 https://exercism.org/tracks/go/exercises/book-store/solutions/klaus-trausner.
    
That kind of solutions would fail on this new test:
//would fail if tries to solve by removing group of size 5
groupPrice(5)+groupPrice(5)+groupPrice(3) = 3000+3000+2160 = 8160
 //would fail if tries to solve by removing group of size 5
groupPrice(4)+(groupPrice4)+groupPrice(4)+groupPrice(1)= 2560 + 2560 +2560 + 800 = 8480
//correct
groupPrice(5)+groupPrice(4)+groupPrice(4) = 2560 + 2560 + 3000 = 8120
