### PR TITLE
bin/fetch-configlet: sync with upstream

### DIFF
--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -1,52 +1,90 @@
 #!/usr/bin/env bash
 
+# This file is a copy of the
+# https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet file.
+# Please submit bugfixes/improvements to the above file to ensure that all tracks benefit from the changes.
+
 set -eo pipefail
 
-readonly LATEST='https://api.github.com/repos/exercism/configlet/releases/latest'
+curlopts=(
+  --silent
+  --show-error
+  --fail
+  --location
+  --retry 3
+)
 
-case "$(uname)" in
-    (Darwin*)   OS='mac'     ;;
-    (Linux*)    OS='linux'   ;;
-    (Windows*)  OS='windows' ;;
-    (MINGW*)    OS='windows' ;;
-    (MSYS_NT-*) OS='windows' ;;
-    (*)         OS='linux'   ;;
-esac
-
-case "$OS" in
-    (windows*) EXT='zip' ;;
-    (*)        EXT='tgz' ;;
-esac
-
-case "$(uname -m)" in
-    (*64*)  ARCH='64bit' ;;
-    (*686*) ARCH='32bit' ;;
-    (*386*) ARCH='32bit' ;;
-    (*)     ARCH='64bit' ;;
-esac
-
-if [ -z "${GITHUB_TOKEN}" ]
-then
-    HEADER=''
-else
-    HEADER="authorization: Bearer ${GITHUB_TOKEN}"
+if [[ -n "${GITHUB_TOKEN}" ]]; then
+  curlopts+=(--header "authorization: Bearer ${GITHUB_TOKEN}")
 fi
 
-FILENAME="configlet-${OS}-${ARCH}.${EXT}"
-
-get_url () {
-    curl --header "$HEADER" -s "$LATEST" |
-        awk -v filename=$FILENAME '$1 ~ /browser_download_url/ && $2 ~ filename { print $2 }' |
-        tr -d '"'
+get_download_url() {
+  local os="$1"
+  local ext="$2"
+  local latest='https://api.github.com/repos/exercism/configlet/releases/latest'
+  local arch
+  case "$(uname -m)" in
+    x86_64) arch='x86-64' ;;
+    *686*)  arch='i386'   ;;
+    *386*)  arch='i386'   ;;
+    *)      arch='x86-64' ;;
+  esac
+  local suffix="${os}_${arch}.${ext}"
+  curl "${curlopts[@]}" --header 'Accept: application/vnd.github.v3+json' "${latest}" |
+    grep "\"browser_download_url\": \".*/download/.*/configlet.*${suffix}\"$" |
+    cut -d'"' -f4
 }
 
-URL=$(get_url)
+main() {
+  local output_dir
+  if [[ -d ./bin ]]; then
+    output_dir="./bin"
+  elif [[ $PWD == */bin ]]; then
+    output_dir="$PWD"
+  else
+    echo "Error: no ./bin directory found. This script should be ran from a repo root." >&2
+    return 1
+  fi
 
-case "$EXT" in
-    (*zip)
-        curl --header "$HEADER" -s --location "$URL" -o bin/latest-configlet.zip
-        unzip bin/latest-configlet.zip -d bin/
-        rm bin/latest-configlet.zip
-        ;;
-    (*) curl --header "$HEADER" -s --location "$URL" | tar xz -C bin/ ;;
-esac
+  local os
+  case "$(uname)" in
+    Darwin*)   os='macos'   ;;
+    Linux*)    os='linux'   ;;
+    Windows*)  os='windows' ;;
+    MINGW*)    os='windows' ;;
+    MSYS_NT-*) os='windows' ;;
+    *)         os='linux'   ;;
+  esac
+
+  local ext
+  case "${os}" in
+    windows*) ext='zip'    ;;
+    *)        ext='tar.gz' ;;
+  esac
+
+  echo "Fetching configlet..." >&2
+  local download_url
+  download_url="$(get_download_url "${os}" "${ext}")"
+  local output_path="${output_dir}/latest-configlet.${ext}"
+  curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
+
+  case "${ext}" in
+    *zip) unzip "${output_path}" -d "${output_dir}"   ;;
+    *)    tar xzf "${output_path}" -C "${output_dir}" ;;
+  esac
+
+  rm -f "${output_path}"
+
+  local executable_ext
+  case "${os}" in
+    windows*) executable_ext='.exe' ;;
+    *)        executable_ext=''     ;;
+  esac
+
+  local configlet_path="${output_dir}/configlet${executable_ext}"
+  local configlet_version
+  configlet_version="$(${configlet_path} --version)"
+  echo "Downloaded configlet ${configlet_version} to ${configlet_path}"
+}
+
+main


### PR DESCRIPTION
The fetch-configlet script in this repo was outdated. Update it to [the upstream version][1], which has many improvements.

Closes: #2258

[1]: https://github.com/exercism/configlet/blob/85745ac34f7c/scripts/fetch-configlet