### PR TITLE
roman-numerals: add test with longest output

### DIFF
--- a/exercises/roman-numerals/canonical-data.json
+++ b/exercises/roman-numerals/canonical-data.json
@@ -253,6 +253,16 @@
       "expected": "MMMI"
     },
     {
+      "uuid": "2f89cad7-73f6-4d1b-857b-0ef531f68b7e",
+      "description": "3888 is MMMDCCCLXXXVIII",
+      "comments": ["This is the longest possible output"],
+      "property": "roman",
+      "input": {
+        "number": 3888
+      },
+      "expected": "MMMDCCCLXXXVIII"
+    },
+    {
       "uuid": "4e18e96b-5fbb-43df-a91b-9cb511fe0856",
       "description": "3999 is MMMCMXCIX",
       "property": "roman",


### PR DESCRIPTION
This matters for languages like C where people need to allocate memory manually for the output.

An example of a mistake this would catch is if someone fails to consider that each arabic digit (except the thousands) can result in up to 4 letters. Or if they correctly compute a maximum of 15 letters but then forget to add 1 for the terminating null byte (in C).

Before this PR, those mistakes would not get caught, as the longest output in existing tests was 9 letters long.

Impact on existing solutions: in a lot of languages this will not matter. In languages with manual memory management, I think solutions that would fail the new test were never correct in the first place.