### PR TITLE
Reimplement test case in DnD Character

### DIFF
--- a/exercises/dnd-character/canonical-data.json
+++ b/exercises/dnd-character/canonical-data.json
@@ -197,6 +197,24 @@
       "property": "strength",
       "input": {},
       "expected": "strength == strength"
+    },
+    {
+      "uuid": "dca2b2ec-f729-4551-84b9-078876bb4808",
+      "reimplements": "2ca77b9b-c099-46c3-a02c-0d0f68ffa0fe",
+      "description": "each ability is only calculated once",
+      "comments": [
+        "Expected values were changed to cover all character abilities"
+      ],
+      "property": "character",
+      "input": {},
+      "expected": {
+        "strength": "strength == strength",
+        "dexterity": "dexterity == dexterity",
+        "constitution": "constitution == constitution",
+        "intelligence": "intelligence == intelligence",
+        "wisdom": "wisdom == wisdom",
+        "charisma": "charisma == charisma"
+      }
     }
   ]
 }


### PR DESCRIPTION
This reimplements test case `2ca77b9b-c099-46c3-a02c-0d0f68ffa0fe` in the DnD Character exercise to verify that *every* ability is calculated only once, instead of only the `strength` ability.

This change was proposed in https://github.com/exercism/java/pull/2548 and it made sense to me to add it to the canonical data.