### PR TITLE
Improve error classification

### DIFF
--- a/exercises/wordy/canonical-data.json
+++ b/exercises/wordy/canonical-data.json
@@ -160,7 +160,7 @@
         "question": "Who is the President of the United States?"
       },
       "expected": {
-        "error": "unknown operation"
+        "error": "syntax error"
       }
     },
     {
@@ -204,7 +204,7 @@
         "question": "What is 1 plus 2 1?"
       },
       "expected": {
-        "error": "syntax error"
+        "error": "unknown operation"
       }
     },
     {
@@ -215,7 +215,7 @@
         "question": "What is 1 2 plus?"
       },
       "expected": {
-        "error": "syntax error"
+        "error": "unknown operation"
       }
     },
     {
@@ -226,7 +226,7 @@
         "question": "What is plus 1 2?"
       },
       "expected": {
-        "error": "syntax error"
+        "error": "unknown operation"
       }
     }
   ]


### PR DESCRIPTION
Most of the wordy exercise is satisfying to complete, but getting the errors correct at the end is very frustrating. The errors themselves seem organised in a non sensical way to me, and getting the tests to pass involves making the code worse, which seems like a bad lesson for a student.

I have hopefully improved the messages, so that:
- 'unknown operation' is for when you expected an operator (plus, minus etc), but didn't get one.
- 'syntax error' is for everything else.

I think another option would be to add a third type of error, for when you are expecting an integer, but don't get one, which I would also be open to.

@BethanyG 