### PR TITLE
typo in game rules

### DIFF
--- a/exercises/yacht/description.md
+++ b/exercises/yacht/description.md
@@ -10,8 +10,8 @@ The score of a throw of the dice depends on category chosen.
 | -------- | ----- | ----------- | ------- |
 | Ones | 1 × number of ones | Any combination | 1 1 1 4 5 scores 3 |
 | Twos | 2 × number of twos | Any combination | 2 2 3 4 5 scores 4 |
-| Threes | 3 × number of threes | Any combination | 3 3 3 3 3 scores 15 |
-| Fours | 4 × number of fours | Any combination | 1 2 3 3 5 scores 0 |
+| Threes | 3 × number of threes | Any combination | 3 3 3 1 5 scores 9 |
+| Fours | 4 × number of fours | Any combination | 1 2 4 4 5 scores 8 |
 | Fives | 5 × number of fives| Any combination | 5 1 5 2 5 scores 15 |
 | Sixes | 6 × number of sixes | Any combination | 2 3 4 5 6 scores 6 |
 | Full House | Total of the dice | Three of one number and two of another | 3 3 3 5 5 scores 19 |


### PR DESCRIPTION
I read the rules on wikipedia and it seems to me they are mistakes in the table: 
- one need to get the highest possible combination: so 0 cannot be the score when 2 "3" exists on the dices
- they are 5 "3" in the "threes" example so it's a "yaght" scoring 50 points. to avoid confusion, I changed the 2 last to other values