### PR TITLE
Tidy shell scripts in ./bin

### DIFF
--- a/bin/check_required_files_present
+++ b/bin/check_required_files_present
@@ -1,92 +1,84 @@
 #!/usr/bin/env bash
-MISSING_FILES=0
-UNNEEDED_FILES=0
-SHOW_PROGRESS='false'
+missing_files=0
+unneeded_files=0
+verbose_progress='false'
 
-if [ ! -d exercises ] ; then
-	echo "\"exercises\" directory not found, make sure you're running from the repository root" >&2
-	exit 1
+if [[ ! -d exercises ]] ; then
+    echo '"exercises" directory not found, make sure you are running from the repository root' >&2
+    exit 1
 fi
 
 function show_progress {
-	if [ $SHOW_PROGRESS == 'true' ]; then
-		echo -n '.'
-	fi
+    if [[ "${verbose_progress}" == 'true' ]]; then
+        printf '.'
+    fi
 }
 
 function require_file {
-	filename=$1
-	if [ ! -f $filename ]; then
-		echo "required file missing: $filename" >&2
-		let "MISSING_FILES+=1"
-	fi
+    local filename=$1
+    if [[ ! -f "${filename}" ]]; then
+        echo "required file missing: ${filename}" >&2
+        (( ++missing_files ))
+    fi
 }
 
 function reject_file {
-	filename=$1
-	if [ -f "$filename" ]; then
-		echo "unneeded file should be removed: $filename" >&2
-		UNNEEDED_FILES=$((UNNEEDED_FILES + 1))
-	fi
+    filename=$1
+    if [[ -f "${filename}" ]]; then
+        echo "unneeded file should be removed: ${filename}" >&2
+        (( ++unneeded_files ))
+    fi
 }
 
 function require_file_or_alternative {
-	filename=$1	
-	alternative_filename=$2
-	if [ ! -f $filename ] && [ ! -f $alternative_filename ]; then		
-		echo "required file missing: $filename or $alternative_filename" >&2
-		let "MISSING_FILES+=1"
-	elif [ -f "$filename" ] && [ -f "$alternative_filename" ]; then
-		echo "one of these two files should be removed: $filename or $alternative_filename" >&2
-		UNNEEDED_FILES=$((UNNEEDED_FILES + 1))
-	fi
+    filename=$1
+    alternative_filename=$2
+    if [[ ! -f "${filename}" && ! -f "${alternative_filename}" ]]; then
+        echo "required file missing: ${filename} or ${alternative_filename}" >&2
+        (( ++missing_files ))
+    elif [[ -f "${filename}" && -f "${alternative_filename}" ]]; then
+        echo "one of these two files should be removed: ${filename} or ${alternative_filename}" >&2
+        (( ++unneeded_files ))
+    fi
 }
 
 function check_directory {
-	directory=$1
-	for exercise_directory in $directory/* ; do
-		show_progress
+    directory=$1
+    for exercise_directory in "${directory}"/* ; do
+        show_progress
 
-		# Only two possibilities are allowed:
-		# 1. legacy: Only description.md
-		# 2. migrated to new format: description.md is gone,
-		#    and only instructions.md and introduction.md exist.
-		desc="$exercise_directory/description.md"
-		inst="$exercise_directory/instructions.md"
-		intro="$exercise_directory/introduction.md"
-		require_file_or_alternative "$desc" "$inst"
-		if [ -f "$inst" ]; then
-			require_file "$intro"
-		elif [ -f "$desc" ]; then
-			reject_file "$intro"
-		fi
+        # only two possibilities are allowed:
+        # 1. legacy: only description.md
+        # 2. migrated to new format: description.md is gone,
+        #    and only instructions.md and introduction.md exist.
+        desc="${exercise_directory}/description.md"
+        inst="${exercise_directory}/instructions.md"
+        intro="${exercise_directory}/introduction.md"
+        require_file_or_alternative "${desc}" "${inst}"
+        if [[ -f "${inst}" ]]; then
+            require_file "${intro}"
+        elif [[ -f "${desc}" ]]; then
+            reject_file "${intro}"
+        fi
 
-		require_file "$exercise_directory/metadata.toml"
-	done
+        require_file "${exercise_directory}/metadata.toml"
+    done
 
 }
 
-while :
-do
-	case "$1" in
-		-p | --progress)
-			SHOW_PROGRESS="true"
-			shift 1
-			;;
-		*)
-			check_directory 'exercises'
-			if [ $SHOW_PROGRESS == 'true' ]; then
-				echo
-				echo Done: $MISSING_FILES files missing and $UNNEEDED_FILES unneeded files.
-			fi
-			if (( $MISSING_FILES > 0 )); then
-				exit 1
-			elif (( $UNNEEDED_FILES > 0 )); then
-				exit 1
-			else
-				exit 0
-			fi
-			;;
-	esac
-done
+if [[ "$1" == "-p" || "$1" == "--progress" ]]; then
+    verbose_progress="true"
+fi
 
+check_directory 'exercises'
+
+if [[ "${verbose_progress}" == 'true' ]]; then
+    echo
+    echo "done: ${missing_files} files missing and ${unneeded_files} unneeded files."
+fi
+
+if (( missing_files || unneeded_files )); then
+    exit 1
+else
+    exit 0
+fi

--- a/bin/check_required_files_present
+++ b/bin/check_required_files_present
@@ -3,7 +3,7 @@ missing_files=0
 unneeded_files=0
 verbose_progress='false'
 
-if [[ ! -d exercises ]] ; then
+if [[ ! -d exercises ]]; then
     echo '"exercises" directory not found, make sure you are running from the repository root' >&2
     exit 1
 fi
@@ -44,7 +44,7 @@ function require_file_or_alternative {
 
 function check_directory {
     directory=$1
-    for exercise_directory in "${directory}"/* ; do
+    for exercise_directory in "${directory}"/*; do
         show_progress
 
         # only two possibilities are allowed:

--- a/bin/reorder-keys
+++ b/bin/reorder-keys
@@ -12,10 +12,10 @@ for canonical_data_file in exercises/*/canonical-data.json; do
         walk(
             if (type == "object") and has("uuid") then
                 . as $obj |
-            reduce ["uuid", "reimplements", "description", "comments", "scenarios", "property", "input", "expected"][] as $key (
-                {};
-                . + (if $obj | has($key) then { ($key): $obj[$key] } else {} end)
-            )
+                reduce ["uuid", "reimplements", "description", "comments", "scenarios", "property", "input", "expected"][] as $key (
+                    {};
+                    . + (if $obj | has($key) then { ($key): $obj[$key] } else {} end)
+                )
             else
                 .
             end

--- a/bin/reorder-keys
+++ b/bin/reorder-keys
@@ -1,12 +1,24 @@
 #!/usr/bin/env bash
 
-if [ ! -d exercises ] ; then
-    echo "Error: \"exercises\" directory not found, make sure you're running from the repository root" >&2
+if [[ ! -d exercises ]] ; then
+    echo 'Error: "exercises" directory not found, make sure you are running from the repository root' >&2
     exit 1
 fi
 
 tmp_file='.reordered-canonical-data.json'
 
 for canonical_data_file in exercises/*/canonical-data.json ; do
-    jq 'walk(if (type == "object") and has("uuid") then . as $obj | reduce ["uuid", "reimplements", "description", "comments", "scenarios", "property", "input", "expected"][] as $key ({}; . + (if $obj | has($key) then { ($key): $obj[$key] } else {} end)) else . end)' "$canonical_data_file" > "$tmp_file" && mv "$tmp_file" "$canonical_data_file"
+    jq '
+        walk(
+            if (type == "object") and has("uuid") then
+                . as $obj |
+            reduce ["uuid", "reimplements", "description", "comments", "scenarios", "property", "input", "expected"][] as $key (
+                {};
+                . + (if $obj | has($key) then { ($key): $obj[$key] } else {} end)
+            )
+            else
+                .
+            end
+        )
+    ' "$canonical_data_file" > "$tmp_file" && mv "$tmp_file" "$canonical_data_file"
 done

--- a/bin/reorder-keys
+++ b/bin/reorder-keys
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-if [[ ! -d exercises ]] ; then
+if [[ ! -d exercises ]]; then
     echo 'Error: "exercises" directory not found, make sure you are running from the repository root' >&2
     exit 1
 fi
 
 tmp_file='.reordered-canonical-data.json'
 
-for canonical_data_file in exercises/*/canonical-data.json ; do
+for canonical_data_file in exercises/*/canonical-data.json; do
     jq '
         walk(
             if (type == "object") and has("uuid") then
@@ -20,5 +20,5 @@ for canonical_data_file in exercises/*/canonical-data.json ; do
                 .
             end
         )
-    ' "$canonical_data_file" > "$tmp_file" && mv "$tmp_file" "$canonical_data_file"
+    ' "${canonical_data_file}" > "${tmp_file}" && mv "${tmp_file}" "${canonical_data_file}"
 done


### PR DESCRIPTION
* Prefer `[[` over `[`
* Expand tabs to 4 spaces
* Quote variables uniformly in `"${var}"` format
* Use `local` for function variables
* Prefer lowercase variable names for non-readonly variables
* Replace `let` with `$((`