### PR TITLE
triangle: add smaller size equality test

### DIFF
--- a/exercises/triangle/canonical-data.json
+++ b/exercises/triangle/canonical-data.json
@@ -103,6 +103,15 @@
           "expected": true
         },
         {
+          "uuid": "eca8ae18-e191-4795-836f-c6457e649d80",
+          "description": "two smaller sides are equal",
+          "property": "isosceles",
+          "input": {
+            "sides": [3, 4, 3]
+          },
+          "expected": true
+        },
+        {
           "uuid": "8d71e185-2bd7-4841-b7e1-71689a5491d8",
           "description": "equilateral triangles are also isosceles",
           "property": "isosceles",


### PR DESCRIPTION
[Original PR](https://github.com/exercism/cpp/pull/943)

[Forum Topic](https://forum.exercism.org/t/triangle-add-smaller-size-equality-test/15873)

This tests the case where the sides are sorted. If the two smaller sides are equal, the code below will falsely classify the triangle as scalene rather than isosceles. The current tests do not test this case.

```cpp
flavor kind(float a, float b, float c) {
    std::array<float, 3> sides{a, b, c};
    std::sort(sides.begin(), sides.end()); // Sides sorting
    if (!is_positive(sides)) {
        throw std::domain_error("Sides must be positive");
    }
    if (!triangle_inequality(sides)) {
        throw std::domain_error("The triangle inequality is violated");
    }
    if (sides[0] == sides[2]) {
        return flavor::equilateral;
    } else if (sides[1] == sides[2]) { // This check is incorrect
        return flavor::isosceles;
    } else {
        return flavor::scalene;
    }
}
```