### PR TITLE
Forth: additional tests for "combined arithmetic" category

### DIFF
--- a/exercises/forth/canonical-data.json
+++ b/exercises/forth/canonical-data.json
@@ -215,7 +215,7 @@
           "expected": [2]
         },
         {
-          "uuid": "",
+          "uuid": "f749b540-53aa-458e-87ec-a70797eddbcb",
           "description": "multiplication and addition",
           "property": "evaluate",
           "input": {
@@ -224,7 +224,7 @@
           "expected": [13]
         },
         {
-          "uuid": "",
+          "uuid": "c8e5a4c2-f9bf-4805-9a35-3c3314e4989a",
           "description": "addition and multiplication",
           "property": "evaluate",
           "input": {

--- a/exercises/forth/canonical-data.json
+++ b/exercises/forth/canonical-data.json
@@ -62,6 +62,15 @@
           "expected": {
             "error": "only one value on the stack"
           }
+        },
+        {
+          "uuid": "1e07a098-c5fa-4c66-97b2-3c81205dbc2f",
+          "description": "more than two values on the stack",
+          "property": "evaluate",
+          "input": {
+            "instructions": ["1 2 3 +"]
+          },
+          "expected": [1, 5]
         }
       ]
     },
@@ -98,6 +107,15 @@
           "expected": {
             "error": "only one value on the stack"
           }
+        },
+        {
+          "uuid": "2c8cc5ed-da97-4cb1-8b98-fa7b526644f4",
+          "description": "more than two values on the stack",
+          "property": "evaluate",
+          "input": {
+            "instructions": ["1 12 3 -"]
+          },
+          "expected": [1, 9]
         }
       ]
     },
@@ -134,6 +152,15 @@
           "expected": {
             "error": "only one value on the stack"
           }
+        },
+        {
+          "uuid": "5cd085b5-deb1-43cc-9c17-6b1c38bc9970",
+          "description": "more than two values on the stack",
+          "property": "evaluate",
+          "input": {
+            "instructions": ["1 2 3 *"]
+          },
+          "expected": [1, 6]
         }
       ]
     },
@@ -190,6 +217,15 @@
           "expected": {
             "error": "only one value on the stack"
           }
+        },
+        {
+          "uuid": "f224f3e0-b6b6-4864-81de-9769ecefa03f",
+          "description": "more than two values on the stack",
+          "property": "evaluate",
+          "input": {
+            "instructions": ["1 12 3 /"]
+          },
+          "expected": [1, 4]
         }
       ]
     },

--- a/exercises/forth/canonical-data.json
+++ b/exercises/forth/canonical-data.json
@@ -213,6 +213,24 @@
             "instructions": ["2 4 * 3 /"]
           },
           "expected": [2]
+        },
+        {
+          "uuid": "",
+          "description": "multiplication and addition",
+          "property": "evaluate",
+          "input": {
+            "instructions": ["1 3 4 * +"]
+          },
+          "expected": [13]
+        },
+        {
+          "uuid": "",
+          "description": "addition and multiplication",
+          "property": "evaluate",
+          "input": {
+            "instructions": ["1 3 4 + *"]
+          },
+          "expected": [7]
         }
       ]
     },


### PR DESCRIPTION
This will ensure that students are popping numbers off the correct end of the stack (for languages without a builtin Stack type).

From: http://forum.exercism.org/t/new-tests-for-forth-exercise-canonical-data/13045