### PR TITLE
New "qu" test for Pig Latin

### DIFF
--- a/exercises/pig-latin/canonical-data.json
+++ b/exercises/pig-latin/canonical-data.json
@@ -98,6 +98,15 @@
             "phrase": "qat"
           },
           "expected": "atqay"
+        },
+        {
+          "uuid": "e59dbbe8-ccee-4619-a8e9-ce017489bfc0",
+          "description": "word beginning with consonant and vowel containing qu",
+          "property": "translate",
+          "input": {
+            "phrase": "liquid"
+          },
+          "expected": "iquidlay"
         }
       ]
     },


### PR DESCRIPTION
I’m seeing some solutions that do this:

* if word starts with a vowel or “xr” or “yt”, then return word + “ay” 
* else if word contains “qu” then ...

Those solutions will fail for a word like “liquid”

https://forum.exercism.org/t/new-qu-test-for-pig-latin/14052