### PR TITLE
Rational Numbers: Add error test case to expreal property

### DIFF
--- a/exercises/rational-numbers/canonical-data.json
+++ b/exercises/rational-numbers/canonical-data.json
@@ -400,6 +400,28 @@
             "r": [0, 1]
           },
           "expected": 1.0
+        },
+        {
+          "uuid": "da137f1c-fc94-4035-9813-94f5152a1102",
+          "description": "Raise a negative real number to a rational number with an even numerator",
+          "property": "expreal",
+          "input": {
+            "x": -1,
+            "r": [2, 2]
+          },
+          "expected": 1.0
+        },
+        {
+          "uuid": "f3734f78-91b2-4e59-905e-8c61dbf34f39",
+          "description": "Fails with a negative base if the numerator of the exponent is odd",
+          "property": "expreal",
+          "input": {
+            "x": -1,
+            "r": [1, 2]
+          },
+          "expected": {
+            "error": "impossible operation"
+          }
         }
       ]
     },

--- a/exercises/rational-numbers/canonical-data.json
+++ b/exercises/rational-numbers/canonical-data.json
@@ -413,14 +413,14 @@
         },
         {
           "uuid": "f3734f78-91b2-4e59-905e-8c61dbf34f39",
-          "description": "Fails with a negative base if the numerator of the exponent is odd",
+          "description": "Fails with a negative real number if the numerator of the rational number is odd",
           "property": "expreal",
           "input": {
             "x": -1,
             "r": [1, 2]
           },
           "expected": {
-            "error": "impossible operation"
+            "error": "impossible to raise a negative base to an exponent with an odd numerator"
           }
         }
       ]


### PR DESCRIPTION
As suggested by @jiegillet in [gleam!248](https://github.com/exercism/gleam/pull/248#discussion_r1121615055), we would like to add a failure edge case when doing the exponentiation of a real number to a rational number.