### PR TITLE
Revise binary-search instructions

### DIFF
--- a/exercises/binary-search/instructions.md
+++ b/exercises/binary-search/instructions.md
@@ -5,17 +5,17 @@ Your task is to implement a binary search algorithm.
 A binary search algorithm finds an item in a list by repeatedly splitting it in half, only keeping the half which contains the item we're looking for.
 It allows us to quickly narrow down the possible locations of our item until we find it, or until we've eliminated all possible locations.
 
-```exercism/caution
+````exercism/caution
 Binary search only works when a list has been sorted.
-```
+````
 
 The algorithm looks like this:
 
-- Divide the sorted list in half and compare the middle element with the item we're looking for.
-- If the middle element is our item, then we're done.
-- If the middle element is greater than our item, we can eliminate that number and all the numbers **after** it.
-- If the middle element is less than our item, we can eliminate that number and all the numbers **before** it.
-- Repeat the process on the part of the list that we kept.
+- Find the middle element of a list and compare it with the item we're looking for.
+- If the middle element is our item, then we're done: return its index.
+- If the middle element is greater than our item, we can eliminate that element and all the elements **after** it.
+- If the middle element is less than our item, we can eliminate that element and all the elements **before** it.
+- Repeat the process on the part of the list that has not been eliminated. If all the list has been eliminated then the item is not in the list.
 
 Here's an example:
 

--- a/exercises/binary-search/instructions.md
+++ b/exercises/binary-search/instructions.md
@@ -5,14 +5,14 @@ Your task is to implement a binary search algorithm.
 A binary search algorithm finds an item in a list by repeatedly splitting it in half, only keeping the half which contains the item we're looking for.
 It allows us to quickly narrow down the possible locations of our item until we find it, or until we've eliminated all possible locations.
 
-````exercism/caution
+~~~~exercism/caution
 Binary search only works when a list has been sorted.
-````
+~~~~
 
 The algorithm looks like this:
 
 - Find the middle element of a sorted list and compare it with the item we're looking for.
-- If the middle element is our item, then we're done: return its index.
+- If the middle element is our item, then we're done!
 - If the middle element is greater than our item, we can eliminate that element and all the elements **after** it.
 - If the middle element is less than our item, we can eliminate that element and all the elements **before** it.
 - Repeat the process on the part of the list that has not been eliminated. If all the list has been eliminated then the item is not in the list.

--- a/exercises/binary-search/instructions.md
+++ b/exercises/binary-search/instructions.md
@@ -11,7 +11,7 @@ Binary search only works when a list has been sorted.
 
 The algorithm looks like this:
 
-- Find the middle element of a list and compare it with the item we're looking for.
+- Find the middle element of a sorted list and compare it with the item we're looking for.
 - If the middle element is our item, then we're done: return its index.
 - If the middle element is greater than our item, we can eliminate that element and all the elements **after** it.
 - If the middle element is less than our item, we can eliminate that element and all the elements **before** it.

--- a/exercises/binary-search/instructions.md
+++ b/exercises/binary-search/instructions.md
@@ -15,7 +15,8 @@ The algorithm looks like this:
 - If the middle element is our item, then we're done!
 - If the middle element is greater than our item, we can eliminate that element and all the elements **after** it.
 - If the middle element is less than our item, we can eliminate that element and all the elements **before** it.
-- Repeat the process on the part of the list that has not been eliminated. If all the list has been eliminated then the item is not in the list.
+- If every element of the list has been eliminated then the item is not in the list.
+- Otherwise, repeat the process on the part of the list that has not been eliminated.
 
 Here's an example:
 


### PR DESCRIPTION
This commit changes a potentially confusing reference to "number" and "numbers" to the generic "element" and "elements" to match the language used earlier in the description ("item" and "element"). It also specifies what should be done when "we're done" and revises the first step to avoid saying that the list should be divided.

I also use 4 tildes for the admonition to match the style guide or whatever as @SaschaMann commented about that.