### PR TITLE
Add `swift-scheduling` exercise

### DIFF
--- a/exercises/swift-scheduling/canonical-data.json
+++ b/exercises/swift-scheduling/canonical-data.json
@@ -137,15 +137,15 @@
         "meetingStart": "2001-04-09T09:00:00",
         "description": "Q4"
       },
-      "expected": "2001-12-28T08:00:00"
+      "expected": "2001-12-31T08:00:00"
     },
     {
       "uuid": "c920886c-44ad-4d34-a156-dc4176186581",
-      "description": "Q3 in the fourth quarter translates to the last workday of the third quarter of this year",
+      "description": "Q3 in the fourth quarter translates to the last workday of the third quarter of next year",
       "property": "deliveryDate",
       "input": {
         "meetingStart": "2022-10-06T11:00:00",
-        "description": "Q4"
+        "description": "Q3"
       },
       "expected": "2023-09-29T08:00:00"
     }

--- a/exercises/swift-scheduling/canonical-data.json
+++ b/exercises/swift-scheduling/canonical-data.json
@@ -140,7 +140,7 @@
       "expected": "2001-12-28T08:00:00"
     },
     {
-      "uuid": "eebd5f32-b16d-4ecd-91a0-584b0364b7ed",
+      "uuid": "c920886c-44ad-4d34-a156-dc4176186581",
       "description": "Q3 in the fourth quarter translates to the last workday of the third quarter of this year",
       "property": "deliveryDate",
       "input": {

--- a/exercises/swift-scheduling/canonical-data.json
+++ b/exercises/swift-scheduling/canonical-data.json
@@ -100,6 +100,16 @@
       "expected": "2022-08-07T20:00:00"
     },
     {
+      "uuid": "d651fcf4-290e-407c-8107-36b9076f39b2",
+      "description": "EOW translates to leap day",
+      "property": "deliveryDate",
+      "input": {
+        "meetingStart": "2008-02-25T10:30:00",
+        "description": "EOW"
+      },
+      "expected": "2008-02-29T17:00:00"
+    },
+    {
       "uuid": "439bf09f-3a0e-44e7-bad5-b7b6d0c4505a",
       "description": "2M before the second month of this year translates to the first workday of the second month of this year",
       "property": "deliveryDate",

--- a/exercises/swift-scheduling/canonical-data.json
+++ b/exercises/swift-scheduling/canonical-data.json
@@ -21,7 +21,7 @@
     },
     {
       "uuid": "93325e7b-677d-4d96-b017-2582af879dc2",
-      "description": "ASAP before noon translates to today at five in the afternoon",
+      "description": "ASAP before one in the afternoon translates to today at five in the afternoon",
       "property": "deliveryDate",
       "input": {
         "meetingStart": "1999-06-03T09:45:00",
@@ -30,14 +30,24 @@
       "expected": "1999-06-03T17:00:00"
     },
     {
-      "uuid": "6fddc1ea-2fe9-4c60-81f7-9220d2f45537",
-      "description": "ASAP after noon translates to tomorrow at noon",
+      "uuid": "cb4252a3-c4c1-41f6-8b8c-e7269733cef8",
+      "description": "ASAP at one in the afternoon translates to tomorrow at one in the afternoon",
       "property": "deliveryDate",
       "input": {
-        "meetingStart": "2008-12-21T13:30:00",
+        "meetingStart": "2008-12-21T13:00:00",
         "description": "ASAP"
       },
-      "expected": "2008-12-22T12:00:00"
+      "expected": "2008-12-22T13:00:00"
+    },
+    {
+      "uuid": "6fddc1ea-2fe9-4c60-81f7-9220d2f45537",
+      "description": "ASAP after one in the afternoon translates to tomorrow at one in the afternoon",
+      "property": "deliveryDate",
+      "input": {
+        "meetingStart": "2008-12-21T14:50:00",
+        "description": "ASAP"
+      },
+      "expected": "2008-12-22T13:00:00"
     },
     {
       "uuid": "25f46bf9-6d2a-4e95-8edd-f62dd6bc8a6e",
@@ -84,7 +94,7 @@
       "description": "EOW on Friday translates to Sunday at eight in the evening",
       "property": "deliveryDate",
       "input": {
-        "meetingStart": "2022-08-05T12:00:00",
+        "meetingStart": "2022-08-05T14:00:00",
         "description": "EOW"
       },
       "expected": "2022-08-07T20:00:00"

--- a/exercises/swift-scheduling/canonical-data.json
+++ b/exercises/swift-scheduling/canonical-data.json
@@ -44,7 +44,7 @@
       "description": "EOW on Monday translates to Friday at five in the afternoon",
       "property": "deliveryDate",
       "input": {
-        "meetingStart": "2025-02-03T00:00:00",
+        "meetingStart": "2025-02-03T16:00:00",
         "description": "EOW"
       },
       "expected": "2025-02-07T17:00:00"
@@ -54,7 +54,7 @@
       "description": "EOW on Tuesday translates to Friday at five in the afternoon",
       "property": "deliveryDate",
       "input": {
-        "meetingStart": "1997-04-29T00:00:00",
+        "meetingStart": "1997-04-29T10:50:00",
         "description": "EOW"
       },
       "expected": "1997-05-02T17:00:00"
@@ -64,7 +64,7 @@
       "description": "EOW on Wednesday translates to Friday at five in the afternoon",
       "property": "deliveryDate",
       "input": {
-        "meetingStart": "2005-09-14T00:00:00",
+        "meetingStart": "2005-09-14T11:00:00",
         "description": "EOW"
       },
       "expected": "2005-09-16T17:00:00"
@@ -74,7 +74,7 @@
       "description": "EOW on Thursday translates to Sunday at eight in the evening",
       "property": "deliveryDate",
       "input": {
-        "meetingStart": "2011-05-19T00:00:00",
+        "meetingStart": "2011-05-19T8:30:00",
         "description": "EOW"
       },
       "expected": "2011-05-22T20:00:00"
@@ -84,50 +84,70 @@
       "description": "EOW on Friday translates to Sunday at eight in the evening",
       "property": "deliveryDate",
       "input": {
-        "meetingStart": "2022-08-05T00:00:00",
+        "meetingStart": "2022-08-05T12:00:00",
         "description": "EOW"
       },
       "expected": "2022-08-07T20:00:00"
     },
     {
       "uuid": "439bf09f-3a0e-44e7-bad5-b7b6d0c4505a",
-      "description": "2M translates to the first workday of the second month",
+      "description": "2M before the second month of this year translates to the first workday of the second month of this year",
       "property": "deliveryDate",
       "input": {
-        "meetingStart": "2007-01-02T00:00:00",
+        "meetingStart": "2007-01-02T14:15:00",
         "description": "2M"
       },
       "expected": "2007-02-01T08:00:00"
     },
     {
       "uuid": "86d82e83-c481-4fb4-9264-625de7521340",
-      "description": "5M translates to the first workday of the fifth month",
+      "description": "11M in the eleventh month translates to the first workday of the eleventh month of next year",
       "property": "deliveryDate",
       "input": {
-        "meetingStart": "2013-02-11T00:00:00",
-        "description": "5M"
+        "meetingStart": "2013-11-21T15:30:00",
+        "description": "11M"
       },
-      "expected": "2013-05-01T08:00:00"
+      "expected": "2014-11-03T08:00:00"
+    },
+    {
+      "uuid": "0d0b8f6a-1915-46f5-a630-1ff06af9da08",
+      "description": "4M in the ninth month translates to the first workday of the fourth month of next year",
+      "property": "deliveryDate",
+      "input": {
+        "meetingStart": "2019-11-18T15:15:00",
+        "description": "4M"
+      },
+      "expected": "2020-04-01T08:00:00"
     },
     {
       "uuid": "06d401e3-8461-438f-afae-8d26aa0289e0",
-      "description": "Q1 translates to the last workday of the first quarter",
+      "description": "Q1 in the first quarter translates to the last workday of the first quarter of this year",
       "property": "deliveryDate",
       "input": {
-        "meetingStart": "2011-02-23T00:00:00",
+        "meetingStart": "2003-01-01T10:45:00",
         "description": "Q1"
       },
-      "expected": "2011-03-31T08:00:00"
+      "expected": "2003-03-31T08:00:00"
     },
     {
       "uuid": "eebd5f32-b16d-4ecd-91a0-584b0364b7ed",
-      "description": "Q4 translates to the last workday of the fourth quarter",
+      "description": "Q4 in the second quarter translates to the last workday of the fourth quarter of this year",
       "property": "deliveryDate",
       "input": {
-        "meetingStart": "2023-04-19T00:00:00",
+        "meetingStart": "2001-04-09T09:00:00",
         "description": "Q4"
       },
-      "expected": "2023-12-29T08:00:00"
+      "expected": "2001-12-28T08:00:00"
+    },
+    {
+      "uuid": "eebd5f32-b16d-4ecd-91a0-584b0364b7ed",
+      "description": "Q3 in the fourth quarter translates to the last workday of the third quarter of this year",
+      "property": "deliveryDate",
+      "input": {
+        "meetingStart": "2022-10-06T11:00:00",
+        "description": "Q4"
+      },
+      "expected": "2023-09-29T08:00:00"
     }
   ]
 }

--- a/exercises/swift-scheduling/canonical-data.json
+++ b/exercises/swift-scheduling/canonical-data.json
@@ -74,7 +74,7 @@
       "description": "EOW on Thursday translates to Sunday at eight in the evening",
       "property": "deliveryDate",
       "input": {
-        "meetingStart": "2011-05-19T8:30:00",
+        "meetingStart": "2011-05-19T08:30:00",
         "description": "EOW"
       },
       "expected": "2011-05-22T20:00:00"

--- a/exercises/swift-scheduling/canonical-data.json
+++ b/exercises/swift-scheduling/canonical-data.json
@@ -1,0 +1,133 @@
+{
+  "exercise": "swift-scheduling",
+  "comments": [
+    "The dates are formatted per ",
+    "https://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.15.",
+    "",
+    "Tracks that support changing the system's current time can consider ",
+    "setting the system's current time to the meeting start instead of ",
+    "passing it as an argument."
+  ],
+  "cases": [
+    {
+      "uuid": "1d0e6e72-f370-408c-bc64-5dafa9c6da73",
+      "description": "NOW translates to two hours later",
+      "property": "deliveryDate",
+      "input": {
+        "meetingStart": "2012-02-13T09:00:00",
+        "description": "NOW"
+      },
+      "expected": "2012-02-13T11:00:00"
+    },
+    {
+      "uuid": "93325e7b-677d-4d96-b017-2582af879dc2",
+      "description": "ASAP before noon translates to today at five in the afternoon",
+      "property": "deliveryDate",
+      "input": {
+        "meetingStart": "1999-06-03T09:45:00",
+        "description": "ASAP"
+      },
+      "expected": "1999-06-03T17:00:00"
+    },
+    {
+      "uuid": "6fddc1ea-2fe9-4c60-81f7-9220d2f45537",
+      "description": "ASAP after noon translates to tomorrow at noon",
+      "property": "deliveryDate",
+      "input": {
+        "meetingStart": "2008-12-21T13:30:00",
+        "description": "ASAP"
+      },
+      "expected": "2008-12-22T12:00:00"
+    },
+    {
+      "uuid": "25f46bf9-6d2a-4e95-8edd-f62dd6bc8a6e",
+      "description": "EOW on Monday translates to Friday at five in the afternoon",
+      "property": "deliveryDate",
+      "input": {
+        "meetingStart": "2025-02-03T00:00:00",
+        "description": "EOW"
+      },
+      "expected": "2025-02-07T17:00:00"
+    },
+    {
+      "uuid": "0b375df5-d198-489e-acee-fd538a768616",
+      "description": "EOW on Tuesday translates to Friday at five in the afternoon",
+      "property": "deliveryDate",
+      "input": {
+        "meetingStart": "1997-04-29T00:00:00",
+        "description": "EOW"
+      },
+      "expected": "1997-05-02T17:00:00"
+    },
+    {
+      "uuid": "4afbb881-0b5c-46be-94e1-992cdc2a8ca4",
+      "description": "EOW on Wednesday translates to Friday at five in the afternoon",
+      "property": "deliveryDate",
+      "input": {
+        "meetingStart": "2005-09-14T00:00:00",
+        "description": "EOW"
+      },
+      "expected": "2005-09-16T17:00:00"
+    },
+    {
+      "uuid": "e1341c2b-5e1b-4702-a95c-a01e8e96e510",
+      "description": "EOW on Thursday translates to Sunday at eight in the evening",
+      "property": "deliveryDate",
+      "input": {
+        "meetingStart": "2011-05-19T00:00:00",
+        "description": "EOW"
+      },
+      "expected": "2011-05-22T20:00:00"
+    },
+    {
+      "uuid": "bbffccf7-97f7-4244-888d-bdd64348fa2e",
+      "description": "EOW on Friday translates to Sunday at eight in the evening",
+      "property": "deliveryDate",
+      "input": {
+        "meetingStart": "2022-08-05T00:00:00",
+        "description": "EOW"
+      },
+      "expected": "2022-08-07T20:00:00"
+    },
+    {
+      "uuid": "439bf09f-3a0e-44e7-bad5-b7b6d0c4505a",
+      "description": "2M translates to the first workday of the second month",
+      "property": "deliveryDate",
+      "input": {
+        "meetingStart": "2007-01-02T00:00:00",
+        "description": "2M"
+      },
+      "expected": "2007-02-01T08:00:00"
+    },
+    {
+      "uuid": "86d82e83-c481-4fb4-9264-625de7521340",
+      "description": "5M translates to the first workday of the fifth month",
+      "property": "deliveryDate",
+      "input": {
+        "meetingStart": "2013-02-11T00:00:00",
+        "description": "5M"
+      },
+      "expected": "2013-05-01T08:00:00"
+    },
+    {
+      "uuid": "06d401e3-8461-438f-afae-8d26aa0289e0",
+      "description": "Q1 translates to the last workday of the first quarter",
+      "property": "deliveryDate",
+      "input": {
+        "meetingStart": "2011-02-23T00:00:00",
+        "description": "Q1"
+      },
+      "expected": "2011-03-31T08:00:00"
+    },
+    {
+      "uuid": "eebd5f32-b16d-4ecd-91a0-584b0364b7ed",
+      "description": "Q4 translates to the last workday of the fourth quarter",
+      "property": "deliveryDate",
+      "input": {
+        "meetingStart": "2023-04-19T00:00:00",
+        "description": "Q4"
+      },
+      "expected": "2023-12-29T08:00:00"
+    }
+  ]
+}

--- a/exercises/swift-scheduling/instructions.md
+++ b/exercises/swift-scheduling/instructions.md
@@ -15,7 +15,7 @@ There are three fixed delivery date descriptions:
 - `"ASAP"` (As Soon As Possible)
 - `"EOW"` (End Of Week)
 
-The following table lists how to translate them:
+The following table shows how to translate them:
 
 | Description | Meeting start                | Delivery date                       |
 | ----------- | ---------------------------- | ----------------------------------- |

--- a/exercises/swift-scheduling/instructions.md
+++ b/exercises/swift-scheduling/instructions.md
@@ -40,4 +40,4 @@ There are two variable delivery date description patterns:
 | `"Q<N>"`    | After N-th quarter²        | At 8:00 on the _last_ workday¹ of next year's N-th quarter² |
 
 ¹ A workday is a Monday, Tuesday, Wednesday, Thursday, or Friday.
-² A year has four quarters, each with three months: January + February + March, April + May + June, July + August + September, and October + November + December.
+² A year has four quarters, each with three months: January/February/March, April/May/June, July/August/September, and October/November/December.

--- a/exercises/swift-scheduling/instructions.md
+++ b/exercises/swift-scheduling/instructions.md
@@ -34,7 +34,7 @@ There are two variable delivery date description patterns:
 
 | Description | Delivery date                                                          |
 | ----------- | ---------------------------------------------------------------------- |
-| `"<N>M"`    | At 8:00 on the _first_ work day<sup>1</sup> of this year's N-th month  |
+| `"<N>M"`    | At 8:00 on the _first_ workday<sup>1</sup> of this year's N-th month  |
 | `"Q<N>"`    | At 8:00 on the _last_ work day<sup>1</sup> of this year's N-th quarter |
 
 <sup>1</sup> A workday is a Monday, Tuesday, Wednesday, Thursday, or Friday.

--- a/exercises/swift-scheduling/instructions.md
+++ b/exercises/swift-scheduling/instructions.md
@@ -35,6 +35,6 @@ There are two variable delivery date description patterns:
 | Description | Delivery date                                                          |
 | ----------- | ---------------------------------------------------------------------- |
 | `"<N>M"`    | At 8:00 on the _first_ workday<sup>1</sup> of this year's N-th month  |
-| `"Q<N>"`    | At 8:00 on the _last_ work day<sup>1</sup> of this year's N-th quarter |
+| `"Q<N>"`    | At 8:00 on the _last_ workday<sup>1</sup> of this year's N-th quarter |
 
 <sup>1</sup> A workday is a Monday, Tuesday, Wednesday, Thursday, or Friday.

--- a/exercises/swift-scheduling/instructions.md
+++ b/exercises/swift-scheduling/instructions.md
@@ -22,7 +22,7 @@ The following table lists how to translate them:
 | `"NOW"`     | -                            | Two hours after the meeting started |
 | `"ASAP"`    | Before 12:00                 | Today at 17:00                      |
 | `"ASAP"`    | After 12:00                  | Tomorrow at 12:00                   |
-| `"EOW"`     | Monday, Tuesday or Wednesday | Friday at 5:00                      |
+| `"EOW"`     | Monday, Tuesday, or Wednesday | Friday at 5:00                      |
 | `"EOW"`     | Thursday or Friday           | Sunday at 20:00                     |
 
 ## Variable delivery date descriptions

--- a/exercises/swift-scheduling/instructions.md
+++ b/exercises/swift-scheduling/instructions.md
@@ -32,11 +32,12 @@ There are two variable delivery date description patterns:
 - `"<N>M"` (N-th month)
 - `"Q<N>"` (N-th quarter)
 
-| Description | Meeting start             | Delivery date                                              |
-| ----------- | ------------------------- | ---------------------------------------------------------- |
-| `"<N>M"`    | Before N-th month         | At 8:00 on the _first_ workday¹ of this year's N-th month  |
-| `"<N>M"`    | After or in N-th month    | At 8:00 on the _first_ workday¹ of next year's N-th month  |
-| `"Q<N>"`    | Before or in N-th quarter | At 8:00 on the _last_ workday¹ of this year's N-th quarter |
-| `"Q<N>"`    | After N-th quarter        | At 8:00 on the _last_ workday¹ of next year's N-th quarter |
+| Description | Meeting start              | Delivery date                                               |
+| ----------- | -------------------------- | ----------------------------------------------------------- |
+| `"<N>M"`    | Before N-th month          | At 8:00 on the _first_ workday¹ of this year's N-th month   |
+| `"<N>M"`    | After or in N-th month     | At 8:00 on the _first_ workday¹ of next year's N-th month   |
+| `"Q<N>"`    | Before or in N-th quarter² | At 8:00 on the _last_ workday¹ of this year's N-th quarter² |
+| `"Q<N>"`    | After N-th quarter²        | At 8:00 on the _last_ workday¹ of next year's N-th quarter² |
 
 ¹ A workday is a Monday, Tuesday, Wednesday, Thursday, or Friday.
+² A year has four quarters, each with three months: January + February + March, April + May + June, July + August + September, and October + November + December.

--- a/exercises/swift-scheduling/instructions.md
+++ b/exercises/swift-scheduling/instructions.md
@@ -1,0 +1,40 @@
+# Instructions
+
+Your task is to convert delivery date descriptions to _actual_ delivery dates, based on when the meeting started.
+
+There are two types of delivery date descriptions:
+
+1. Fixed: a predefined set of words.
+2. Variable: words that have a variable component, but follow a predefined set of patterns.
+
+## Fixed delivery date descriptions
+
+There are three fixed delivery date descriptions:
+
+- `"NOW"`
+- `"ASAP"` (As Soon As Possible)
+- `"EOW"` (End Of Week)
+
+The following table lists how to translate them:
+
+| Description | Meeting start                | Delivery date                       |
+| ----------- | ---------------------------- | ----------------------------------- |
+| `"NOW"`     | -                            | Two hours after the meeting started |
+| `"ASAP"`    | Before 12:00                 | Today at 17:00                      |
+| `"ASAP"`    | After 12:00                  | Tomorrow at 12:00                   |
+| `"EOW"`     | Monday, Tuesday or Wednesday | Friday at 5:00                      |
+| `"EOW"`     | Thursday or Friday           | Sunday at 20:00                     |
+
+## Variable delivery date descriptions
+
+There are two variable delivery date description patterns:
+
+- `"<N>M"` (N-th month)
+- `"Q<N>"` (N-th quarter)
+
+| Description | Delivery date                                                          |
+| ----------- | ---------------------------------------------------------------------- |
+| `"<N>M"`    | At 8:00 on the _first_ work day<sup>1</sup> of this year's N-th month  |
+| `"Q<N>"`    | At 8:00 on the _last_ work day<sup>1</sup> of this year's N-th quarter |
+
+<sup>1</sup> A work day is either a Monday, Tuesday, Wednesday, Thursday or Friday.

--- a/exercises/swift-scheduling/instructions.md
+++ b/exercises/swift-scheduling/instructions.md
@@ -32,9 +32,11 @@ There are two variable delivery date description patterns:
 - `"<N>M"` (N-th month)
 - `"Q<N>"` (N-th quarter)
 
-| Description | Delivery date                                                         |
-| ----------- | --------------------------------------------------------------------- |
-| `"<N>M"`    | At 8:00 on the _first_ workday<sup>1</sup> of this year's N-th month  |
-| `"Q<N>"`    | At 8:00 on the _last_ workday<sup>1</sup> of this year's N-th quarter |
+| Description | Meeting start            | Delivery date                                                         |
+| ----------- | ------------------------ | --------------------------------------------------------------------- |
+| `"<N>M"`    | Before N-th month        | At 8:00 on the _first_ workday<sup>1</sup> of this year's N-th month  |
+| `"<N>M"`    | After or in N-th month   | At 8:00 on the _first_ workday<sup>1</sup> of next year's N-th month  |
+| `"Q<N>"`    | Before N-th quarter      | At 8:00 on the _last_ workday<sup>1</sup> of this year's N-th quarter |
+| `"Q<N>"`    | After or in N-th quarter | At 8:00 on the _last_ workday<sup>1</sup> of next year's N-th quarter |
 
 <sup>1</sup> A workday is a Monday, Tuesday, Wednesday, Thursday, or Friday.

--- a/exercises/swift-scheduling/instructions.md
+++ b/exercises/swift-scheduling/instructions.md
@@ -20,8 +20,8 @@ The following table shows how to translate them:
 | Description | Meeting start                 | Delivery date                       |
 | ----------- | ----------------------------- | ----------------------------------- |
 | `"NOW"`     | -                             | Two hours after the meeting started |
-| `"ASAP"`    | Before 12:00                  | Today at 17:00                      |
-| `"ASAP"`    | After 12:00                   | Tomorrow at 12:00                   |
+| `"ASAP"`    | Before 13:00                  | Today at 17:00                      |
+| `"ASAP"`    | After or at 13:00             | Tomorrow at 13:00                   |
 | `"EOW"`     | Monday, Tuesday, or Wednesday | Friday at 17:00                     |
 | `"EOW"`     | Thursday or Friday            | Sunday at 20:00                     |
 

--- a/exercises/swift-scheduling/instructions.md
+++ b/exercises/swift-scheduling/instructions.md
@@ -17,13 +17,13 @@ There are three fixed delivery date descriptions:
 
 The following table shows how to translate them:
 
-| Description | Meeting start                | Delivery date                       |
-| ----------- | ---------------------------- | ----------------------------------- |
-| `"NOW"`     | -                            | Two hours after the meeting started |
-| `"ASAP"`    | Before 12:00                 | Today at 17:00                      |
-| `"ASAP"`    | After 12:00                  | Tomorrow at 12:00                   |
+| Description | Meeting start                 | Delivery date                       |
+| ----------- | ----------------------------- | ----------------------------------- |
+| `"NOW"`     | -                             | Two hours after the meeting started |
+| `"ASAP"`    | Before 12:00                  | Today at 17:00                      |
+| `"ASAP"`    | After 12:00                   | Tomorrow at 12:00                   |
 | `"EOW"`     | Monday, Tuesday, or Wednesday | Friday at 5:00                      |
-| `"EOW"`     | Thursday or Friday           | Sunday at 20:00                     |
+| `"EOW"`     | Thursday or Friday            | Sunday at 20:00                     |
 
 ## Variable delivery date descriptions
 
@@ -32,8 +32,8 @@ There are two variable delivery date description patterns:
 - `"<N>M"` (N-th month)
 - `"Q<N>"` (N-th quarter)
 
-| Description | Delivery date                                                          |
-| ----------- | ---------------------------------------------------------------------- |
+| Description | Delivery date                                                         |
+| ----------- | --------------------------------------------------------------------- |
 | `"<N>M"`    | At 8:00 on the _first_ workday<sup>1</sup> of this year's N-th month  |
 | `"Q<N>"`    | At 8:00 on the _last_ workday<sup>1</sup> of this year's N-th quarter |
 

--- a/exercises/swift-scheduling/instructions.md
+++ b/exercises/swift-scheduling/instructions.md
@@ -22,7 +22,7 @@ The following table shows how to translate them:
 | `"NOW"`     | -                             | Two hours after the meeting started |
 | `"ASAP"`    | Before 12:00                  | Today at 17:00                      |
 | `"ASAP"`    | After 12:00                   | Tomorrow at 12:00                   |
-| `"EOW"`     | Monday, Tuesday, or Wednesday | Friday at 5:00                      |
+| `"EOW"`     | Monday, Tuesday, or Wednesday | Friday at 17:00                     |
 | `"EOW"`     | Thursday or Friday            | Sunday at 20:00                     |
 
 ## Variable delivery date descriptions

--- a/exercises/swift-scheduling/instructions.md
+++ b/exercises/swift-scheduling/instructions.md
@@ -32,11 +32,11 @@ There are two variable delivery date description patterns:
 - `"<N>M"` (N-th month)
 - `"Q<N>"` (N-th quarter)
 
-| Description | Meeting start            | Delivery date                                                         |
-| ----------- | ------------------------ | --------------------------------------------------------------------- |
-| `"<N>M"`    | Before N-th month        | At 8:00 on the _first_ workday<sup>1</sup> of this year's N-th month  |
-| `"<N>M"`    | After or in N-th month   | At 8:00 on the _first_ workday<sup>1</sup> of next year's N-th month  |
-| `"Q<N>"`    | Before N-th quarter      | At 8:00 on the _last_ workday<sup>1</sup> of this year's N-th quarter |
-| `"Q<N>"`    | After or in N-th quarter | At 8:00 on the _last_ workday<sup>1</sup> of next year's N-th quarter |
+| Description | Meeting start             | Delivery date                                                         |
+| ----------- | ------------------------- | --------------------------------------------------------------------- |
+| `"<N>M"`    | Before N-th month         | At 8:00 on the _first_ workday<sup>1</sup> of this year's N-th month  |
+| `"<N>M"`    | After or in N-th month    | At 8:00 on the _first_ workday<sup>1</sup> of next year's N-th month  |
+| `"Q<N>"`    | Before or in N-th quarter | At 8:00 on the _last_ workday<sup>1</sup> of this year's N-th quarter |
+| `"Q<N>"`    | After N-th quarter        | At 8:00 on the _last_ workday<sup>1</sup> of next year's N-th quarter |
 
 <sup>1</sup> A workday is a Monday, Tuesday, Wednesday, Thursday, or Friday.

--- a/exercises/swift-scheduling/instructions.md
+++ b/exercises/swift-scheduling/instructions.md
@@ -37,4 +37,4 @@ There are two variable delivery date description patterns:
 | `"<N>M"`    | At 8:00 on the _first_ work day<sup>1</sup> of this year's N-th month  |
 | `"Q<N>"`    | At 8:00 on the _last_ work day<sup>1</sup> of this year's N-th quarter |
 
-<sup>1</sup> A work day is either a Monday, Tuesday, Wednesday, Thursday or Friday.
+<sup>1</sup> A workday is a Monday, Tuesday, Wednesday, Thursday, or Friday.

--- a/exercises/swift-scheduling/instructions.md
+++ b/exercises/swift-scheduling/instructions.md
@@ -32,11 +32,11 @@ There are two variable delivery date description patterns:
 - `"<N>M"` (N-th month)
 - `"Q<N>"` (N-th quarter)
 
-| Description | Meeting start             | Delivery date                                                         |
-| ----------- | ------------------------- | --------------------------------------------------------------------- |
-| `"<N>M"`    | Before N-th month         | At 8:00 on the _first_ workday<sup>1</sup> of this year's N-th month  |
-| `"<N>M"`    | After or in N-th month    | At 8:00 on the _first_ workday<sup>1</sup> of next year's N-th month  |
-| `"Q<N>"`    | Before or in N-th quarter | At 8:00 on the _last_ workday<sup>1</sup> of this year's N-th quarter |
-| `"Q<N>"`    | After N-th quarter        | At 8:00 on the _last_ workday<sup>1</sup> of next year's N-th quarter |
+| Description | Meeting start             | Delivery date                                              |
+| ----------- | ------------------------- | ---------------------------------------------------------- |
+| `"<N>M"`    | Before N-th month         | At 8:00 on the _first_ workday¹ of this year's N-th month  |
+| `"<N>M"`    | After or in N-th month    | At 8:00 on the _first_ workday¹ of next year's N-th month  |
+| `"Q<N>"`    | Before or in N-th quarter | At 8:00 on the _last_ workday¹ of this year's N-th quarter |
+| `"Q<N>"`    | After N-th quarter        | At 8:00 on the _last_ workday¹ of next year's N-th quarter |
 
-<sup>1</sup> A workday is a Monday, Tuesday, Wednesday, Thursday, or Friday.
+¹ A workday is a Monday, Tuesday, Wednesday, Thursday, or Friday.

--- a/exercises/swift-scheduling/introduction.md
+++ b/exercises/swift-scheduling/introduction.md
@@ -2,5 +2,5 @@
 
 This week, it is your turn to take notes in the department's planning meeting.
 In this meeting, your boss will set delivery dates for all open work items.
-Annoyingly, instead of specifying the _actual_ delivery date, your boss will only _describe them_ in an annoying abbreviated format.
+Annoyingly, instead of specifying the _actual_ delivery dates, your boss will only _describe them_ in an abbreviated format.
 As many of your colleagues won't be familiar with this corporate lingo, you'll need to convert these delivery date descriptions to actual delivery dates.

--- a/exercises/swift-scheduling/introduction.md
+++ b/exercises/swift-scheduling/introduction.md
@@ -1,0 +1,6 @@
+# Introduction
+
+This week, it is your turn to take notes in the department's planning meeting.
+In this meeting, your boss will set delivery dates for all open work items.
+Annoyingly, instead of specifying the _actual_ delivery date, your boss will only _describe them_ in an annoying abbreviated format.
+As many of your colleagues won't be familiar with this corporate lingo, you'll need to convert these delivery date descriptions to actual delivery dates.

--- a/exercises/swift-scheduling/metadata.toml
+++ b/exercises/swift-scheduling/metadata.toml
@@ -1,0 +1,2 @@
+title = "Swift Scheduling"
+blurb = "Convert delivery date descriptions to actual delivery dates."


### PR DESCRIPTION
This is a proposal to add new date-based exercise. The primary goal is to have more date-based exercises. This exercise requires students to convert strings to dates, and will need to add date arithmetic. I'm open to any improvements, so please consider this a starting point.

As a PoC, I've implemented it in C#: https://github.com/exercism/csharp/pull/2397