### PR TITLE
Fix rendering issue in secret-handshake

### DIFF
--- a/exercises/secret-handshake/instructions.md
+++ b/exercises/secret-handshake/instructions.md
@@ -43,5 +43,6 @@ jump, double blink
 
 ~~~~exercism/note
 If you aren't sure what binary is or how it works, check out [this binary tutorial][intro-to-binary].
+
 [intro-to-binary]: https://medium.com/basecs/bits-bytes-building-with-binary-13cb4289aafa
 ~~~~


### PR DESCRIPTION
The markdown processor seems to have choked on the link reference in the exercism note, presumably because it was missing a blank line between the main text and the reference definition.

See https://github.com/exercism/problem-specifications/pull/2219#discussion_r1143402812