### PR TITLE
Turn off markdown linting rule for code blocks

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -3,5 +3,6 @@
 {
     "MD004": "dash", // Prefer hyphens for unordered lists
     "MD013": false,  // Exercism tends to break lines at sentence ends rather than at a column limit
-    "MD024": false   // The format for instructions.md requires  repeated headings, e.g. "Task"
+    "MD024": false,  // The format for instructions.md requires  repeated headings, e.g. "Task"
+    "MD048": false   // We want three backticks for codeblocks, but four tildes for special blocks.
 }


### PR DESCRIPTION
Our style guide says that we want three backticks for code blocks, but to prefer (where possible) four tildes for special blocks like the exercism/caution block or exercism/note block.

The linter we use provides three options for linting:
- only backticks
- only tildes
- be consistent within a file

None of these options work for us, so we're turning off this linting rule.