### PR TITLE
protein-translation: remove incorrect test

### DIFF
--- a/exercises/protein-translation/canonical-data.json
+++ b/exercises/protein-translation/canonical-data.json
@@ -261,6 +261,7 @@
     },
     {
       "uuid": "9eac93f3-627a-4c90-8653-6d0a0595bc6f",
+      "reimplements": "1e75ea2a-f907-4994-ae5c-118632a1cb0f",
       "description": "Unknown amino acids, not part of a codon, can't translate",
       "comments": [
         "It's up to a track how to behave when a character is encountered ",


### PR DESCRIPTION
The codon AAA maps to the amino acid lysine. While it is not listed in the exercise instructions, users should be free to implement the translation for all amino acids.

Since we cannot delete tests, this is done by making another test reimplement the incorrect one.

[Link to discussion on the forum](https://forum.exercism.org/t/incorrect-test-in-protein-translation/10616).