### PR TITLE
Typo in Eluid's Eggs metadata blurb

### DIFF
--- a/exercises/pop-count/metadata.toml
+++ b/exercises/pop-count/metadata.toml
@@ -1,4 +1,4 @@
 title = "Eliud's Eggs"
-blurb = "Help Eluid count the number of eggs in her chicken coop by counting the number of 1 bits in a binary representation."
+blurb = "Help Eliud count the number of eggs in her chicken coop by counting the number of 1 bits in a binary representation."
 source = "Christian Willner, Eric Willigers"
 source_url = "https://forum.exercism.org/t/new-exercise-suggestion-pop-count/7632/5"


### PR DESCRIPTION
#2335 changed `pop-count`'s title from Pop Count to Eliud's Eggs, but the config.json blurb spells it as Eluid. The introduction and exercise title uses Eliud.