### PR TITLE
ci: support instructions.md file

### DIFF
--- a/bin/check_required_files_present
+++ b/bin/check_required_files_present
@@ -21,11 +21,20 @@ function require_file {
 	fi
 }
 
+function require_file_or_alternative {
+	filename=$1	
+	alternative_filename=$2
+	if [ ! -f $filename ] && [ ! -f $alternative_filename ]; then		
+		echo "required file missing: $filename or $alternate_filename" >&2
+		let "MISSING_FILES+=1"
+	fi
+}
+
 function check_directory {
 	directory=$1
 	for exercise_directory in $directory/* ; do
 		show_progress
-		require_file "$exercise_directory/description.md"
+		require_file_or_alternative "$exercise_directory/description.md" "$exercise_directory/instructions.md"
 		require_file "$exercise_directory/metadata.toml"
 	done
 


### PR DESCRIPTION
CI didn't yet account for the fact that an exercise could have an `instructions.md` file instead of a `description.md` file.
Better to fix this now than be bitten by it later :)