### PR TITLE
Update knapsack description

### DIFF
--- a/exercises/knapsack/description.md
+++ b/exercises/knapsack/description.md
@@ -18,7 +18,7 @@ Each item will have a weight and value.
 
 For example:
 
-```
+```none
 Items: [
   { "weight": 5, "value": 10 },
   { "weight": 4, "value": 40 },

--- a/exercises/knapsack/description.md
+++ b/exercises/knapsack/description.md
@@ -13,10 +13,11 @@ Given a knapsack with a specific carrying capacity (W), help Bob determine the m
 Note that Bob can take only one of each item.
 
 All values given will be strictly positive.
-Items will be represented as a list of pairs, `wi` and `vi`, where the first element `wi` is the weight of the *i*th item and `vi` is the value for that item.
+Items will be represented with a weight and value each.
 
 For example:
 
+```
 Items: [
   { "weight": 5, "value": 10 },
   { "weight": 4, "value": 40 },
@@ -25,6 +26,7 @@ Items: [
 ]
 
 Knapsack Limit: 10
+```
 
 For the above, the first item has weight 5 and value 10, the second item has weight 4 and value 40, and so on.
 

--- a/exercises/knapsack/description.md
+++ b/exercises/knapsack/description.md
@@ -13,7 +13,8 @@ Given a knapsack with a specific carrying capacity (W), help Bob determine the m
 Note that Bob can take only one of each item.
 
 All values given will be strictly positive.
-Items will be represented with a weight and value each.
+Items will be represented as a list of items.
+Each item will have a weight and value.
 
 For example:
 


### PR DESCRIPTION
The description of the knapsack problem has been updated quite a few times, resulting in two inconsistencies:

- The text references `wi` and `vi`, but they don't appear in the example input
- The example input uses JSON-esque formatting, but without linebreaks, rendering as

  ![image](https://github.com/exercism/problem-specifications/assets/8521043/529c77ab-b268-4e50-bef4-c35a5159c482)

This PR simplifies the description, and puts the example input into a code block to preserve formatting.