### PR TITLE
Pig Latin: Remove use of "constant clusters"

### DIFF
--- a/exercises/pig-latin/description.md
+++ b/exercises/pig-latin/description.md
@@ -8,11 +8,12 @@ It obeys a few simple rules (below), but when it's spoken quickly it's really di
 - **Rule 1**: If a word begins with a vowel sound, add an "ay" sound to the end of the word.
   Please note that "xr" and "yt" at the beginning of a word make vowel sounds (e.g. "xray" -> "xrayay", "yttria" -> "yttriaay").
 - **Rule 2**: If a word begins with a consonant sound, move it to the end of the word and then add an "ay" sound to the end of the word.
-  Consonant sounds can be made up of multiple consonants, a.k.a. a consonant cluster (e.g. "chair" -> "airchay").
+  Consonant sounds can be made up of multiple consonants, such as the "ch" in "chair" or "st" in "stand" (e.g. "chair" -> "airchay").
 - **Rule 3**: If a word starts with a consonant sound followed by "qu", move it to the end of the word, and then add an "ay" sound to the end of the word (e.g. "square" -> "aresquay").
 - **Rule 4**: If a word contains a "y" after a consonant cluster or as the second letter in a two letter word it makes a vowel sound (e.g. "rhythm" -> "ythmrhay", "my" -> "ymay").
 
 There are a few more rules for edge cases, and there are regional variants too.
+Check the tests for all the details.
 
 Read more about [Pig Latin on Wikipedia][pig-latin].
 


### PR DESCRIPTION
Context: https://forum.exercism.org/t/pig-latin-ch-in-chair-is-not-consonant-cluster/6285

> maybe try to use those confusing terms as little as possible until fully understand them. the fact that there are different definitions for consonant clusters and consonant digraphs on different websites further proves that there is no reason to continue using them.
