### PR TITLE
Add `eliuds-eggs` exercise

### DIFF
--- a/exercises/eliuds-eggs/canonical-data.json
+++ b/exercises/eliuds-eggs/canonical-data.json
@@ -1,0 +1,41 @@
+{
+  "exercise": "eliuds-eggs",
+  "cases": [
+    {
+      "uuid": "559e789d-07d1-4422-9004-3b699f83bca3",
+      "description": "0 eggs",
+      "property": "eggCount",
+      "input": {
+        "number": 0
+      },
+      "expected": 0
+    },
+    {
+      "uuid": "97223282-f71e-490c-92f0-b3ec9e275aba",
+      "description": "1 egg",
+      "property": "eggCount",
+      "input": {
+        "number": 16
+      },
+      "expected": 1
+    },
+    {
+      "uuid": "1f8fd18f-26e9-4144-9a0e-57cdfc4f4ff5",
+      "description": "4 eggs",
+      "property": "eggCount",
+      "input": {
+        "number": 89
+      },
+      "expected": 4
+    },
+    {
+      "uuid": "0c18be92-a498-4ef2-bcbb-28ac4b06cb81",
+      "description": "13 eggs",
+      "property": "eggCount",
+      "input": {
+        "number": 2000000000
+      },
+      "expected": 13
+    }
+  ]
+}

--- a/exercises/eliuds-eggs/instructions.md
+++ b/exercises/eliuds-eggs/instructions.md
@@ -1,0 +1,8 @@
+# Instructions
+
+Your task is to count the number of 1 bits in the binary representation of a number.
+
+## Restrictions
+
+Keep your hands off that bit-count functionality provided by your standard library!
+Solve this one yourself using other basic tools instead.

--- a/exercises/eliuds-eggs/introduction.md
+++ b/exercises/eliuds-eggs/introduction.md
@@ -1,0 +1,47 @@
+# Introduction
+
+Your friend Eliud inherited a farm from her grandma Tigist.
+Her granny was an inventor and had a tendency to build things in an overly complicated manner.
+The chicken coop has a digital display showing an encoded number representing the positions of all eggs that could be picked up.
+
+Eliud is asking you to write a program that shows the actual number of eggs in the coop.
+
+The position information encoding is calculated as follows:
+
+1. Scan the potential egg-laying spots and mark down a `1` for an existing egg or a `0` for an empty spot.
+2. Convert the number from binary to decimal.
+3. Show the result on the display.
+
+Example 1:
+
+```text
+Chicken Coop:
+ _ _ _ _ _ _ _
+|E| |E|E| | |E|
+
+Resulting Binary:
+ 1 0 1 1 0 0 1
+
+Decimal number on the display:
+89
+
+Actual eggs in the coop:
+4
+```
+
+Example 2:
+
+```text
+Chicken Coop:
+ _ _ _ _ _ _ _ _
+| | | |E| | | | |
+
+Resulting Binary:
+ 0 0 0 1 0 0 0 0
+
+Decimal number on the display:
+16
+
+Actual eggs in the coop:
+1
+```

--- a/exercises/eliuds-eggs/metadata.toml
+++ b/exercises/eliuds-eggs/metadata.toml
@@ -1,0 +1,4 @@
+title = "Eliud's Eggs"
+blurb = "Help Eliud count the number of eggs in her chicken coop by counting the number of 1 bits in a binary representation."
+source = "Christian Willner, Eric Willigers"
+source_url = "https://forum.exercism.org/t/new-exercise-suggestion-pop-count/7632/5"


### PR DESCRIPTION
The `pop-count` exercise should really have been named `eliuds-eggs`.
To help migrate to this new name in a non-breaking way, we're not renaming `pop-count` but instead have both of them temporarily.
Once all tracks have been updated (we'll do a bulk PR), we can remove the obsolete `pop-count` exercise.
