### PR TITLE
Add "mystery" as test cast to pig-latin

### DIFF
--- a/exercises/pig-latin/canonical-data.json
+++ b/exercises/pig-latin/canonical-data.json
@@ -150,6 +150,15 @@
           "expected": "erapythay"
         },
         {
+          "uuid": ??,
+          "description": "word with y in the middle",
+          "property": "translate",
+          "input": {
+            "phrase": "mystery"
+          },
+          "expected": "ysterymay"
+        },
+        {
           "uuid": "e0b3ae65-f508-4de3-8999-19c2f8e243e1",
           "description": "word beginning with thr",
           "property": "translate",


### PR DESCRIPTION
Slightly niche, but I did see a solution that succeeded in all the current test cases but failed for "mystery". Due to the way the logic that looks for the 'y' can be (mis)handled.

Whilst looking through the python pig-latin exercise, I noticed [another test case that has been added to this file 2 weeks ago](https://github.com/exercism/problem-specifications/commit/d11557d07392c625d4145ff427f6d43f2dca42ff) which still isn't tested for on the Python exercise as of today (21-12-2024).

Apologies if this isn't the most helpful way to point out these issues.