### PR TITLE
Rename "proteins"->"amino acids" in protein-translation description table

### DIFF
--- a/exercises/protein-translation/canonical-data.json
+++ b/exercises/protein-translation/canonical-data.json
@@ -8,7 +8,7 @@
         "Tracks may choose to expect an error when an empty RNA sequence  ",
         "is given, or use this test to expect an empty result.            "
       ],
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": ""
       },
@@ -17,7 +17,7 @@
     {
       "uuid": "96d3d44f-34a2-4db4-84cd-fff523e069be",
       "description": "Methionine RNA sequence",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "AUG"
       },
@@ -26,7 +26,7 @@
     {
       "uuid": "1b4c56d8-d69f-44eb-be0e-7b17546143d9",
       "description": "Phenylalanine RNA sequence 1",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UUU"
       },
@@ -35,7 +35,7 @@
     {
       "uuid": "81b53646-bd57-4732-b2cb-6b1880e36d11",
       "description": "Phenylalanine RNA sequence 2",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UUC"
       },
@@ -44,7 +44,7 @@
     {
       "uuid": "42f69d4f-19d2-4d2c-a8b0-f0ae9ee1b6b4",
       "description": "Leucine RNA sequence 1",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UUA"
       },
@@ -53,7 +53,7 @@
     {
       "uuid": "ac5edadd-08ed-40a3-b2b9-d82bb50424c4",
       "description": "Leucine RNA sequence 2",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UUG"
       },
@@ -62,7 +62,7 @@
     {
       "uuid": "8bc36e22-f984-44c3-9f6b-ee5d4e73f120",
       "description": "Serine RNA sequence 1",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UCU"
       },
@@ -71,7 +71,7 @@
     {
       "uuid": "5c3fa5da-4268-44e5-9f4b-f016ccf90131",
       "description": "Serine RNA sequence 2",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UCC"
       },
@@ -80,7 +80,7 @@
     {
       "uuid": "00579891-b594-42b4-96dc-7ff8bf519606",
       "description": "Serine RNA sequence 3",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UCA"
       },
@@ -89,7 +89,7 @@
     {
       "uuid": "08c61c3b-fa34-4950-8c4a-133945570ef6",
       "description": "Serine RNA sequence 4",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UCG"
       },
@@ -98,7 +98,7 @@
     {
       "uuid": "54e1e7d8-63c0-456d-91d2-062c72f8eef5",
       "description": "Tyrosine RNA sequence 1",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UAU"
       },
@@ -107,7 +107,7 @@
     {
       "uuid": "47bcfba2-9d72-46ad-bbce-22f7666b7eb1",
       "description": "Tyrosine RNA sequence 2",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UAC"
       },
@@ -116,7 +116,7 @@
     {
       "uuid": "3a691829-fe72-43a7-8c8e-1bd083163f72",
       "description": "Cysteine RNA sequence 1",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UGU"
       },
@@ -125,7 +125,7 @@
     {
       "uuid": "1b6f8a26-ca2f-43b8-8262-3ee446021767",
       "description": "Cysteine RNA sequence 2",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UGC"
       },
@@ -134,7 +134,7 @@
     {
       "uuid": "1e91c1eb-02c0-48a0-9e35-168ad0cb5f39",
       "description": "Tryptophan RNA sequence",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UGG"
       },
@@ -143,7 +143,7 @@
     {
       "uuid": "e547af0b-aeab-49c7-9f13-801773a73557",
       "description": "STOP codon RNA sequence 1",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UAA"
       },
@@ -152,7 +152,7 @@
     {
       "uuid": "67640947-ff02-4f23-a2ef-816f8a2ba72e",
       "description": "STOP codon RNA sequence 2",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UAG"
       },
@@ -161,7 +161,7 @@
     {
       "uuid": "9c2ad527-ebc9-4ace-808b-2b6447cb54cb",
       "description": "STOP codon RNA sequence 3",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UGA"
       },
@@ -170,7 +170,7 @@
     {
       "uuid": "f4d9d8ee-00a8-47bf-a1e3-1641d4428e54",
       "description": "Sequence of two protein codons translates into proteins",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UUUUUU"
       },
@@ -182,7 +182,7 @@
       "comments": [
         "The codons are different, the proteins they translate into are not."
       ],
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UUAUUG"
       },
@@ -191,7 +191,7 @@
     {
       "uuid": "d0f295df-fb70-425c-946c-ec2ec185388e",
       "description": "Translate RNA strand into correct protein list",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "AUGUUUUGG"
       },
@@ -200,7 +200,7 @@
     {
       "uuid": "e30e8505-97ec-4e5f-a73e-5726a1faa1f4",
       "description": "Translation stops if STOP codon at beginning of sequence",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UAGUGG"
       },
@@ -209,7 +209,7 @@
     {
       "uuid": "5358a20b-6f4c-4893-bce4-f929001710f3",
       "description": "Translation stops if STOP codon at end of two-codon sequence",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UGGUAG"
       },
@@ -218,7 +218,7 @@
     {
       "uuid": "ba16703a-1a55-482f-bb07-b21eef5093a3",
       "description": "Translation stops if STOP codon at end of three-codon sequence",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "AUGUUUUAA"
       },
@@ -227,7 +227,7 @@
     {
       "uuid": "4089bb5a-d5b4-4e71-b79e-b8d1f14a2911",
       "description": "Translation stops if STOP codon in middle of three-codon sequence",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UGGUAGUGG"
       },
@@ -236,7 +236,7 @@
     {
       "uuid": "2c2a2a60-401f-4a80-b977-e0715b23b93d",
       "description": "Translation stops if STOP codon in middle of six-codon sequence",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UGGUGUUAUUAAUGGUUU"
       },
@@ -245,7 +245,7 @@
     {
       "uuid": "f6f92714-769f-4187-9524-e353e8a41a80",
       "description": "Sequence of two non-STOP codons does not translate to a STOP codon",
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "AUGAUG"
       },
@@ -260,7 +260,7 @@
         "order to remove the requirement for input validation.            "
       ],
       "scenarios": ["input-validation"],
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "AAA"
       },
@@ -279,7 +279,7 @@
         "order to remove the requirement for input validation.            "
       ],
       "scenarios": ["input-validation"],
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "XYZ"
       },
@@ -296,7 +296,7 @@
         "remove the requirement for input validation.                     "
       ],
       "scenarios": ["input-validation"],
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "AUGU"
       },
@@ -314,7 +314,7 @@
         "it into proteins.                                                "
       ],
       "scenarios": ["input-validation", "runtime-validation"],
-      "property": "polypeptide",
+      "property": "protein",
       "input": {
         "strand": "UUCUUCUAAUGGU"
       },

--- a/exercises/protein-translation/canonical-data.json
+++ b/exercises/protein-translation/canonical-data.json
@@ -3,7 +3,7 @@
   "cases": [
     {
       "uuid": "2c44f7bf-ba20-43f7-a3bf-f2219c0c3f98",
-      "description": "Empty RNA sequence results in no amino acids",
+      "description": "Empty RNA sequence results in no proteins",
       "comments": [
         "Tracks may choose to expect an error when an empty RNA sequence  ",
         "is given, or use this test to expect an empty result.            "

--- a/exercises/protein-translation/canonical-data.json
+++ b/exercises/protein-translation/canonical-data.json
@@ -3,12 +3,12 @@
   "cases": [
     {
       "uuid": "2c44f7bf-ba20-43f7-a3bf-f2219c0c3f98",
-      "description": "Empty RNA sequence results in no proteins",
+      "description": "Empty RNA sequence results in no amino acids",
       "comments": [
         "Tracks may choose to expect an error when an empty RNA sequence  ",
         "is given, or use this test to expect an empty result.            "
       ],
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": ""
       },
@@ -17,7 +17,7 @@
     {
       "uuid": "96d3d44f-34a2-4db4-84cd-fff523e069be",
       "description": "Methionine RNA sequence",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "AUG"
       },
@@ -26,7 +26,7 @@
     {
       "uuid": "1b4c56d8-d69f-44eb-be0e-7b17546143d9",
       "description": "Phenylalanine RNA sequence 1",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UUU"
       },
@@ -35,7 +35,7 @@
     {
       "uuid": "81b53646-bd57-4732-b2cb-6b1880e36d11",
       "description": "Phenylalanine RNA sequence 2",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UUC"
       },
@@ -44,7 +44,7 @@
     {
       "uuid": "42f69d4f-19d2-4d2c-a8b0-f0ae9ee1b6b4",
       "description": "Leucine RNA sequence 1",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UUA"
       },
@@ -53,7 +53,7 @@
     {
       "uuid": "ac5edadd-08ed-40a3-b2b9-d82bb50424c4",
       "description": "Leucine RNA sequence 2",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UUG"
       },
@@ -62,7 +62,7 @@
     {
       "uuid": "8bc36e22-f984-44c3-9f6b-ee5d4e73f120",
       "description": "Serine RNA sequence 1",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UCU"
       },
@@ -71,7 +71,7 @@
     {
       "uuid": "5c3fa5da-4268-44e5-9f4b-f016ccf90131",
       "description": "Serine RNA sequence 2",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UCC"
       },
@@ -80,7 +80,7 @@
     {
       "uuid": "00579891-b594-42b4-96dc-7ff8bf519606",
       "description": "Serine RNA sequence 3",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UCA"
       },
@@ -89,7 +89,7 @@
     {
       "uuid": "08c61c3b-fa34-4950-8c4a-133945570ef6",
       "description": "Serine RNA sequence 4",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UCG"
       },
@@ -98,7 +98,7 @@
     {
       "uuid": "54e1e7d8-63c0-456d-91d2-062c72f8eef5",
       "description": "Tyrosine RNA sequence 1",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UAU"
       },
@@ -107,7 +107,7 @@
     {
       "uuid": "47bcfba2-9d72-46ad-bbce-22f7666b7eb1",
       "description": "Tyrosine RNA sequence 2",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UAC"
       },
@@ -116,7 +116,7 @@
     {
       "uuid": "3a691829-fe72-43a7-8c8e-1bd083163f72",
       "description": "Cysteine RNA sequence 1",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UGU"
       },
@@ -125,7 +125,7 @@
     {
       "uuid": "1b6f8a26-ca2f-43b8-8262-3ee446021767",
       "description": "Cysteine RNA sequence 2",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UGC"
       },
@@ -134,7 +134,7 @@
     {
       "uuid": "1e91c1eb-02c0-48a0-9e35-168ad0cb5f39",
       "description": "Tryptophan RNA sequence",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UGG"
       },
@@ -143,7 +143,7 @@
     {
       "uuid": "e547af0b-aeab-49c7-9f13-801773a73557",
       "description": "STOP codon RNA sequence 1",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UAA"
       },
@@ -152,7 +152,7 @@
     {
       "uuid": "67640947-ff02-4f23-a2ef-816f8a2ba72e",
       "description": "STOP codon RNA sequence 2",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UAG"
       },
@@ -161,7 +161,7 @@
     {
       "uuid": "9c2ad527-ebc9-4ace-808b-2b6447cb54cb",
       "description": "STOP codon RNA sequence 3",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UGA"
       },
@@ -170,7 +170,7 @@
     {
       "uuid": "f4d9d8ee-00a8-47bf-a1e3-1641d4428e54",
       "description": "Sequence of two protein codons translates into proteins",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UUUUUU"
       },
@@ -182,7 +182,7 @@
       "comments": [
         "The codons are different, the proteins they translate into are not."
       ],
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UUAUUG"
       },
@@ -191,7 +191,7 @@
     {
       "uuid": "d0f295df-fb70-425c-946c-ec2ec185388e",
       "description": "Translate RNA strand into correct protein list",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "AUGUUUUGG"
       },
@@ -200,7 +200,7 @@
     {
       "uuid": "e30e8505-97ec-4e5f-a73e-5726a1faa1f4",
       "description": "Translation stops if STOP codon at beginning of sequence",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UAGUGG"
       },
@@ -209,7 +209,7 @@
     {
       "uuid": "5358a20b-6f4c-4893-bce4-f929001710f3",
       "description": "Translation stops if STOP codon at end of two-codon sequence",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UGGUAG"
       },
@@ -218,7 +218,7 @@
     {
       "uuid": "ba16703a-1a55-482f-bb07-b21eef5093a3",
       "description": "Translation stops if STOP codon at end of three-codon sequence",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "AUGUUUUAA"
       },
@@ -227,7 +227,7 @@
     {
       "uuid": "4089bb5a-d5b4-4e71-b79e-b8d1f14a2911",
       "description": "Translation stops if STOP codon in middle of three-codon sequence",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UGGUAGUGG"
       },
@@ -236,7 +236,7 @@
     {
       "uuid": "2c2a2a60-401f-4a80-b977-e0715b23b93d",
       "description": "Translation stops if STOP codon in middle of six-codon sequence",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UGGUGUUAUUAAUGGUUU"
       },
@@ -245,7 +245,7 @@
     {
       "uuid": "f6f92714-769f-4187-9524-e353e8a41a80",
       "description": "Sequence of two non-STOP codons does not translate to a STOP codon",
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "AUGAUG"
       },
@@ -260,7 +260,7 @@
         "order to remove the requirement for input validation.            "
       ],
       "scenarios": ["input-validation"],
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "AAA"
       },
@@ -279,7 +279,7 @@
         "order to remove the requirement for input validation.            "
       ],
       "scenarios": ["input-validation"],
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "XYZ"
       },
@@ -296,7 +296,7 @@
         "remove the requirement for input validation.                     "
       ],
       "scenarios": ["input-validation"],
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "AUGU"
       },
@@ -314,7 +314,7 @@
         "it into proteins.                                                "
       ],
       "scenarios": ["input-validation", "runtime-validation"],
-      "property": "proteins",
+      "property": "polypeptide",
       "input": {
         "strand": "UUCUUCUAAUGGU"
       },

--- a/exercises/protein-translation/canonical-data.json
+++ b/exercises/protein-translation/canonical-data.json
@@ -8,7 +8,7 @@
         "Tracks may choose to expect an error when an empty RNA sequence  ",
         "is given, or use this test to expect an empty result.            "
       ],
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": ""
       },
@@ -17,7 +17,7 @@
     {
       "uuid": "96d3d44f-34a2-4db4-84cd-fff523e069be",
       "description": "Methionine RNA sequence",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "AUG"
       },
@@ -26,7 +26,7 @@
     {
       "uuid": "1b4c56d8-d69f-44eb-be0e-7b17546143d9",
       "description": "Phenylalanine RNA sequence 1",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UUU"
       },
@@ -35,7 +35,7 @@
     {
       "uuid": "81b53646-bd57-4732-b2cb-6b1880e36d11",
       "description": "Phenylalanine RNA sequence 2",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UUC"
       },
@@ -44,7 +44,7 @@
     {
       "uuid": "42f69d4f-19d2-4d2c-a8b0-f0ae9ee1b6b4",
       "description": "Leucine RNA sequence 1",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UUA"
       },
@@ -53,7 +53,7 @@
     {
       "uuid": "ac5edadd-08ed-40a3-b2b9-d82bb50424c4",
       "description": "Leucine RNA sequence 2",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UUG"
       },
@@ -62,7 +62,7 @@
     {
       "uuid": "8bc36e22-f984-44c3-9f6b-ee5d4e73f120",
       "description": "Serine RNA sequence 1",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UCU"
       },
@@ -71,7 +71,7 @@
     {
       "uuid": "5c3fa5da-4268-44e5-9f4b-f016ccf90131",
       "description": "Serine RNA sequence 2",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UCC"
       },
@@ -80,7 +80,7 @@
     {
       "uuid": "00579891-b594-42b4-96dc-7ff8bf519606",
       "description": "Serine RNA sequence 3",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UCA"
       },
@@ -89,7 +89,7 @@
     {
       "uuid": "08c61c3b-fa34-4950-8c4a-133945570ef6",
       "description": "Serine RNA sequence 4",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UCG"
       },
@@ -98,7 +98,7 @@
     {
       "uuid": "54e1e7d8-63c0-456d-91d2-062c72f8eef5",
       "description": "Tyrosine RNA sequence 1",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UAU"
       },
@@ -107,7 +107,7 @@
     {
       "uuid": "47bcfba2-9d72-46ad-bbce-22f7666b7eb1",
       "description": "Tyrosine RNA sequence 2",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UAC"
       },
@@ -116,7 +116,7 @@
     {
       "uuid": "3a691829-fe72-43a7-8c8e-1bd083163f72",
       "description": "Cysteine RNA sequence 1",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UGU"
       },
@@ -125,7 +125,7 @@
     {
       "uuid": "1b6f8a26-ca2f-43b8-8262-3ee446021767",
       "description": "Cysteine RNA sequence 2",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UGC"
       },
@@ -134,7 +134,7 @@
     {
       "uuid": "1e91c1eb-02c0-48a0-9e35-168ad0cb5f39",
       "description": "Tryptophan RNA sequence",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UGG"
       },
@@ -143,7 +143,7 @@
     {
       "uuid": "e547af0b-aeab-49c7-9f13-801773a73557",
       "description": "STOP codon RNA sequence 1",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UAA"
       },
@@ -152,7 +152,7 @@
     {
       "uuid": "67640947-ff02-4f23-a2ef-816f8a2ba72e",
       "description": "STOP codon RNA sequence 2",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UAG"
       },
@@ -161,7 +161,7 @@
     {
       "uuid": "9c2ad527-ebc9-4ace-808b-2b6447cb54cb",
       "description": "STOP codon RNA sequence 3",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UGA"
       },
@@ -170,7 +170,7 @@
     {
       "uuid": "f4d9d8ee-00a8-47bf-a1e3-1641d4428e54",
       "description": "Sequence of two protein codons translates into proteins",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UUUUUU"
       },
@@ -182,7 +182,7 @@
       "comments": [
         "The codons are different, the proteins they translate into are not."
       ],
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UUAUUG"
       },
@@ -191,7 +191,7 @@
     {
       "uuid": "d0f295df-fb70-425c-946c-ec2ec185388e",
       "description": "Translate RNA strand into correct protein list",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "AUGUUUUGG"
       },
@@ -200,7 +200,7 @@
     {
       "uuid": "e30e8505-97ec-4e5f-a73e-5726a1faa1f4",
       "description": "Translation stops if STOP codon at beginning of sequence",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UAGUGG"
       },
@@ -209,7 +209,7 @@
     {
       "uuid": "5358a20b-6f4c-4893-bce4-f929001710f3",
       "description": "Translation stops if STOP codon at end of two-codon sequence",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UGGUAG"
       },
@@ -218,7 +218,7 @@
     {
       "uuid": "ba16703a-1a55-482f-bb07-b21eef5093a3",
       "description": "Translation stops if STOP codon at end of three-codon sequence",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "AUGUUUUAA"
       },
@@ -227,7 +227,7 @@
     {
       "uuid": "4089bb5a-d5b4-4e71-b79e-b8d1f14a2911",
       "description": "Translation stops if STOP codon in middle of three-codon sequence",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UGGUAGUGG"
       },
@@ -236,7 +236,7 @@
     {
       "uuid": "2c2a2a60-401f-4a80-b977-e0715b23b93d",
       "description": "Translation stops if STOP codon in middle of six-codon sequence",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UGGUGUUAUUAAUGGUUU"
       },
@@ -245,7 +245,7 @@
     {
       "uuid": "f6f92714-769f-4187-9524-e353e8a41a80",
       "description": "Sequence of two non-STOP codons does not translate to a STOP codon",
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "AUGAUG"
       },
@@ -260,7 +260,7 @@
         "order to remove the requirement for input validation.            "
       ],
       "scenarios": ["input-validation"],
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "AAA"
       },
@@ -279,7 +279,7 @@
         "order to remove the requirement for input validation.            "
       ],
       "scenarios": ["input-validation"],
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "XYZ"
       },
@@ -296,7 +296,7 @@
         "remove the requirement for input validation.                     "
       ],
       "scenarios": ["input-validation"],
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "AUGU"
       },
@@ -314,7 +314,7 @@
         "it into proteins.                                                "
       ],
       "scenarios": ["input-validation", "runtime-validation"],
-      "property": "protein",
+      "property": "proteins",
       "input": {
         "strand": "UUCUUCUAAUGGU"
       },

--- a/exercises/protein-translation/description.md
+++ b/exercises/protein-translation/description.md
@@ -9,13 +9,15 @@ RNA: `"AUGUUUUCU"` => translates to
 Codons: `"AUG", "UUU", "UCU"`
 => which become a polypeptide with the following sequence =>
 
-Protein: `"Methionine", "Phenylalanine", "Serine"`
+Polypeptide: `"Methionine", "Phenylalanine", "Serine"`
+
+The polypeptide later folds into an active protein and performs its functions in the cell.
 
 There are 64 codons which in turn correspond to 20 amino acids; however, all of the codon sequences and resulting amino acids are not important in this exercise.
 If it works for one codon, the program should work for all of them.
 However, feel free to expand the list in the test suite to include them all.
 
-There are also three terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the protein is terminated.
+There are also three terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the polypeptide is terminated.
 
 All subsequent codons after are ignored, like this:
 
@@ -23,13 +25,13 @@ RNA: `"AUGUUUUCUUAAAUG"` =>
 
 Codons: `"AUG", "UUU", "UCU", "UAA", "AUG"` =>
 
-Protein: `"Methionine", "Phenylalanine", "Serine"`
+Polypeptide: `"Methionine", "Phenylalanine", "Serine"`
 
 Note the stop codon `"UAA"` terminates the translation and the final methionine is not translated into the protein sequence.
 
 Below are the codons and resulting Amino Acids needed for the exercise.
 
-| Codon              | Protein       |
+| Codon              | Amino Acid    |
 | :----------------- | :------------ |
 | AUG                | Methionine    |
 | UUU, UUC           | Phenylalanine |

--- a/exercises/protein-translation/description.md
+++ b/exercises/protein-translation/description.md
@@ -2,7 +2,7 @@
 
 Translate RNA sequences into proteins.
 
-RNA can be broken into three nucleotide sequences called codons, and then translated to a protein like so:
+RNA can be broken into three-nucleotide sequences called codons, and then translated to a protein like so:
 
 RNA: `"AUGUUUUCU"` => translates to
 

--- a/exercises/protein-translation/description.md
+++ b/exercises/protein-translation/description.md
@@ -27,7 +27,7 @@ Protein: `"Methionine", "Phenylalanine", "Serine"`
 
 Note the stop codon `"UAA"` terminates the translation and the final methionine is not translated into the protein sequence.
 
-Below are the codons and resulting Amino Acids needed for the exercise.
+Below are the codons and resulting amino acids needed for the exercise.
 
 | Codon              | Amino Acid    |
 | :----------------- | :------------ |

--- a/exercises/protein-translation/description.md
+++ b/exercises/protein-translation/description.md
@@ -2,12 +2,12 @@
 
 Translate RNA sequences into proteins.
 
-RNA can be broken into three nucleotide sequences called codons, and then translated to a polypeptide like so:
+RNA can be broken into three nucleotide sequences called codons, and then translated to a protein like so:
 
 RNA: `"AUGUUUUCU"` => translates to
 
 Codons: `"AUG", "UUU", "UCU"`
-=> which become a polypeptide with the following sequence =>
+=> which become a protein with the following sequence =>
 
 Protein: `"Methionine", "Phenylalanine", "Serine"`
 

--- a/exercises/protein-translation/description.md
+++ b/exercises/protein-translation/description.md
@@ -9,15 +9,13 @@ RNA: `"AUGUUUUCU"` => translates to
 Codons: `"AUG", "UUU", "UCU"`
 => which become a polypeptide with the following sequence =>
 
-Polypeptide: `"Methionine", "Phenylalanine", "Serine"`
-
-The polypeptide later folds into an active protein and performs its functions in the cell.
+Protein: `"Methionine", "Phenylalanine", "Serine"`
 
 There are 64 codons which in turn correspond to 20 amino acids; however, all of the codon sequences and resulting amino acids are not important in this exercise.
 If it works for one codon, the program should work for all of them.
 However, feel free to expand the list in the test suite to include them all.
 
-There are also three terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the polypeptide is terminated.
+There are also three terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the protein is terminated.
 
 All subsequent codons after are ignored, like this:
 
@@ -25,7 +23,7 @@ RNA: `"AUGUUUUCUUAAAUG"` =>
 
 Codons: `"AUG", "UUU", "UCU", "UAA", "AUG"` =>
 
-Polypeptide: `"Methionine", "Phenylalanine", "Serine"`
+Protein: `"Methionine", "Phenylalanine", "Serine"`
 
 Note the stop codon `"UAA"` terminates the translation and the final methionine is not translated into the protein sequence.
 


### PR DESCRIPTION
Closes https://github.com/exercism/problem-specifications/issues/1639

Related [forum discussion](https://forum.exercism.org/t/protein-translation-wording-should-be-changed-in-the-exercise-description/13157) 