### PR TITLE
Poker: Make high card tests more robust

### DIFF
--- a/exercises/poker/canonical-data.json
+++ b/exercises/poker/canonical-data.json
@@ -43,6 +43,15 @@
       "expected": ["3S 5H 6S 8D 7H"]
     },
     {
+      "uuid": "da01becd-f5b0-4342-b7f3-1318191d0580",
+      "description": "winning high card hand also has the lowest card",
+      "property": "bestHands",
+      "input": {
+        "hands": ["2S 5H 6S 8D 7H", "3S 4D 6D 8C 7S"]
+      },
+      "expected": ["2S 5H 6S 8D 7H"]
+    },
+    {
       "uuid": "f7175a89-34ff-44de-b3d7-f6fd97d1fca4",
       "description": "one pair beats high card",
       "property": "bestHands",
@@ -59,6 +68,15 @@
         "hands": ["4S 2H 6S 2D JH", "2S 4H 6C 4D JD"]
       },
       "expected": ["2S 4H 6C 4D JD"]
+    },
+    {
+      "uuid": "b3acd3a7-f9fa-4647-85ab-e0a9e07d1365",
+      "description": "both hands have the same pair, high card wins",
+      "property": "bestHands",
+      "input": {
+        "hands": ["4H 4S AH JC 3D", "4C 4D AS 5D 6C"]
+      },
+      "expected": ["4H 4S AH JC 3D"]
     },
     {
       "uuid": "935bb4dc-a622-4400-97fa-86e7d06b1f76",
@@ -142,6 +160,19 @@
       "expected": ["4S AH AS 8C AD"]
     },
     {
+      "uuid": "26a4a7d4-34a2-4f18-90b4-4a8dd35d2bb1",
+      "reimplements": "eb856cc2-481c-4b0d-9835-4d75d07a5d9d",
+      "description": "with multiple decks, two players can have same three of a kind, ties go to highest remaining cards",
+      "comments": [
+        "Ensure that high cards are checked in the correct order (high to low)."
+      ],
+      "property": "bestHands",
+      "input": {
+        "hands": ["5S AH AS 7C AD", "4S AH AS 8C AD"]
+      },
+      "expected": ["4S AH AS 8C AD"]
+    },
+    {
       "uuid": "a858c5d9-2f28-48e7-9980-b7fa04060a60",
       "description": "a straight beats three of a kind",
       "property": "bestHands",
@@ -212,6 +243,19 @@
         "hands": ["4H 7H 8H 9H 6H", "2S 4S 5S 6S 7S"]
       },
       "expected": ["4H 7H 8H 9H 6H"]
+    },
+    {
+      "uuid": "e04137c5-c19a-4dfc-97a1-9dfe9baaa2ff",
+      "reimplements": "4d90261d-251c-49bd-a468-896bf10133de",
+      "description": "both hands have a flush, tie goes to high card, down to the last one if necessary",
+      "comments": [
+        "Ensure that high cards are checked in the correct order (high to low)."
+      ],
+      "property": "bestHands",
+      "input": {
+        "hands": ["2H 7H 8H 9H 6H", "3S 5S 6S 7S 8S"]
+      },
+      "expected": ["2H 7H 8H 9H 6H"]
     },
     {
       "uuid": "3a19361d-8974-455c-82e5-f7152f5dba7c",


### PR DESCRIPTION
Ensure that high cards are checked in the correct order (high ranking cards down to low ranking cards). Tests previously succeeded even when comparing lowest ranking spare cards first (e.g. "3H JS" beats "2C 5H" even when comparing "3H" vs. "2C").

Two tests added to ensure hands with pairs and triplets of the same rank are checked for high cards down to the last card.