### PR TITLE
Connect exercise: add test with multiple starting points

### DIFF
--- a/exercises/connect/canonical-data.json
+++ b/exercises/connect/canonical-data.json
@@ -145,6 +145,22 @@
         ]
       },
       "expected": "X"
+    },
+    {
+      "uuid": "5b27dff5-a862-4a83-a74d-35375f07cbd4",
+      "description": "X wins using the middle path with more than a starting point",
+      "property": "winner",
+      "input": {
+        "board": [
+          "O X O X",
+          " X O X O",
+          "  . X . O",
+          "   X . O .",
+          "    O O O O",
+          "     X X X ."
+        ]
+      },
+      "expected": "X"
     }
   ]
 }


### PR DESCRIPTION
I'm proposing to add a test case in the Connect exercise to check when there are multiple starting points.