### PR TITLE
Add test to dominoes for uniform order swapping

### DIFF
--- a/exercises/dominoes/canonical-data.json
+++ b/exercises/dominoes/canonical-data.json
@@ -170,6 +170,21 @@
         "dominoes": [[1, 2], [2, 3], [3, 1], [4, 5], [5, 6], [6, 4]]
       },
       "expected": false
+    },
+    {
+      "uuid": "25c9ae19-cfd3-42bd-a7df-c02e512ac82a",
+      "description": "dominoes can only be used either swapped or unswapped",
+      "comments": [
+        "Solutions might just check if any of the numbers of two dominoes match",
+        "and still handle the special case of only one domino being present.",
+        "This is caught by this test since no matter if a domino is swapped or not,",
+        "they are not chainable."
+      ],
+      "property": "canChain",
+      "input": {
+        "dominoes": [[1, 2], [3, 2]]
+      },
+      "expected": false
     }
   ]
 }


### PR DESCRIPTION
Also see [here](https://forum.exercism.org/t/dominoes-exercise-lacks-test-to-check-proper-reversing-of-tiles/13227) and [here](https://github.com/exercism/crystal/pull/697).

I came across a student's solution that would essentially only check that any numbers for two adjacent dominoes match. In essence that means that a domino can be used swapped and unswapped at the same time. The solution still had a special handling for the singleton case, which is why it was not caught by the singleton domino test already present.
This test invalidates such a solution.

Feedback on this PR is much appreciated :)