### PR TITLE
pangram: Clarify instructions

### DIFF
--- a/exercises/pangram/instructions.md
+++ b/exercises/pangram/instructions.md
@@ -5,4 +5,4 @@ Your task is to figure out if a sentence is a pangram.
 A pangram is a sentence using every letter of the alphabet at least once.
 It is case insensitive, so it doesn't matter if a letter is lower-case (e.g. `k`) or upper-case (e.g. `K`).
 
-For this exercise, a sentence is a pangram if it contains each of the 26 basic characters in the English alphabet.
+For this exercise, a sentence is a pangram if it contains each of the 26 letters in the English alphabet.

--- a/exercises/pangram/instructions.md
+++ b/exercises/pangram/instructions.md
@@ -5,4 +5,4 @@ Your task is to figure out if a sentence is a pangram.
 A pangram is a sentence using every letter of the alphabet at least once.
 It is case insensitive, so it doesn't matter if a letter is lower-case (e.g. `k`) or upper-case (e.g. `K`).
 
-For this exercise we only use the basic letters used in the English alphabet: `a` to `z`.
+For this exercise we only consider the basic letters used in English as part of the alphabet: `a` to `z`.

--- a/exercises/pangram/instructions.md
+++ b/exercises/pangram/instructions.md
@@ -5,4 +5,4 @@ Your task is to figure out if a sentence is a pangram.
 A pangram is a sentence using every letter of the alphabet at least once.
 It is case insensitive, so it doesn't matter if a letter is lower-case (e.g. `k`) or upper-case (e.g. `K`).
 
-For this exercise we only consider the basic letters used in English as part of the alphabet: `a` to `z`.
+For this exercise, a sentence is a pangram if it contains each of the 26 basic characters in the English alphabet.


### PR DESCRIPTION
Unfortunately #2215 introduced an ambiguity for some downstream implementations of this exercise that use non-ASCII inputs that shouldn't be considered part of the alphabet for the purpose of defining pangrams.

This PR is meant to clarify that only 'a':'z' are relevant to determine if a sentence is a pangram without restricting the inputs to those characters.

See also: https://github.com/exercism/julia/pull/614