### PR TITLE
check_required_files: Correctly display the name of the missing alt file

### DIFF
--- a/bin/check_required_files_present
+++ b/bin/check_required_files_present
@@ -25,7 +25,7 @@ function require_file_or_alternative {
 	filename=$1	
 	alternative_filename=$2
 	if [ ! -f $filename ] && [ ! -f $alternative_filename ]; then		
-		echo "required file missing: $filename or $alternate_filename" >&2
+		echo "required file missing: $filename or $alternative_filename" >&2
 		let "MISSING_FILES+=1"
 	fi
 }


### PR DESCRIPTION
there is no such variable alternate_filename. It needs to be alternative_filename instead.