### PR TITLE
Revise sieve's exercise instructions

### DIFF
--- a/exercises/sieve/instructions.md
+++ b/exercises/sieve/instructions.md
@@ -27,17 +27,75 @@ The tests don't check that you've implemented the algorithm, only that you've co
 Let's say you're finding the primes less than or equal to 10.
 
 - Write out 2, 3, 4, 5, 6, 7, 8, 9, 10, leaving them all unmarked.
+
+  ```text
+  2 3 4 5 6 7 8 9 10
+  ```
+
 - 2 is unmarked and is therefore a prime.
   Mark 4, 6, 8 and 10 as "not prime".
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] 9 [10]
+  ↑
+  ```
+
 - 3 is unmarked and is therefore a prime.
   Mark 6 and 9 as not prime _(marking 6 is optional - as it's already been marked)_.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+    ↑
+  ```
+
 - 4 is marked as "not prime", so we skip over it.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+       ↑
+  ```
+
 - 5 is unmarked and is therefore a prime.
   Mark 10 as not prime _(optional - as it's already been marked)_.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+          ↑
+  ```
+
 - 6 is marked as "not prime", so we skip over it.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+             ↑
+  ```
+
 - 7 is unmarked and is therefore a prime.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+                ↑
+  ```
+
 - 8 is marked as "not prime", so we skip over it.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+                   ↑
+  ```
+
 - 9 is marked as "not prime", so we skip over it.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+                       ↑
+  ```
+
 - 10 is marked as "not prime", so we stop as there are no more numbers to check.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+                           ↑
+  ```
 
 You've examined all the numbers and found that 2, 3, 5, and 7 are still unmarked, meaning they're the primes less than or equal to 10.

--- a/exercises/sieve/instructions.md
+++ b/exercises/sieve/instructions.md
@@ -6,26 +6,27 @@ A prime number is a number larger than 1 that is only divisible by 1 and itself.
 For example, 2, 3, 5, 7, 11, and 13 are prime numbers.
 By contrast, 6 is _not_ a prime number as it not only divisible by 1 and itself, but also by 2 and 3.
 
-To use the Sieve of Eratosthenes, you first create a list of all the numbers between 2 and your given number.
-Then you repeat the following steps:
+To use the Sieve of Eratosthenes, first, write out all the numbers from 2 up to and including your given number.
+Then, follow these steps:
 
-1. Find the next unmarked number in your list (skipping over marked numbers).
+1. Find the next unmarked number (skipping over marked numbers).
    This is a prime number.
 2. Mark all the multiples of that prime number as **not** prime.
 
-You keep repeating these steps until you've gone through every number in your list.
+Repeat the steps until you've gone through every number.
 At the end, all the unmarked numbers are prime.
 
 ~~~~exercism/note
-The tests don't check that you've implemented the algorithm, only that you've come up with the correct list of primes.
-To check you are implementing the Sieve correctly, a good first test is to check that you do not use division or remainder operations.
+The Sieve of Eratosthenes marks off multiples of each prime using addition (repeatedly adding the prime) or multiplication (directly computing its multiples), rather than checking each number for divisibility.
+
+The tests don't check that you've implemented the algorithm, only that you've come up with the correct primes.
 ~~~~
 
 ## Example
 
 Let's say you're finding the primes less than or equal to 10.
 
-- List out 2, 3, 4, 5, 6, 7, 8, 9, 10, leaving them all unmarked.
+- Write out 2, 3, 4, 5, 6, 7, 8, 9, 10, leaving them all unmarked.
 - 2 is unmarked and is therefore a prime.
   Mark 4, 6, 8 and 10 as "not prime".
 - 3 is unmarked and is therefore a prime.
@@ -39,4 +40,4 @@ Let's say you're finding the primes less than or equal to 10.
 - 9 is marked as "not prime", so we skip over it.
 - 10 is marked as "not prime", so we stop as there are no more numbers to check.
 
-You've examined all numbers and found 2, 3, 5, and 7 are still unmarked, which means they're the primes less than or equal to 10.
+You've examined all the numbers and found that 2, 3, 5, and 7 are still unmarked, meaning they're the primes less than or equal to 10.


### PR DESCRIPTION
Forum discussion

https://forum.exercism.org/t/updating-sieve-exercise-instructions/15703

Summary of the changes:

* Clarified that the starting numbers are "from 2 up to and including your given number".
* Removed explicit references to lists to avoid conflicts with track-specific terminology.
* Updated the note to clarify how the Sieve marks off multiples of each prime.
* Removed references to division and remainder operations from the note, as there are multiple ways to check for divisibility.
* Updated the example to show what happens at each step. I'll revert this change if there's any disagreement. If anyone has a better way to indicate the result of each step, please share it here.