### PR TITLE
linked-list: use tildes for admonition, not backticks

### DIFF
--- a/exercises/linked-list/instructions.md
+++ b/exercises/linked-list/instructions.md
@@ -13,7 +13,7 @@ Sometimes a station gets closed down, and in that case the station needs to be r
 
 The size of a route is measured not by how far the train travels, but by how many stations it stops at.
 
-```exercism/note
+~~~~exercism/note
 The linked list is a fundamental data structure in computer science, often used in the implementation of other data structures.
 As the name suggests, it is a list of nodes that are linked together.
 It is a list of "nodes", where each node links to its neighbor or neighbors.
@@ -23,4 +23,4 @@ In a **doubly linked list** each node links to both the node that comes before, 
 If you want to dig deeper into linked lists, check out [this article][intro-linked-list] that explains it using nice drawings.
 
 [intro-linked-list]: https://medium.com/basecs/whats-a-linked-list-anyway-part-1-d8b7e6508b9d
-```
+~~~~


### PR DESCRIPTION
Commit https://github.com/exercism/problem-specifications/commit/d48e19ae1dcbe8a48bfecbfc6ff184bf6760e18d added an admonition that used backticks, but every other admonition uses tildes.

From the [Exercism Markdown specification][1]:

> We support special types of blocks that can be added to documents to pull out commentary that doesn't fit with the main body of the text.
>
> [...]
>
> All blocks are written using 4 tildes, in the form of:
> 
> ````
> ~~~~exercism/note
> Content goes here
> 
> You can include code:
> ```ruby
> str = "Hello, World"
> ```
> ~~~~
> ````
> 
> (Note: You may also use backticks or other levels of tildes in exceptional circumstances)


[1]: https://github.com/exercism/docs/blob/8c604214c423/building/markdown/markdown.md#special-blocks-sometimes-called-admonitions

---

With this PR, every admonition uses tildes:

```console
$ git rev-parse --short HEAD
84d547a2
$ git grep --break --heading 'exercism/' -- 'exercises/*.md'
exercises/binary:search/instructions.md
8:~~~~exercism/caution

exercises/counter/description.md
5:Please see the discussion in [https://github.com/exercism/problem-specifications/issues/80](https://github.com/exercism/problem-specifications/issues/80)

exercises/etl/instructions.md
25:~~~~exercism/note

exercises/gigasecond/introduction.md
16:~~~~exercism/note

exercises/killer:sudoku-helper/description.md
59:[one-solution-img]: https://media.githubusercontent.com/media/exercism/v3-files/main/julia/killer-sudoku-helper/example1.png
60:[four-solutions-img]: https://media.githubusercontent.com/media/exercism/v3-files/main/julia/killer-sudoku-helper/example2.png
61:[not-possible-img]: https://media.githubusercontent.com/media/exercism/v3-files/main/julia/killer-sudoku-helper/example3.png

exercises/linked:list/instructions.md
16:~~~~exercism/note

exercises/pangram/introduction.md
10:~~~~exercism/note

exercises/rational:numbers/description.md
5:~~~~exercism/note

exercises/rna:transcription/instructions.md
18:~~~~exercism/note

exercises/rna:transcription/introduction.md
7:~~~~exercism/note

exercises/secret:handshake/instructions.md
44:~~~~exercism/note

exercises/sieve/instructions.md
21:~~~~exercism/note
```