### PR TITLE
darts: use US English in test description

### DIFF
--- a/exercises/darts/canonical-data.json
+++ b/exercises/darts/canonical-data.json
@@ -46,7 +46,7 @@
     },
     {
       "uuid": "1c5ffd9f-ea66-462f-9f06-a1303de5a226",
-      "description": "Exactly on centre",
+      "description": "Exactly on center",
       "property": "score",
       "input": {
         "x": 0,
@@ -56,7 +56,7 @@
     },
     {
       "uuid": "b65abce3-a679-4550-8115-4b74bda06088",
-      "description": "Near the centre",
+      "description": "Near the center",
       "property": "score",
       "input": {
         "x": -0.1,


### PR DESCRIPTION
From the [Exercism Style Guide][1]:

>This document acts as a Style Guide for the language and wording used in exercises.
>
>[...]
>
>All content should be written in US English, which differs from UK English in a variety of ways.
>In the future other translations may occur, but the "official" Exercism language is US English.

[1]: https://github.com/exercism/docs/blob/5828116bb6d4/building/markdown/style-guide.md#language

---

With this PR, there is no more `centre` in this repo:

```console
$ git rev-parse --short HEAD
8386de61
$ git grep centre || echo 'none'
none
```