### PR TITLE
Remove ambiguity in explanation of empty product

### DIFF
--- a/exercises/largest-series-product/description.md
+++ b/exercises/largest-series-product/description.md
@@ -9,6 +9,11 @@ Note that these series are only required to occupy *adjacent positions* in the i
 For the input `'73167176531330624919225119674426574742355349194934'`,
 the largest product for a series of 6 digits is 23520.
 
-For a series of zero digits, the largest product is 1 because 1 is the multiplicative identity.
-(You don't need to know what a multiplicative identity is to solve this problem;
-it just means that multiplying a number by 1 gives you the same number.)
+For a series of zero digits, you need to return the empty product (the result of multiplying no numbers), which is 1.
+
+~~~~exercism/advanced
+You do not need to understand why the empty product is 1 to solve this problem,
+but in case you are interested, here is an informal argument: if we split a list of numbers `A` into two new lists `B` and `C`, then we expect `product(A) == product(B) * product(C)` because we don't expect the order that you multiply things to matter; now if we split a list containing only the number 3 into the empty list and a list containing the number 3 then the product of the empty list has to be 1 for `product([3]) == product([]) * product([3])` to be true.
+
+The same kind of argument justifies why the sum of no numbers is 0.
+~~~~


### PR DESCRIPTION
This commit removes some mathematical jargon (multiplicative identity) and instead describes what should be returned.

The explanation of what the multiplicative identity is has been replaced with a short explanation (in an admonition block) of why the empty product (of numbers) is 1.