### PR TITLE
Label alphabets as English rather than Latin

### DIFF
--- a/exercises/affine-cipher/description.md
+++ b/exercises/affine-cipher/description.md
@@ -20,7 +20,7 @@ Where:
 
 - `i` is the letter's index from `0` to the length of the alphabet - 1.
 - `m` is the length of the alphabet.
-  For the Roman alphabet `m` is `26`.
+  For the English alphabet `m` is `26`.
 - `a` and `b` are integers which make up the encryption key.
 
 Values `a` and `m` must be _coprime_ (or, _relatively prime_) for automatic decryption to succeed, i.e., they have number `1` as their only common factor (more information can be found in the [Wikipedia article about coprime integers][coprime-integers]).

--- a/exercises/atbash-cipher/description.md
+++ b/exercises/atbash-cipher/description.md
@@ -5,7 +5,7 @@ Create an implementation of the Atbash cipher, an ancient encryption system crea
 The Atbash cipher is a simple substitution cipher that relies on transposing all the letters in the alphabet such that the resulting alphabet is backwards.
 The first letter is replaced with the last letter, the second with the second-last, and so on.
 
-An Atbash cipher for the Latin alphabet would be as follows:
+An Atbash cipher for the English alphabet would be as follows:
 
 ```text
 Plain:  abcdefghijklmnopqrstuvwxyz

--- a/exercises/rotational-cipher/description.md
+++ b/exercises/rotational-cipher/description.md
@@ -9,7 +9,7 @@ The letter is shifted for as many values as the value of the key.
 The general notation for rotational ciphers is `ROT + <key>`.
 The most commonly used rotational cipher is `ROT13`.
 
-A `ROT13` on the Latin alphabet would be as follows:
+A `ROT13` on the English alphabet would be as follows:
 
 ```text
 Plain:  abcdefghijklmnopqrstuvwxyz


### PR DESCRIPTION
See the forum post for more details:
https://forum.exercism.org/t/rotational-cipher-atbash-cipher-affine-cipher-the-english-alphabet-is-not-the-latin-roman-alphabet/15618