### PR TITLE
Rename "Pop Count" to "Eluid's Eggs"

### DIFF
--- a/exercises/pop-count/metadata.toml
+++ b/exercises/pop-count/metadata.toml
@@ -1,4 +1,4 @@
-title = "Pop Count"
-blurb = "Count the 1 bits in a number"
+title = "Eliud's Eggs"
+blurb = "Help Eluid count the number of eggs in her chicken coop by counting the number of 1 bits in a binary representation."
 source = "Christian Willner, Eric Willigers"
 source_url = "https://forum.exercism.org/t/new-exercise-suggestion-pop-count/7632/5"


### PR DESCRIPTION
Exercises should be named after their story, not their implementation details.

I'd also like to change the slug, but I'll leave that for another day.