### PR TITLE
Improve description of "simple-cipher" + give perspective (for others as well)

### DIFF
--- a/exercises/affine-cipher/description.md
+++ b/exercises/affine-cipher/description.md
@@ -72,3 +72,17 @@ Finding MMI for `a = 15`:
 
 [mmi]: https://en.wikipedia.org/wiki/Modular_multiplicative_inverse
 [coprime-integers]: https://en.wikipedia.org/wiki/Coprime_integers
+
+## Perspective
+
+While stronger than the atbash cipher, the affine cipher is still weak because the number of possible keys is way too small: 12 possible values for `a` (needs to be coprime to 26), 26 for `b`, so only 312 different keys. Given a ciphertext, you can write a program that prints all 312 possible plaintexts, one per line, and look at the list to quickly identify the line that looks like English. (This could even be automated using a dictionary.)
+
+The affine cipher is an example of a [substitution cipher][sc]; other examples can be found in exercises "simple-cipher", "atbash-cipher", and "rotational-cipher".
+
+You can find examples of ciphers based on an different principle, known as [transposition ciphers][tc], in exercises "crypto-square" and "rail-fence-cipher".
+
+All of these ciphers are considered toy ciphers by current standards. However, substitution and transposition (also called permutation) are two building blocks of modern ciphers like [AES][aes].
+
+[sc]: https://en.wikipedia.org/wiki/Substitution_cipher
+[tc]: https://en.wikipedia.org/wiki/Transposition_cipher
+[aes]: https://en.wikipedia.org/wiki/Advanced_Encryption_Standard

--- a/exercises/atbash-cipher/description.md
+++ b/exercises/atbash-cipher/description.md
@@ -25,3 +25,17 @@ All text will be encoded as lowercase letters.
 - Encoding `x123 yes` gives `c123b vh`
 - Decoding `gvhg` gives `test`
 - Decoding `gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt` gives `thequickbrownfoxjumpsoverthelazydog`
+
+## Perspective
+
+The atbash cipher is weak because there is no secret key: as soon as you know (or guess) that the text has been encrypted with the atbash cipher, you can immediately decrypt it.
+
+The atbash cipher is an example of a [substitution cipher][sc]; other examples can be found in exercises "rotational-cipher", "simple-cipher" and "affine-cipher".
+
+You can find examples of ciphers based on an different principle, known as [transposition ciphers][tc], in exercises "crypto-square" and "rail-fence-cipher".
+
+All of these ciphers are considered toy ciphers by current standards. However, substitution and transposition (also called permutation) are two building blocks of modern ciphers like [AES][aes].
+
+[sc]: https://en.wikipedia.org/wiki/Substitution_cipher
+[tc]: https://en.wikipedia.org/wiki/Transposition_cipher
+[aes]: https://en.wikipedia.org/wiki/Advanced_Encryption_Standard

--- a/exercises/crypto-square/description.md
+++ b/exercises/crypto-square/description.md
@@ -69,3 +69,15 @@ Notice that were we to stack these, we could visually decode the ciphertext back
 "aohghn "
 "sseoau "
 ```
+
+## Perspective
+
+This cipher is weak because there is no secret key: as soon as you know (or guess) that the text has been encrypted with this cipher, you can immediately decrypt it.
+
+It is an example of a [transposition cipher][tc], like the exercise "rail-fence-cipher". Other exercises, like "rotational-cipher", "simple-cipher", "atbash-cipher" and "affine-cipher", are examples of [substitution ciphers][sc].
+
+Substitution and transposition (also called permutation) are two building blocks of modern ciphers such as [AES][aes].
+
+[tc]: https://en.wikipedia.org/wiki/Transposition_cipher
+[sc]: https://en.wikipedia.org/wiki/Substitution_cipher
+[aes]: https://en.wikipedia.org/wiki/Advanced_Encryption_Standard

--- a/exercises/rail-fence-cipher/description.md
+++ b/exercises/rail-fence-cipher/description.md
@@ -55,3 +55,15 @@ W . . . E . . . C . . . R . . . L . . . T . . . E
 ```
 
 If you now read along the zig-zag shape you can read the original message.
+
+## Perspective
+
+This cipher is weak because set the of possible values for the secret key (the number of rails) is very small (no more than the length of the message). Given a message encrypted with the rail fence cipher, you can write a program that tries all possible numbers of rails and prints out all possible plaintexts, one per line. It is then easy to look at the output and identify the line that looks like English. (This could even be automated, for example using a dictionary.)
+
+The rail fence cipher is an example of a [transposition cipher][tc], like the exercise "crypto-square". Other exercises, like "rotational-cipher", "simple-cipher", "atbash-cipher" and "affine-cipher", are examples of [substitution ciphers][sc].
+
+All of these ciphers are considered toy ciphers by current standards. However, substitution and transposition (also called permutation) are two building blocks of modern ciphers like [AES][aes].
+
+[tc]: https://en.wikipedia.org/wiki/Transposition_cipher
+[sc]: https://en.wikipedia.org/wiki/Substitution_cipher
+[aes]: https://en.wikipedia.org/wiki/Advanced_Encryption_Standard

--- a/exercises/rotational-cipher/description.md
+++ b/exercises/rotational-cipher/description.md
@@ -27,3 +27,17 @@ Ciphertext is written out in the same formatting as the input including spaces a
 - ROT26 `Cool` gives `Cool`
 - ROT13 `The quick brown fox jumps over the lazy dog.` gives `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.`
 - ROT13 `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.` gives `The quick brown fox jumps over the lazy dog.`
+
+## Perspective
+
+The rotational cipher is very weak because the number of possible keys is way too small. Given a message encrypted with this cipher, you can write a program that prints all 26 possible plaintexts and look at the list to quickly identify the one that looks like English. (This could even be automated, for example using a dictionary.)
+
+You can find an improvement over this rotational cipher (also called shift cipher) in the exercise "simple-cipher". Other examples of [substitution ciphers][sc] can be found in exercises "atbash-cipher" and "affine-cipher".
+
+You can find examples of ciphers based on an different principle, known as [transposition ciphers][tc], in exercises "crypto-square" and "rail-fence-cipher".
+
+All of these ciphers are considered toy ciphers by current standards. However, substitution and transposition (also called permutation) are two building blocks of modern ciphers like [AES][aes].
+
+[sc]: https://en.wikipedia.org/wiki/Substitution_cipher
+[tc]: https://en.wikipedia.org/wiki/Transposition_cipher
+[aes]: https://en.wikipedia.org/wiki/Advanced_Encryption_Standard

--- a/exercises/simple-cipher/description.md
+++ b/exercises/simple-cipher/description.md
@@ -69,13 +69,20 @@ If someone doesn't submit a key at all, generate a truly random key of at least 
 ## Extensions
 
 Shift ciphers work by making the text slightly odd, but are vulnerable to frequency analysis.
-Substitution ciphers help that, but are still very vulnerable when the key is short or if spaces are preserved.
-Later on you'll see one solution to this problem in the exercise "crypto-square".
+Substitution ciphers help that, but are still very vulnerable, especially when the key is short or if spaces are preserved.
+Later on you'll see one an improvement in the exercise "crypto-square".
+
+However, all of these ciphers are considered toy ciphers by current standards. Modern alternatives include [AES][aes] and [Chacha][chacha].
 
 If you want to go farther in this field, the questions begin to be about how we can exchange keys in a secure way.
 Take a look at [Diffie-Hellman on Wikipedia][dh] for one of the first implementations of this scheme.
 
+For a solid foundation in modern cryptography, you can check out the [Crypto 101][c101] course by Alfred Menezes.
+
 [cc]: https://en.wikipedia.org/wiki/Caesar_cipher
 [img-caesar-cipher]: https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Caesar_cipher_left_shift_of_3.svg/320px-Caesar_cipher_left_shift_of_3.svg.png
 [vc]: https://en.wikipedia.org/wiki/Vigen%C3%A8re_cipher
+[aes]: https://en.wikipedia.org/wiki/Advanced_Encryption_Standard
+[chacha]: https://en.wikipedia.org/wiki/Salsa20#ChaCha_variant
 [dh]: https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange
+[c101]: https://cryptography101.ca/crypto101-building-blocks/

--- a/exercises/simple-cipher/description.md
+++ b/exercises/simple-cipher/description.md
@@ -66,13 +66,16 @@ Let's make your substitution cipher a little more fault tolerant by providing a 
 
 If someone doesn't submit a key at all, generate a truly random key of at least 100 lowercase characters in length.
 
-## Extensions
+## Perspective
 
-Shift ciphers work by making the text slightly odd, but are vulnerable to frequency analysis.
-Substitution ciphers help that, but are still very vulnerable, especially when the key is short or if spaces are preserved.
-Later on you'll see one an improvement in the exercise "crypto-square".
+Shift ciphers work by making the text slightly odd, but are very weak because
+the number of possible keys is way too small. Given a message encrypted with this cipher, you can write a program that prints all 26 possible plaintexts and look at the list to quickly identify the one that looks like English. This could even be automated, for example using a dictionary, or frequency analysis.
 
-However, all of these ciphers are considered toy ciphers by current standards. Modern alternatives include [AES][aes] and [Chacha][chacha].
+Substitution ciphers help that, but are still vulnerable to frequency analysis, especially when the key is short or if spaces are preserved. (Note: the Vigenère Cipher is only one example of a [substitution cipher][sc]; others can be found in exercises "atbash-cipher" and "affine-cipher".)
+
+You can find examples of ciphers based on an different principle, known as [transposition ciphers][tc], in exercises "crypto-square" and "rail-fence-cipher".
+
+All of these ciphers are considered toy ciphers by current standards. However, substitution and transposition (also called permutation) are two building blocks of modern ciphers like [AES][aes].
 
 If you want to go farther in this field, the questions begin to be about how we can exchange keys in a secure way.
 Take a look at [Diffie-Hellman on Wikipedia][dh] for one of the first implementations of this scheme.
@@ -82,7 +85,10 @@ For a solid foundation in modern cryptography, you can check out the [Crypto 101
 [cc]: https://en.wikipedia.org/wiki/Caesar_cipher
 [img-caesar-cipher]: https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Caesar_cipher_left_shift_of_3.svg/320px-Caesar_cipher_left_shift_of_3.svg.png
 [vc]: https://en.wikipedia.org/wiki/Vigen%C3%A8re_cipher
+
+[sc]: https://en.wikipedia.org/wiki/Substitution_cipher
+[tc]: https://en.wikipedia.org/wiki/Transposition_cipher
 [aes]: https://en.wikipedia.org/wiki/Advanced_Encryption_Standard
-[chacha]: https://en.wikipedia.org/wiki/Salsa20#ChaCha_variant
+
 [dh]: https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange
 [c101]: https://cryptography101.ca/crypto101-building-blocks/

--- a/exercises/simple-cipher/description.md
+++ b/exercises/simple-cipher/description.md
@@ -1,6 +1,6 @@
 # Description
 
-Implement a simple shift cipher like Caesar and a more secure substitution cipher.
+Implement a simple shift cipher like Caesar and a more secure substitution cipher, know as the Vigenère Cipher.
 
 ## Step 1
 
@@ -8,10 +8,10 @@ Implement a simple shift cipher like Caesar and a more secure substitution ciphe
 If anyone wishes to decipher these, and get at their meaning, he must substitute the fourth letter of the alphabet, namely D, for A, and so with the others."
 —Suetonius, Life of Julius Caesar
 
-Ciphers are very straight-forward algorithms that allow us to render text less readable while still allowing easy deciphering.
+Shift ciphers are very straight-forward algorithms that allow us to render text less readable while still allowing easy deciphering.
 They are vulnerable to many forms of cryptanalysis, but Caesar was lucky that his enemies were not cryptanalysts.
 
-The Caesar Cipher was used for some messages from Julius Caesar that were sent afield.
+The [Caesar Cipher][cc] was used for some messages from Julius Caesar that were sent afield.
 Now Caesar knew that the cipher wasn't very good, but he had one ally in that respect: almost nobody could read well.
 So even being a couple letters off was sufficient so that people couldn't recognize the few words that they did know.
 
@@ -30,7 +30,7 @@ When "ldpdsdqgdehdu" is put into the decode function it would return the origina
 ## Step 2
 
 Shift ciphers quickly cease to be useful when the opposition commander figures them out.
-So instead, let's try using a substitution cipher.
+So instead, let's try using a substitution cipher: the [Vigènere Cipher][vc].
 Try amending the code to allow us to specify a key and use that for the shift distance.
 
 Here's an example:
@@ -45,6 +45,19 @@ In the example above, we've set a = 0 for the key value.
 So when the plaintext is added to the key, we end up with the same message coming out.
 So "aaaa" is not an ideal key.
 But if we set the key to "dddd", we would get the same thing as the Caesar Cipher.
+
+Things get interesting when the key becomes more complex than a repeating letter. For example:
+
+Given the key "adadadadadadadadad", encoding the string "iamapandabear"
+would return "idmdpdngaeedr".
+
+If the key is shorter than the message, it will be repeated. For example:
+
+Given the key "ad", encoding the string "iamapandabear"
+would return "idmdpdngaeedr" (same as the previous example).
+
+Given the key "lemon", encoding the string "attackatdawn"
+would return "lxfopvefrnhr" (the key has been expanded to "lemonlemonle").
 
 ## Step 3
 
@@ -62,5 +75,7 @@ Later on you'll see one solution to this problem in the exercise "crypto-square"
 If you want to go farther in this field, the questions begin to be about how we can exchange keys in a secure way.
 Take a look at [Diffie-Hellman on Wikipedia][dh] for one of the first implementations of this scheme.
 
+[cc]: https://en.wikipedia.org/wiki/Caesar_cipher
 [img-caesar-cipher]: https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Caesar_cipher_left_shift_of_3.svg/320px-Caesar_cipher_left_shift_of_3.svg.png
+[vc]: https://en.wikipedia.org/wiki/Vigen%C3%A8re_cipher
 [dh]: https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange


### PR DESCRIPTION
This PR:
- improves the description of "simpler-cipher" by giving non-trivial examples of the Vigenere and naming it;
- improves the last section by making it clear that this and crypto-square is all toy/historical and giving pointers to modern crypto;
- adds a "perspective" section to other exercises about toy ciphers, with references to other exercises and to a modern cipher.