### PR TITLE
Fix inconsistent 'factor of x' description in raindrops

### DIFF
--- a/exercises/raindrops/canonical-data.json
+++ b/exercises/raindrops/canonical-data.json
@@ -75,7 +75,7 @@
     },
     {
       "uuid": "37ab74db-fed3-40ff-b7b9-04acdfea8edf",
-      "description": "the sound for 14 is Plong as it has a factor of 7",
+      "description": "the sound for 14 is Plong as it has a factor 7",
       "property": "convert",
       "input": {
         "number": 14


### PR DESCRIPTION
All other descriptions referencing factor say 'factor x', but this test's description says 'factor of x' .