### PR TITLE
Transpose: ensure all lines are right-trimmed

### DIFF
--- a/exercises/transpose/canonical-data.json
+++ b/exercises/transpose/canonical-data.json
@@ -262,6 +262,27 @@
         "    56",
         "    5"
       ]
+    },
+    {
+      "uuid": "1aeb65e9-00b7-4c1a-8bc5-a53ec655282d",
+      "description": "Upper-left triangle",
+      "property": "transpose",
+      "input": {
+        "lines": [
+          "ABCDE",
+          "ABCD",
+          "ABC",
+          "AB",
+          "A"
+        ]
+      },
+      "expected": [
+        "AAAAA",
+        "BBBB",
+        "CCC",
+        "DD",
+        "E"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Some solutions only trim the last line. This test should catch those issues.

The added test requires a right trimming to all the lines besides the first one.

I had this solution that was just trimming the last line of the input. The mentee was aware enough to find those failing cases

```
export const transpose = (input) => {
  if (input.length == 0) return input;
  const rows = input.length;
  // Find the length of the longest string
  const columns = Math.max(...input.map((arr) => arr.length));
  // Now pad the smaller string to make them all equal in length
  input = input.map((str) => str.padEnd(columns));
  let output = Array(columns)
    .fill()
    .map(() => Array(rows).fill(''));
  for (let i = 0; i < rows; i++) {
    for (let j = 0; j < columns; j++) {
      output[j][i] = input[i][j];
    }
  }
  output = output.map((arr) => arr.join(''));
  // remove the right padding at the last item, but can't it occur in the last 2 rows?
  output[output.length - 1] = output[output.length - 1].trimEnd();
  return output;
};
```

Note: I did generate a random uuid v4, I do not know if this is the way to do.

Other legitimate variation of this test could be:

```
ABCDE
A
A
A
A
```

```
ABCDEF
    E
   D
  C
 B
```

Forum topic: https://forum.exercism.org/t/transpose-ensure-all-lines-are-right-trimmed/5165