### PR TITLE
Roman to Latin in `affine-cipher`

### DIFF
--- a/exercises/affine-cipher/description.md
+++ b/exercises/affine-cipher/description.md
@@ -20,7 +20,7 @@ Where:
 
 - `i` is the letter's index from `0` to the length of the alphabet - 1.
 - `m` is the length of the alphabet.
-  For the Roman alphabet `m` is `26`.
+  For the Latin alphabet `m` is `26`.
 - `a` and `b` are integers which make up the encryption key.
 
 Values `a` and `m` must be _coprime_ (or, _relatively prime_) for automatic decryption to succeed, i.e., they have number `1` as their only common factor (more information can be found in the [Wikipedia article about coprime integers][coprime-integers]).


### PR DESCRIPTION
See http://forum.exercism.org/t/rotational-cipher-atbash-cipher-affine-cipher-the-english-alphabet-is-not-the-latin-roman-alphabet/15618/16.