### PR TITLE
bob: Let multiple line question example be one sentence

### DIFF
--- a/exercises/bob/canonical-data.json
+++ b/exercises/bob/canonical-data.json
@@ -225,6 +225,17 @@
         "heyBob": "This is a statement ending with whitespace      "
       },
       "expected": "Whatever."
+    },
+    {
+      "uuid": "2c7278ac-f955-4eb4-bf8f-e33eb4116a15",
+      "reimplements": "66953780-165b-4e7e-8ce3-4bcb80b6385a",
+      "description": "multiple line question",
+      "comments": ["Use one sentence, spanning multiple lines."],
+      "property": "response",
+      "input": {
+        "heyBob": "\nDoes this cryogenic chamber make\n me look fat?"
+      },
+      "expected": "Sure."
     }
   ]
 }


### PR DESCRIPTION
Using multiple sentences is a bit ambiguous in this exercise, in general. This is especially so, if we follow a sentence with a
question mark by a sentence with a dot.

To avoid that ambiguity gettting in the way of showcasing the intended way to handle multi-line queries, let this example use just one sentence, but let it spread over multiple lines.

Disucssion: https://forum.exercism.org/t/bob-exercise-text-should-mention-linebreak-handling/13582/17

@SleeplessByte 