### PR TITLE
Matrix: Ensure whole matrix is correct

### DIFF
--- a/exercises/matrix/canonical-data.json
+++ b/exercises/matrix/canonical-data.json
@@ -80,6 +80,134 @@
         "index": 2
       },
       "expected": [1903, 3, 4]
+    },
+    {
+      "uuid": "f5288dbd-2141-453d-9c38-a351d68ed4d9",
+      "reimplements": "ca733dab-9d85-4065-9ef6-a880a951dafd",
+      "description": "extract row from one number matrix",
+      "comments": [
+        "Expected value is now the entire matrix, not just a single row."
+      ],
+      "property": "row",
+      "input": {
+        "string": "1"
+      },
+      "expected": [[1]]
+    },
+    {
+      "uuid": "e094abae-25ba-4dd9-9194-882fee685c81",
+      "reimplements": "5c93ec93-80e1-4268-9fc2-63bc7d23385c",
+      "description": "can extract row",
+      "comments": [
+        "Expected value is now the entire matrix, not just a single row."
+      ],
+      "property": "row",
+      "input": {
+        "string": "1 2\n3 4"
+      },
+      "expected": [
+        [1, 2],
+        [3, 4]
+      ]
+    },
+    {
+      "uuid": "53956e40-2d04-44e3-a0a5-d5134259ded4",
+      "reimplements": "2f1aad89-ad0f-4bd2-9919-99a8bff0305a",
+      "description": "extract row where numbers have different widths",
+      "comments": [
+        "Expected value is now the entire matrix, not just a single row."
+      ],
+      "property": "row",
+      "input": {
+        "string": "1 2\n10 20"
+      },
+      "expected": [
+        [1, 2],
+        [10, 20]
+      ]
+    },
+    {
+      "uuid": "57cc5c9d-feab-4910-a2f3-a2abf5e400fd",
+      "reimplements": "68f7f6ba-57e2-4e87-82d0-ad09889b5204",
+      "description": "can extract row from non-square matrix with no corresponding column",
+      "comments": [
+        "Expected value is now the entire matrix, not just a single row."
+      ],
+      "property": "row",
+      "input": {
+        "string": "1 2 3\n4 5 6\n7 8 9\n8 7 6"
+      },
+      "expected": [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+        [8, 7, 6]
+      ]
+    },
+    {
+      "uuid": "3e02bc02-d090-441c-b3da-45a73e85f80a",
+      "reimplements": "e8c74391-c93b-4aed-8bfe-f3c9beb89ebb",
+      "description": "extract column from one number matrix",
+      "comments": [
+        "Expected value is now the entire matrix, not just a single row."
+      ],
+      "property": "column",
+      "input": {
+        "string": "1"
+      },
+      "expected": [[1]]
+    },
+    {
+      "uuid": "8f20855b-6001-4aba-b13f-c720b3a2029e",
+      "reimplements": "7136bdbd-b3dc-48c4-a10c-8230976d3727",
+      "description": "can extract column",
+      "comments": [
+        "Expected value is now the entire matrix, not just a single row."
+      ],
+      "property": "column",
+      "input": {
+        "string": "1 2 3\n4 5 6\n7 8 9"
+      },
+      "expected": [
+        [1, 4, 7],
+        [2, 5, 8],
+        [3, 6, 9]
+      ]
+    },
+    {
+      "uuid": "c89c2878-e654-4e47-b329-f089353f80b4",
+      "reimplements": "ad64f8d7-bba6-4182-8adf-0c14de3d0eca",
+      "description": "can extract column from non-square matrix with no corresponding row",
+      "comments": [
+        "Expected value is now the entire matrix, not just a single row."
+      ],
+      "property": "column",
+      "input": {
+        "string": "1 2 3 4\n5 6 7 8\n9 8 7 6"
+      },
+      "expected": [
+        [1, 5, 9],
+        [2, 6, 8],
+        [3, 7, 7],
+        [4, 8, 6]
+      ]
+    },
+    {
+      "uuid": "2518b9f7-3b42-4ef3-82e2-e64a2163b339",
+      "reimplements": "9eddfa5c-8474-440e-ae0a-f018c2a0dd89",
+      "description": "extract column where numbers have different widths",
+      "comments": [
+        "Expected value is now the entire matrix, not just a single row."
+      ],
+      "property": "column",
+      "input": {
+        "string": "89 1903 3\n18 3 1\n9 4 800"
+      },
+      "expected": [
+        [89, 18, 9],
+        [1903, 3, 4],
+        [3, 1, 800]
+      ]
     }
   ]
 }


### PR DESCRIPTION
There are some proposed solutions where the mentee submit solution that would emit extra empty rows. For instance with an off by one error in a for-loop.

By checking that the whole matrix is exactly as expected we can catch such mistakes.

(Re-open of #2195, cc @SleeplessByte)