### PR TITLE
New spec: Leibniz formula

### DIFF
--- a/exercises/leibniz-formula/canonical-data.json
+++ b/exercises/leibniz-formula/canonical-data.json
@@ -1,0 +1,73 @@
+{
+  "exercise": "leibniz-formula",
+  "comments": [
+    "The expected outputs should be the calculated π within an allowed distance, ",
+    "so for example given 10 fractions, the response should be π +/- 0.01.",
+    "The response fields below give the allowed distance given the number of fractions"
+  ],
+  "cases": [
+    {
+      "uuid": "92b94868-22c2-4dcf-85b2-e7c3788b1563",
+      "description": "no fractions at all",
+      "property": "distance",
+      "input": {
+        "value": "0"
+      },
+      "expected": 1
+    },
+    {
+      "uuid": "63d6e921-d748-4dd5-98a4-d313eba0c654",
+      "description": "one fraction",
+      "property": "distance",
+      "input": {
+        "value": "1"
+      },
+      "expected": 0.5
+    },
+    {
+      "uuid": "d9d076cf-dca0-4ee0-bea0-51d672f8d96e",
+      "description": "ten fractions",
+      "property": "distance",
+      "input": {
+        "value": "10"
+      },
+      "expected": 0.1
+    },
+    {
+      "uuid": "fa8cbcab-e99e-4c1d-b135-9b9bd44a1211",
+      "description": "hundred fractions",
+      "property": "distance",
+      "input": {
+        "value": "100"
+      },
+      "expected": 0.01
+    },
+    {
+      "uuid": "d2a93b78-9589-4c54-bef1-ea5051f42ca6",
+      "description": "thousand fractions",
+      "property": "distance",
+      "input": {
+        "value": "1000"
+      },
+      "expected": 0.001
+    },
+    {
+      "uuid": "6c6cd3f2-7047-475a-bd57-86a14c07a94c",
+      "description": "million fractions",
+      "property": "distance",
+      "input": {
+        "value": "1000000"
+      },
+      "expected": 0.000001
+    },
+    {
+      "uuid": "bdc0165b-5b18-42fd-9226-bc60fc5e6645",
+      "description": "billion fractions",
+      "property": "distance",
+      "input": {
+        "value": "1000000000"
+      },
+      "expected": 0.000000001
+    }
+  ]
+}

--- a/exercises/leibniz-formula/description.md
+++ b/exercises/leibniz-formula/description.md
@@ -1,0 +1,29 @@
+# Description
+
+Calculate π using [Leibniz formula](https://en.wikipedia.org/wiki/Leibniz_formula_for_%CF%80).
+
+```
+1 - 1/3 + 1/5 - 1/7 + 1/9 - ... = π/4
+```
+
+According to [Gottfried Leibniz](https://en.wikipedia.org/wiki/Gottfried_Leibniz), you can calculate π using the formula
+above.
+The more fractions you use, the closer your calculation will come to π.
+
+Here are some examples:
+
+| number of fractions | calculated π          |
+|---------------------|-----------------------|
+| 0                   | 4                     |
+| 1                   | 2.666666666666666...  |
+| 10                  | 3.232315809405594...  |
+| 100                 | 3.1514934010709914... |
+| 1 000               | 3.1425916543395442... |
+
+Your goal is to create a function that takes the number of fractions as argument, and returns the calculated π using the
+formula with the given number of fractions.
+
+## Implementation notes
+
+One adequate solution to this problem is to use [reduction](https://en.wikipedia.org/wiki/Fold_(higher-order_function)), since
+every calculation is based on the previous result.

--- a/exercises/leibniz-formula/metadata.toml
+++ b/exercises/leibniz-formula/metadata.toml
@@ -1,0 +1,4 @@
+title = "Leibniz formula"
+blurb = "Calculate π using Leibniz formula."
+source = "The Leibniz formula on Wikipedia"
+source_url = "https://en.wikipedia.org/wiki/Leibniz_formula_for_%CF%80"


### PR DESCRIPTION
A suggestion for a new exercise: calculate π using Leibniz formula:
1 - 1/3 + 1/5 - 1/7 + 1/9 - ... = π/4

The implementation should take the number of fractions to use when calculating π and the response should be within a given distance from π. The "expected" fields in the canonical-data.json file specify the allowed distance.