### PR TITLE
Strain: Add canonical data

### DIFF
--- a/exercises/strain/canonical-data.json
+++ b/exercises/strain/canonical-data.json
@@ -1,0 +1,155 @@
+{
+  "exercise": "strain",
+  "cases": [
+    {
+      "description": "filter list returning only values that satisfy the predicate function",
+      "cases": [
+        {
+          "uuid": "26af8c32-ba6a-4eb3-aa0a-ebd8f136e003",
+          "description": "keep on empty list returns empty list",
+          "property": "keep",
+          "input": {
+            "list": [],
+            "predicate": "fn(x) -> true"
+          },
+          "expected": []
+        },
+        {
+          "uuid": "f535cb4d-e99b-472a-bd52-9fa0ffccf454",
+          "description": "keeps everything",
+          "property": "keep",
+          "input": {
+            "list": [1, 3, 5],
+            "predicate": "fn(x) -> x % 2 == 1"
+          },
+          "expected": [1, 3, 5]
+        },
+        {
+          "uuid": "950b8e8e-f628-42a8-85e2-9b30f09cde38",
+          "description": "keeps nothing",
+          "property": "keep",
+          "input": {
+            "list": [1, 3, 5],
+            "predicate": "fn(x) -> x % 2 == 0"
+          },
+          "expected": []
+        },
+        {
+          "uuid": "92694259-6e76-470c-af87-156bdf75018a",
+          "description": "keeps first and last",
+          "property": "keep",
+          "input": {
+            "list": [1, 2, 3],
+            "predicate": "fn(x) -> x % 2 == 1"
+          },
+          "expected": [1, 3]
+        },
+        {
+          "uuid": "938f7867-bfc7-449e-a21b-7b00cbb56994",
+          "description": "keeps neither first nor last",
+          "property": "keep",
+          "input": {
+            "list": [1, 2, 3],
+            "predicate": "fn(x) -> x % 2 == 0"
+          },
+          "expected": [2]
+        },
+        {
+          "uuid": "8908e351-4437-4d2b-a0f7-770811e48816",
+          "description": "keeps strings",
+          "property": "keep",
+          "input": {
+            "list": ["apple", "zebra", "banana", "zombies", "cherimoya", "zealot"],
+            "predicate": "fn(x) -> starts_with(x, 'z')"
+          },
+          "expected": ["zebra", "zombies", "zealot"]
+        },
+        {
+          "uuid": "2728036b-102a-4f1e-a3ef-eac6160d876a",
+          "description": "keeps lists",
+          "property": "keep",
+          "input": {
+            "list": [[1, 2, 3], [5, 5, 5], [5, 1, 2], [2, 1, 2], [1, 5, 2], [2, 2, 1], [1, 2, 5]],
+            "predicate": "fn(x) -> contains(x, 5)"
+          },
+          "expected": [[5, 5, 5], [5, 1, 2], [1, 5, 2], [1, 2, 5]]
+        }
+      ]
+    },
+    {
+      "description": "filter list returning only values that do not satisfy the predicate function",
+      "cases": [
+        {
+          "uuid": "ef16beb9-8d84-451a-996a-14e80607fce6",
+          "description": "discard on empty list returns empty list",
+          "property": "discard",
+          "input": {
+            "list": [],
+            "predicate": "fn(x) -> true"
+          },
+          "expected": []
+        },
+        {
+          "uuid": "2f42f9bc-8e06-4afe-a222-051b5d8cd12a",
+          "description": "discards everything",
+          "property": "discard",
+          "input": {
+            "list": [1, 3, 5],
+            "predicate": "fn(x) -> x % 2 == 1"
+          },
+          "expected": []
+        },
+        {
+          "uuid": "ca990fdd-08c2-4f95-aa50-e0f5e1d6802b",
+          "description": "discards nothing",
+          "property": "discard",
+          "input": {
+            "list": [1, 3, 5],
+            "predicate": "fn(x) -> x % 2 == 0"
+          },
+          "expected": [1, 3, 5]
+        },
+        {
+          "uuid": "71595dae-d283-48ca-a52b-45fa96819d2f",
+          "description": "discards first and last",
+          "property": "discard",
+          "input": {
+            "list": [1, 2, 3],
+            "predicate": "fn(x) -> x % 2 == 1"
+          },
+          "expected": [2]
+        },
+        {
+          "uuid": "ae141f79-f86d-4567-b407-919eaca0f3dd",
+          "description": "discards neither first nor last",
+          "property": "discard",
+          "input": {
+            "list": [1, 2, 3],
+            "predicate": "fn(x) -> x % 2 == 0"
+          },
+          "expected": [1, 3]
+        },
+        {
+          "uuid": "daf25b36-a59f-4f29-bcfe-302eb4e43609",
+          "description": "discards strings",
+          "property": "discard",
+          "input": {
+            "list": ["apple", "zebra", "banana", "zombies", "cherimoya", "zealot"],
+            "predicate": "fn(x) -> starts_with(x, 'z')"
+          },
+          "expected": ["apple", "banana", "cherimoya"]
+        },
+        {
+          "uuid": "a38d03f9-95ad-4459-80d1-48e937e4acaf",
+          "description": "discards lists",
+          "property": "discard",
+          "input": {
+            "list": [[1, 2, 3], [5, 5, 5], [5, 1, 2], [2, 1, 2], [1, 5, 2], [2, 2, 1], [1, 2, 5]],
+            "predicate": "fn(x) -> contains(x, 5)"
+          },
+          "expected": [[1, 2, 3], [2, 1, 2], [2, 2, 1]]
+        }
+      ]
+    }
+  ]
+}

--- a/exercises/strain/canonical-data.json
+++ b/exercises/strain/canonical-data.json
@@ -20,7 +20,7 @@
           "property": "keep",
           "input": {
             "list": [1, 3, 5],
-            "predicate": "fn(x) -> x % 2 == 1"
+            "predicate": "fn(x) -> true"
           },
           "expected": [1, 3, 5]
         },
@@ -30,7 +30,7 @@
           "property": "keep",
           "input": {
             "list": [1, 3, 5],
-            "predicate": "fn(x) -> x % 2 == 0"
+            "predicate": "fn(x) -> false"
           },
           "expected": []
         },
@@ -115,7 +115,7 @@
           "property": "discard",
           "input": {
             "list": [1, 3, 5],
-            "predicate": "fn(x) -> x % 2 == 1"
+            "predicate": "fn(x) -> true"
           },
           "expected": []
         },
@@ -125,7 +125,7 @@
           "property": "discard",
           "input": {
             "list": [1, 3, 5],
-            "predicate": "fn(x) -> x % 2 == 0"
+            "predicate": "fn(x) -> false"
           },
           "expected": [1, 3, 5]
         },

--- a/exercises/strain/canonical-data.json
+++ b/exercises/strain/canonical-data.json
@@ -2,192 +2,168 @@
   "exercise": "strain",
   "cases": [
     {
-      "description": "filter list returning only values that satisfy the predicate function",
-      "cases": [
-        {
-          "uuid": "26af8c32-ba6a-4eb3-aa0a-ebd8f136e003",
-          "description": "keep on empty list returns empty list",
-          "property": "keep",
-          "input": {
-            "list": [],
-            "predicate": "fn(x) -> true"
-          },
-          "expected": []
-        },
-        {
-          "uuid": "f535cb4d-e99b-472a-bd52-9fa0ffccf454",
-          "description": "keeps everything",
-          "property": "keep",
-          "input": {
-            "list": [1, 3, 5],
-            "predicate": "fn(x) -> true"
-          },
-          "expected": [1, 3, 5]
-        },
-        {
-          "uuid": "950b8e8e-f628-42a8-85e2-9b30f09cde38",
-          "description": "keeps nothing",
-          "property": "keep",
-          "input": {
-            "list": [1, 3, 5],
-            "predicate": "fn(x) -> false"
-          },
-          "expected": []
-        },
-        {
-          "uuid": "92694259-6e76-470c-af87-156bdf75018a",
-          "description": "keeps first and last",
-          "property": "keep",
-          "input": {
-            "list": [1, 2, 3],
-            "predicate": "fn(x) -> x % 2 == 1"
-          },
-          "expected": [1, 3]
-        },
-        {
-          "uuid": "938f7867-bfc7-449e-a21b-7b00cbb56994",
-          "description": "keeps neither first nor last",
-          "property": "keep",
-          "input": {
-            "list": [1, 2, 3],
-            "predicate": "fn(x) -> x % 2 == 0"
-          },
-          "expected": [2]
-        },
-        {
-          "uuid": "8908e351-4437-4d2b-a0f7-770811e48816",
-          "description": "keeps strings",
-          "property": "keep",
-          "input": {
-            "list": [
-              "apple",
-              "zebra",
-              "banana",
-              "zombies",
-              "cherimoya",
-              "zealot"
-            ],
-            "predicate": "fn(x) -> starts_with(x, 'z')"
-          },
-          "expected": ["zebra", "zombies", "zealot"]
-        },
-        {
-          "uuid": "2728036b-102a-4f1e-a3ef-eac6160d876a",
-          "description": "keeps lists",
-          "property": "keep",
-          "input": {
-            "list": [
-              [1, 2, 3],
-              [5, 5, 5],
-              [5, 1, 2],
-              [2, 1, 2],
-              [1, 5, 2],
-              [2, 2, 1],
-              [1, 2, 5]
-            ],
-            "predicate": "fn(x) -> contains(x, 5)"
-          },
-          "expected": [
-            [5, 5, 5],
-            [5, 1, 2],
-            [1, 5, 2],
-            [1, 2, 5]
-          ]
-        }
+      "uuid": "26af8c32-ba6a-4eb3-aa0a-ebd8f136e003",
+      "description": "keep on empty list returns empty list",
+      "property": "keep",
+      "input": {
+        "list": [],
+        "predicate": "fn(x) -> true"
+      },
+      "expected": []
+    },
+    {
+      "uuid": "f535cb4d-e99b-472a-bd52-9fa0ffccf454",
+      "description": "keeps everything",
+      "property": "keep",
+      "input": {
+        "list": [1, 3, 5],
+        "predicate": "fn(x) -> true"
+      },
+      "expected": [1, 3, 5]
+    },
+    {
+      "uuid": "950b8e8e-f628-42a8-85e2-9b30f09cde38",
+      "description": "keeps nothing",
+      "property": "keep",
+      "input": {
+        "list": [1, 3, 5],
+        "predicate": "fn(x) -> false"
+      },
+      "expected": []
+    },
+    {
+      "uuid": "92694259-6e76-470c-af87-156bdf75018a",
+      "description": "keeps first and last",
+      "property": "keep",
+      "input": {
+        "list": [1, 2, 3],
+        "predicate": "fn(x) -> x % 2 == 1"
+      },
+      "expected": [1, 3]
+    },
+    {
+      "uuid": "938f7867-bfc7-449e-a21b-7b00cbb56994",
+      "description": "keeps neither first nor last",
+      "property": "keep",
+      "input": {
+        "list": [1, 2, 3],
+        "predicate": "fn(x) -> x % 2 == 0"
+      },
+      "expected": [2]
+    },
+    {
+      "uuid": "8908e351-4437-4d2b-a0f7-770811e48816",
+      "description": "keeps strings",
+      "property": "keep",
+      "input": {
+        "list": ["apple", "zebra", "banana", "zombies", "cherimoya", "zealot"],
+        "predicate": "fn(x) -> starts_with(x, 'z')"
+      },
+      "expected": ["zebra", "zombies", "zealot"]
+    },
+    {
+      "uuid": "2728036b-102a-4f1e-a3ef-eac6160d876a",
+      "description": "keeps lists",
+      "property": "keep",
+      "input": {
+        "list": [
+          [1, 2, 3],
+          [5, 5, 5],
+          [5, 1, 2],
+          [2, 1, 2],
+          [1, 5, 2],
+          [2, 2, 1],
+          [1, 2, 5]
+        ],
+        "predicate": "fn(x) -> contains(x, 5)"
+      },
+      "expected": [
+        [5, 5, 5],
+        [5, 1, 2],
+        [1, 5, 2],
+        [1, 2, 5]
       ]
     },
     {
-      "description": "filter list returning only values that do not satisfy the predicate function",
-      "cases": [
-        {
-          "uuid": "ef16beb9-8d84-451a-996a-14e80607fce6",
-          "description": "discard on empty list returns empty list",
-          "property": "discard",
-          "input": {
-            "list": [],
-            "predicate": "fn(x) -> true"
-          },
-          "expected": []
-        },
-        {
-          "uuid": "2f42f9bc-8e06-4afe-a222-051b5d8cd12a",
-          "description": "discards everything",
-          "property": "discard",
-          "input": {
-            "list": [1, 3, 5],
-            "predicate": "fn(x) -> true"
-          },
-          "expected": []
-        },
-        {
-          "uuid": "ca990fdd-08c2-4f95-aa50-e0f5e1d6802b",
-          "description": "discards nothing",
-          "property": "discard",
-          "input": {
-            "list": [1, 3, 5],
-            "predicate": "fn(x) -> false"
-          },
-          "expected": [1, 3, 5]
-        },
-        {
-          "uuid": "71595dae-d283-48ca-a52b-45fa96819d2f",
-          "description": "discards first and last",
-          "property": "discard",
-          "input": {
-            "list": [1, 2, 3],
-            "predicate": "fn(x) -> x % 2 == 1"
-          },
-          "expected": [2]
-        },
-        {
-          "uuid": "ae141f79-f86d-4567-b407-919eaca0f3dd",
-          "description": "discards neither first nor last",
-          "property": "discard",
-          "input": {
-            "list": [1, 2, 3],
-            "predicate": "fn(x) -> x % 2 == 0"
-          },
-          "expected": [1, 3]
-        },
-        {
-          "uuid": "daf25b36-a59f-4f29-bcfe-302eb4e43609",
-          "description": "discards strings",
-          "property": "discard",
-          "input": {
-            "list": [
-              "apple",
-              "zebra",
-              "banana",
-              "zombies",
-              "cherimoya",
-              "zealot"
-            ],
-            "predicate": "fn(x) -> starts_with(x, 'z')"
-          },
-          "expected": ["apple", "banana", "cherimoya"]
-        },
-        {
-          "uuid": "a38d03f9-95ad-4459-80d1-48e937e4acaf",
-          "description": "discards lists",
-          "property": "discard",
-          "input": {
-            "list": [
-              [1, 2, 3],
-              [5, 5, 5],
-              [5, 1, 2],
-              [2, 1, 2],
-              [1, 5, 2],
-              [2, 2, 1],
-              [1, 2, 5]
-            ],
-            "predicate": "fn(x) -> contains(x, 5)"
-          },
-          "expected": [
-            [1, 2, 3],
-            [2, 1, 2],
-            [2, 2, 1]
-          ]
-        }
+      "uuid": "ef16beb9-8d84-451a-996a-14e80607fce6",
+      "description": "discard on empty list returns empty list",
+      "property": "discard",
+      "input": {
+        "list": [],
+        "predicate": "fn(x) -> true"
+      },
+      "expected": []
+    },
+    {
+      "uuid": "2f42f9bc-8e06-4afe-a222-051b5d8cd12a",
+      "description": "discards everything",
+      "property": "discard",
+      "input": {
+        "list": [1, 3, 5],
+        "predicate": "fn(x) -> true"
+      },
+      "expected": []
+    },
+    {
+      "uuid": "ca990fdd-08c2-4f95-aa50-e0f5e1d6802b",
+      "description": "discards nothing",
+      "property": "discard",
+      "input": {
+        "list": [1, 3, 5],
+        "predicate": "fn(x) -> false"
+      },
+      "expected": [1, 3, 5]
+    },
+    {
+      "uuid": "71595dae-d283-48ca-a52b-45fa96819d2f",
+      "description": "discards first and last",
+      "property": "discard",
+      "input": {
+        "list": [1, 2, 3],
+        "predicate": "fn(x) -> x % 2 == 1"
+      },
+      "expected": [2]
+    },
+    {
+      "uuid": "ae141f79-f86d-4567-b407-919eaca0f3dd",
+      "description": "discards neither first nor last",
+      "property": "discard",
+      "input": {
+        "list": [1, 2, 3],
+        "predicate": "fn(x) -> x % 2 == 0"
+      },
+      "expected": [1, 3]
+    },
+    {
+      "uuid": "daf25b36-a59f-4f29-bcfe-302eb4e43609",
+      "description": "discards strings",
+      "property": "discard",
+      "input": {
+        "list": ["apple", "zebra", "banana", "zombies", "cherimoya", "zealot"],
+        "predicate": "fn(x) -> starts_with(x, 'z')"
+      },
+      "expected": ["apple", "banana", "cherimoya"]
+    },
+    {
+      "uuid": "a38d03f9-95ad-4459-80d1-48e937e4acaf",
+      "description": "discards lists",
+      "property": "discard",
+      "input": {
+        "list": [
+          [1, 2, 3],
+          [5, 5, 5],
+          [5, 1, 2],
+          [2, 1, 2],
+          [1, 5, 2],
+          [2, 2, 1],
+          [1, 2, 5]
+        ],
+        "predicate": "fn(x) -> contains(x, 5)"
+      },
+      "expected": [
+        [1, 2, 3],
+        [2, 1, 2],
+        [2, 2, 1]
       ]
     }
   ]

--- a/exercises/strain/canonical-data.json
+++ b/exercises/strain/canonical-data.json
@@ -59,7 +59,14 @@
           "description": "keeps strings",
           "property": "keep",
           "input": {
-            "list": ["apple", "zebra", "banana", "zombies", "cherimoya", "zealot"],
+            "list": [
+              "apple",
+              "zebra",
+              "banana",
+              "zombies",
+              "cherimoya",
+              "zealot"
+            ],
             "predicate": "fn(x) -> starts_with(x, 'z')"
           },
           "expected": ["zebra", "zombies", "zealot"]
@@ -69,10 +76,23 @@
           "description": "keeps lists",
           "property": "keep",
           "input": {
-            "list": [[1, 2, 3], [5, 5, 5], [5, 1, 2], [2, 1, 2], [1, 5, 2], [2, 2, 1], [1, 2, 5]],
+            "list": [
+              [1, 2, 3],
+              [5, 5, 5],
+              [5, 1, 2],
+              [2, 1, 2],
+              [1, 5, 2],
+              [2, 2, 1],
+              [1, 2, 5]
+            ],
             "predicate": "fn(x) -> contains(x, 5)"
           },
-          "expected": [[5, 5, 5], [5, 1, 2], [1, 5, 2], [1, 2, 5]]
+          "expected": [
+            [5, 5, 5],
+            [5, 1, 2],
+            [1, 5, 2],
+            [1, 2, 5]
+          ]
         }
       ]
     },
@@ -134,7 +154,14 @@
           "description": "discards strings",
           "property": "discard",
           "input": {
-            "list": ["apple", "zebra", "banana", "zombies", "cherimoya", "zealot"],
+            "list": [
+              "apple",
+              "zebra",
+              "banana",
+              "zombies",
+              "cherimoya",
+              "zealot"
+            ],
             "predicate": "fn(x) -> starts_with(x, 'z')"
           },
           "expected": ["apple", "banana", "cherimoya"]
@@ -144,10 +171,22 @@
           "description": "discards lists",
           "property": "discard",
           "input": {
-            "list": [[1, 2, 3], [5, 5, 5], [5, 1, 2], [2, 1, 2], [1, 5, 2], [2, 2, 1], [1, 2, 5]],
+            "list": [
+              [1, 2, 3],
+              [5, 5, 5],
+              [5, 1, 2],
+              [2, 1, 2],
+              [1, 5, 2],
+              [2, 2, 1],
+              [1, 2, 5]
+            ],
             "predicate": "fn(x) -> contains(x, 5)"
           },
-          "expected": [[1, 2, 3], [2, 1, 2], [2, 2, 1]]
+          "expected": [
+            [1, 2, 3],
+            [2, 1, 2],
+            [2, 2, 1]
+          ]
         }
       ]
     }


### PR DESCRIPTION
Following the discussion that happened in [this topic](https://forum.exercism.org/t/proposal-to-add-test-cases-to-the-strain-problem-spec/3961/8), this PR adds canonical data for the Strain exercise, using a list of test cases that have been implemented by the majority of the tracks.

Closes #588