### PR TITLE
Remove or replace all Twitter links

### DIFF
--- a/exercises/accumulate/metadata.toml
+++ b/exercises/accumulate/metadata.toml
@@ -1,4 +1,4 @@
 title = "Accumulate"
 blurb = "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection."
 source = "Conversation with James Edward Gray II"
-source_url = "https://twitter.com/jeg2"
+source_url = "http://graysoftinc.com/"

--- a/exercises/binary-search-tree/metadata.toml
+++ b/exercises/binary-search-tree/metadata.toml
@@ -1,4 +1,4 @@
 title = "Binary Search Tree"
 blurb = "Insert and search for numbers in a binary tree."
 source = "Josh Cheek"
-source_url = "https://twitter.com/josh_cheek"
+source_url = "https://www.deviantart.com/joshcheek"

--- a/exercises/clock/metadata.toml
+++ b/exercises/clock/metadata.toml
@@ -1,4 +1,3 @@
 title = "Clock"
 blurb = "Implement a clock that handles times without dates."
 source = "Pairing session with Erin Drummond"
-source_url = "https://twitter.com/ebdrummond"

--- a/exercises/meetup/metadata.toml
+++ b/exercises/meetup/metadata.toml
@@ -1,4 +1,4 @@
 title = "Meetup"
 blurb = "Calculate the date of meetups."
 source = "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month"
-source_url = "https://twitter.com/copiousfreetime"
+source_url = "http://www.copiousfreetime.org/"

--- a/exercises/strain/metadata.toml
+++ b/exercises/strain/metadata.toml
@@ -1,4 +1,4 @@
 title = "Strain"
 blurb = "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false."
 source = "Conversation with James Edward Gray II"
-source_url = "https://twitter.com/jeg2"
+source_url = "http://graysoftinc.com/"


### PR DESCRIPTION
Currently not logged in users are only allowed to see pages for single tweets. They are not allowed to see profile pages for example. I'm not allowed to access [https://twitter.com/jeg2](https://twitter.com/jeg2). And scripts aren't allow to access anything. `curl -I` on a valid tweet URL always returns 403. Thus Twitter is no longer appropriate to use as sources for anything.

Twitter links are also blocking https://github.com/exercism/problem-specifications/pull/2294

All the `http` instead of `https` are intentional - those are old websites that do not use SSL.