### PR TITLE
Deprecate `scale-generator` exercise

### DIFF
--- a/exercises/scale-generator/.deprecated
+++ b/exercises/scale-generator/.deprecated
@@ -1,0 +1,2 @@
+**NOTE: This exercise has been deprecated**
+See https://forum.exercism.org/t/scale-generator-tests/8236/1


### PR DESCRIPTION
We're deprecating the `scale-generator` exercise as it has been a source of confusion for many students.
Unfortunately, there is no clear path to improving this exercise, hence us deprecating the exercise.

See https://forum.exercism.org/t/scale-generator-tests/8236/1
