### PR TITLE
hamming: Change 'difference' to 'distance' in metadata

### DIFF
--- a/exercises/hamming/metadata.toml
+++ b/exercises/hamming/metadata.toml
@@ -1,4 +1,4 @@
 title = "Hamming"
-blurb = "Calculate the Hamming difference between two DNA strands."
+blurb = "Calculate the Hamming distance between two DNA strands."
 source = "The Calculating Point Mutations problem at Rosalind"
 source_url = "https://rosalind.info/problems/hamm/"


### PR DESCRIPTION
The metadata mentions 'Hamming difference', which doesn’t formally exist. It has been changed to 'Hamming distance' to ensure consistency across the exercise.