### PR TITLE
Fix formatting in two-fer instructions

### DIFF
--- a/exercises/two-fer/instructions.md
+++ b/exercises/two-fer/instructions.md
@@ -17,9 +17,9 @@ One for you, one for me.
 
 Here are some examples:
 
-|Name    |Dialogue
-|:-------|:------------------
-|Alice   |One for Alice, one for me.
-|Bohdan  |One for Bohdan, one for me.
-|        |One for you, one for me.
-|Zaphod  |One for Zaphod, one for me.
+| Name   | Dialogue                    |
+| :----- | :-------------------------- |
+| Alice  | One for Alice, one for me.  |
+| Bohdan | One for Bohdan, one for me. |
+|        | One for you, one for me.    |
+| Zaphod | One for Zaphod, one for me. |


### PR DESCRIPTION
I noticed that CI was unhappy in the javascript track when we synced this exercise.

This reformats the table so that next time we sync we don't undo the fix.

This is not a high-priority fix, so I won't be syncing it to all the tracks; it can come in as part of the next sync that brings in little fixes here and there.