### PR TITLE
Matrix: Ensure whole matrix is correct

### DIFF
--- a/exercises/matrix/canonical-data.json
+++ b/exercises/matrix/canonical-data.json
@@ -6,80 +6,72 @@
       "description": "extract row from one number matrix",
       "property": "row",
       "input": {
-        "string": "1",
-        "index": 1
+        "string": "1"
       },
-      "expected": [1]
+      "expected": [[1]]
     },
     {
       "uuid": "5c93ec93-80e1-4268-9fc2-63bc7d23385c",
       "description": "can extract row",
       "property": "row",
       "input": {
-        "string": "1 2\n3 4",
-        "index": 2
+        "string": "1 2\n3 4"
       },
-      "expected": [3, 4]
+      "expected": [[1 , 2], [3, 4]]
     },
     {
       "uuid": "2f1aad89-ad0f-4bd2-9919-99a8bff0305a",
       "description": "extract row where numbers have different widths",
       "property": "row",
       "input": {
-        "string": "1 2\n10 20",
-        "index": 2
+        "string": "1 2\n10 20"
       },
-      "expected": [10, 20]
+      "expected": [[1 , 2], [10, 20]]
     },
     {
       "uuid": "68f7f6ba-57e2-4e87-82d0-ad09889b5204",
       "description": "can extract row from non-square matrix with no corresponding column",
       "property": "row",
       "input": {
-        "string": "1 2 3\n4 5 6\n7 8 9\n8 7 6",
-        "index": 4
+        "string": "1 2 3\n4 5 6\n7 8 9\n8 7 6"
       },
-      "expected": [8, 7, 6]
+      "expected": [[1 , 2, 3], [4, 5, 6], [7, 8, 9], [8, 7, 6]]
     },
     {
       "uuid": "e8c74391-c93b-4aed-8bfe-f3c9beb89ebb",
       "description": "extract column from one number matrix",
       "property": "column",
       "input": {
-        "string": "1",
-        "index": 1
+        "string": "1"
       },
-      "expected": [1]
+      "expected": [[1]]
     },
     {
       "uuid": "7136bdbd-b3dc-48c4-a10c-8230976d3727",
       "description": "can extract column",
       "property": "column",
       "input": {
-        "string": "1 2 3\n4 5 6\n7 8 9",
-        "index": 3
+        "string": "1 2 3\n4 5 6\n7 8 9"
       },
-      "expected": [3, 6, 9]
+      "expected": [[1, 4, 7], [2, 5, 8], [3, 6, 9]]
     },
     {
       "uuid": "ad64f8d7-bba6-4182-8adf-0c14de3d0eca",
       "description": "can extract column from non-square matrix with no corresponding row",
       "property": "column",
       "input": {
-        "string": "1 2 3 4\n5 6 7 8\n9 8 7 6",
-        "index": 4
+        "string": "1 2 3 4\n5 6 7 8\n9 8 7 6"
       },
-      "expected": [4, 8, 6]
+      "expected": [[1, 5, 9], [2, 6, 8], [3, 7, 7], [4, 8, 6]]
     },
     {
       "uuid": "9eddfa5c-8474-440e-ae0a-f018c2a0dd89",
       "description": "extract column where numbers have different widths",
       "property": "column",
       "input": {
-        "string": "89 1903 3\n18 3 1\n9 4 800",
-        "index": 2
+        "string": "89 1903 3\n18 3 1\n9 4 800"
       },
-      "expected": [1903, 3, 4]
+      "expected": [[89, 18, 9], [1903, 3, 4], [3, 1, 800]]
     }
   ]
 }


### PR DESCRIPTION
There are some proposed solutions where the mentee submit solution that would emit extra empty rows. For instance with an off by one error in a for-loop.

By checking that the whole matrix is exactly as expected we can catch such mistakes.

For the record this was discussed in the following thread; https://forum.exercism.org/t/pull-requrest-on-exercism-javascript/3440/3

<details>
  <summary>Detailed summary from the thread</summary>

For instance the following solution will fail nearly all newer `columns` tests while it currently pass those tests:

```
export class Matrix {
  constructor(matrix) {
    this.matrix = matrix
  }

  get rows() {
    return this.matrix
      .split('\n')
      .map(row => row.split(' ').map(entry => +entry));
  }

  get columns() {
    const columns = [];
    for (let i = 0; i <= this.rows.length; i++) {
      columns[i] = this.rows.map((row) => {
        return row[i];
      });
     }
     return columns;
  }
}
```

The issue is that the user is iterating on `this.rows.length` instead of `this.rows[0].length`. And the user is using `<=` over `<`.

Those are the failing tests:

```
// extract column from one number matrix
expected: [[1]]
received: [[1], [undefined]]
// can extract column
expected: [[1, 4, 7], [2, 5, 8], [3, 6, 9]]
received: [[1, 4, 7], [2, 5, 8], [3, 6, 9], [undefined, undefined, undefined]]
// extract column where numbers have different widths
expected: [[89, 18, 9], [1903, 3, 4], [3, 1, 800]]
received: [[89, 18, 9], [1903, 3, 4], [3, 1, 800], [undefined, undefined, undefined]]
```
</details>

Also, I do not know if this expected but the JS test suite has one more test:

https://github.com/homersimpsons/javascript/blob/f9f722fc7c4b6ab3d700178f076e305784ba686b/exercises/practice/matrix/matrix.spec.js#L34-L36