### PR TITLE
flatten-array: Replace references to lists with arrays, and revise instructions

### DIFF
--- a/exercises/flatten-array/canonical-data.json
+++ b/exercises/flatten-array/canonical-data.json
@@ -184,8 +184,44 @@
       ]
     },
     {
+      "uuid": "bc72da10-5f55-4ada-baf3-50e4da02ec8e",
+      "reimplements": "c6cf26de-8ccd-4410-84bd-b9efd88fd2bc",
+      "description": "consecutive null values at the front of the array are omitted from the final result",
+      "comments": ["Replaces references to lists with arrays in description."],
+      "property": "flatten",
+      "input": {
+        "array": [
+          null,
+          null,
+          3
+        ]
+      },
+      "expected": [
+        3
+      ]
+    },
+    {
       "uuid": "382c5242-587e-4577-b8ce-a5fb51e385a1",
       "description": "consecutive null values in the middle of the list are omitted from the final result",
+      "property": "flatten",
+      "input": {
+        "array": [
+          1,
+          null,
+          null,
+          4
+        ]
+      },
+      "expected": [
+        1,
+        4
+      ]
+    },
+    {
+      "uuid": "6991836d-0d9b-4703-80a0-3f1f23eb5981",
+      "reimplements": "382c5242-587e-4577-b8ce-a5fb51e385a1",
+      "description": "consecutive null values in the middle of the array are omitted from the final result",
+      "comments": ["Replaces references to lists with arrays in description."],
       "property": "flatten",
       "input": {
         "array": [
@@ -240,8 +276,79 @@
       ]
     },
     {
+      "uuid": "dc90a09c-5376-449c-a7b3-c2d20d540069",
+      "reimplements": "ef1d4790-1b1e-4939-a179-51ace0829dbd",
+      "description": "6 level nested array with null values",
+      "comments": ["Replaces references to lists with arrays in description."],
+      "property": "flatten",
+      "input": {
+        "array": [
+          0,
+          2,
+          [
+            [
+              2,
+              3
+            ],
+            8,
+            [
+              [
+                100
+              ]
+            ],
+            null,
+            [
+              [
+                null
+              ]
+            ]
+          ],
+          -2
+        ]
+      },
+      "expected": [
+        0,
+        2,
+        2,
+        3,
+        8,
+        100,
+        -2
+      ]
+    },
+    {
       "uuid": "85721643-705a-4150-93ab-7ae398e2942d",
       "description": "all values in nested list are null",
+      "property": "flatten",
+      "input": {
+        "array": [
+          null,
+          [
+            [
+              [
+                null
+              ]
+            ]
+          ],
+          null,
+          null,
+          [
+            [
+              null,
+              null
+            ],
+            null
+          ],
+          null
+        ]
+      },
+      "expected": []
+    },
+    {
+      "uuid": "51f5d9af-8f7f-4fb5-a156-69e8282cb275",
+      "reimplements": "85721643-705a-4150-93ab-7ae398e2942d",
+      "description": "all values in nested array are null",
+      "comments": ["Replaces references to lists with arrays in description."],
       "property": "flatten",
       "input": {
         "array": [

--- a/exercises/flatten-array/description.md
+++ b/exercises/flatten-array/description.md
@@ -1,11 +1,16 @@
 # Description
 
-Take a nested list and return a single flattened list with all values except nil/null.
+Take a nested array of any depth and return a fully flattened array.
 
-The challenge is to take an arbitrarily-deep nested list-like structure and produce a flattened structure without any nil/null values.
+Note that some language tracks may include null-like values in the input array, and the way these values are represented varies by track.
+Such values should be excluded from the flattened array.
 
-For example:
+Additionally, input arrays may have data of different types, depending on the track.
 
-input: [1,[2,3,null,4],[null],5]
+Check the test suite for details.
 
-output: [1,2,3,4,5]
+## Example
+
+input: `[1,[2,6,null],[[null,[4]],5]]`
+
+output: `[1,2,6,4,5]`

--- a/exercises/flatten-array/description.md
+++ b/exercises/flatten-array/description.md
@@ -5,12 +5,12 @@ Take a nested array of any depth and return a fully flattened array.
 Note that some language tracks may include null-like values in the input array, and the way these values are represented varies by track.
 Such values should be excluded from the flattened array.
 
-Additionally, input arrays may have data of different types, depending on the track.
+Additionally, the input may be of a different data type and contain different types, depending on the track.
 
 Check the test suite for details.
 
 ## Example
 
-input: `[1,[2,6,null],[[null,[4]],5]]`
+input: `[1, [2, 6, null], [[null, [4]], 5]]`
 
-output: `[1,2,6,4,5]`
+output: `[1, 2, 6, 4, 5]`


### PR DESCRIPTION
Forum

https://forum.exercism.org/t/flatten-array-mentions-both-lists-and-arrays/15849

Summary:

* Null-like values are optional according to the specifications; this has been clarified in the instructions.
* Added a clarification in the instructions that some tracks may contain data of different types.
* Replaced all references to lists with arrays in both the instructions and tests.
* Reimplemented tests that previously referred to lists in their descriptions; they now refer to arrays.
* Updated example in instructions with a more complex case.