### PR TITLE
largest-series-product: use double quotes for string

### DIFF
--- a/exercises/largest-series-product/description.md
+++ b/exercises/largest-series-product/description.md
@@ -2,11 +2,11 @@
 
 Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.
 
-For example, for the input `'1027839564'`, the largest product for a series of 3 digits is 270 `(9 * 5 * 6)`, and the largest product for a series of 5 digits is 7560 `(7 * 8 * 3 * 9 * 5)`.
+For example, for the input `"1027839564"`, the largest product for a series of 3 digits is 270 `(9 * 5 * 6)`, and the largest product for a series of 5 digits is 7560 `(7 * 8 * 3 * 9 * 5)`.
 
-Note that these series are only required to occupy *adjacent positions* in the input; the digits need not be *numerically consecutive*.
+Note that these series are only required to occupy _adjacent positions_ in the input; the digits need not be _numerically consecutive_.
 
-For the input `'73167176531330624919225119674426574742355349194934'`,
+For the input `"73167176531330624919225119674426574742355349194934"`,
 the largest product for a series of 6 digits is 23520.
 
 For a series of zero digits, the largest product is 1 because 1 is the multiplicative identity.


### PR DESCRIPTION
This PR changes the description to use double quotes instead of single quotes, which seems to be more common across languages.
