### PR TITLE
saddle-points: instructions: fix directions

### DIFF
--- a/exercises/saddle-points/instructions.md
+++ b/exercises/saddle-points/instructions.md
@@ -3,7 +3,7 @@
 Your task is to find the potential trees where you could build your tree house.
 
 The data company provides the data as grids that show the heights of the trees.
-The rows of the grid represent the north-south direction, and the columns represent the east-west direction.
+The rows of the grid represent the east-west direction, and the columns represent the north-south direction.
 
 An acceptable tree will be the the largest in its row, while being the smallest in its column.
 


### PR DESCRIPTION
Please double-check that I haven't become confused here.

This PR is a follow-up of https://github.com/exercism/problem-specifications/pull/2248#discussion_r1155550370.

---

These directions didn't match what we said elsewhere in the instructions:

>An acceptable tree will be the largest in its row, while being the smallest in its column.

And in the introduction:

>The best tree will be the tallest tree compared to all the other trees to the east and west, so that you have the best possible view of the sunrises and sunsets.
>
>You don't like climbing too much, so the perfect tree will also be the shortest among all the trees to the north and to the south.

And in the test cases:

 >Here is a grid that has exactly one candidate tree.
>
>```
>     1  2  3  4
>   |-----------
>1 | 9  8  7  8
>2 | 5  3  2  4  <--- potential tree house at row 2, column 1, for tree with height 5
>3 | 6  6  7  1
>```
>
>- Row 2 has values 5, 3, and 1. The largest value is 5.
>- Column 1 has values 9, 5, and 6. The smallest value is 5.
>
>So the point at `[2, 1]` (row: 2, column: 1) is a great spot for a tree house.

Fixes: #2263