### PR TITLE
Change anagram test case input

### DIFF
--- a/exercises/anagram/canonical-data.json
+++ b/exercises/anagram/canonical-data.json
@@ -133,6 +133,17 @@
       "expected": []
     },
     {
+      "uuid": "630abb71-a94e-4715-8395-179ec1df9f91",
+      "reimplements": "7cc195ad-e3c7-44ee-9fd2-d3c344806a2c",
+      "description": "does not detect an anagram if the original word is repeated",
+      "property": "findAnagrams",
+      "input": {
+        "subject": "go",
+        "candidates": ["goGoGO"]
+      },
+      "expected": []
+    },
+    {
       "uuid": "9878a1c9-d6ea-4235-ae51-3ea2befd6842",
       "description": "anagrams must use all letters exactly once",
       "property": "findAnagrams",


### PR DESCRIPTION
The input for the anagram function is supposed to be a list containing single word strings, as in all other test cases. This test case has multiple words in the same string, separated by whitespace.