### PR TITLE
fix: prevent matching STOP in a valid non-STOP sequence

### DIFF
--- a/exercises/protein-translation/canonical-data.json
+++ b/exercises/protein-translation/canonical-data.json
@@ -243,6 +243,15 @@
       "expected": ["Tryptophan", "Cysteine", "Tyrosine"]
     },
     {
+      "uuid": "f6f92714-769f-4187-9524-e353e8a41a80",
+      "description": "Sequence of two non-STOP codons is not matched to a STOP codon",
+      "property": "proteins",
+      "input": {
+        "strand": "AUGAUG"
+      },
+      "expected": ["Methionine", "Methionine"]
+    },
+    {
       "uuid": "1e75ea2a-f907-4994-ae5c-118632a1cb0f",
       "description": "Non-existing codon can't translate",
       "comments": [

--- a/exercises/protein-translation/canonical-data.json
+++ b/exercises/protein-translation/canonical-data.json
@@ -244,7 +244,7 @@
     },
     {
       "uuid": "f6f92714-769f-4187-9524-e353e8a41a80",
-      "description": "Sequence of two non-STOP codons is not matched to a STOP codon",
+      "description": "Sequence of two non-STOP codons does not translate to a STOP codon",
       "property": "proteins",
       "input": {
         "strand": "AUGAUG"


### PR DESCRIPTION
When `AUG` and `AUG` (also `UUA` and `AUG`) are combined, they contain a substring that potentially matches a STOP codon.  A naive implementation may falsely match the non-STOP sequence as a STOP codon.

This simple test covers a gap in the current suite.

```
  AUGAUG
   ^^^ - not a STOP codon

  UUAAUG
   ^^^ - not a STOP codon
```
