### PR TITLE
fix: append sum-of-multiple canonical data

### DIFF
--- a/exercises/sum-of-multiples/canonical-data.json
+++ b/exercises/sum-of-multiples/canonical-data.json
@@ -142,6 +142,16 @@
       "expected": 0
     },
     {
+      "uuid": "13345f18-8933-4dc3-81fc-1f9af040a64f",
+      "description": "a limit of 0 always returns 0",
+      "property": "sum",
+      "input": {
+        "factors": [],
+        "limit": 0
+      },
+      "expected": 0
+    },
+    {
       "uuid": "c423ae21-a0cb-4ec7-aeb1-32971af5b510",
       "description": "the factor 0 does not affect the sum of multiples of other factors",
       "property": "sum",


### PR DESCRIPTION
Adds a scenario where limit is 0. In some languages (namely Rust) potential solutions can currently pass all existing scenarios, yet throw an error when a limit of 0 is passed.

# Related
* https://github.com/exercism/rust/pull/1607#issuecomment-1407954955