### PR TITLE
Update docs for the Luhn exercise

### DIFF
--- a/exercises/luhn/instructions.md
+++ b/exercises/luhn/instructions.md
@@ -14,25 +14,23 @@ All other non-digit characters are disallowed.
 
 ### Valid credit card number
 
-```text
-4539 3195 0343 6467
-```
+The number to be checked is `4539 3195 0343 6467`.
 
-The first step of the Luhn algorithm is to double every second digit, starting from the rightmost (last) digit of the number and moving left.
+The first step of the Luhn algorithm is to start at the end of the number and double every second digit, beginning with the second digit from the right and moving left.
 
 ```text
 4539 3195 0343 6467
 ↑ ↑  ↑ ↑  ↑ ↑  ↑ ↑  (double these)
 ```
 
-If the result of doubling a digit is greater than 9, subtract 9 from that result.
+If the result of doubling a digit is greater than 9, we subtract 9 from that result.
 We end up with:
 
 ```text
 8569 6195 0383 3437
 ```
 
-Then sum all digits, and if the sum is evenly divisible by 10, the original number is valid.
+Finally, we sum all digits, and if the sum is evenly divisible by 10, the original number is valid.
 
 ```text
 8 + 5 + 6 + 9 + 6 + 1 + 9 + 5 + 0 + 3 + 8 + 3 + 3 + 4 + 3 + 7 = 80
@@ -42,25 +40,23 @@ Then sum all digits, and if the sum is evenly divisible by 10, the original numb
 
 ### Invalid Canadian SIN
 
-```text
-066 123 468
-```
+The number to be checked is `066 123 468`.
 
-Double every second digit starting from the rightmost (last) digit of the number and moving left.
+We start at the end of the number and double every second digit, beginning with the second digit from the right and moving left.
 
 ```text
 066 123 478
  ↑  ↑ ↑  ↑  (double these)
 ```
 
-If the result of doubling a digit is greater than 9, subtract 9 from that result.
+If the result of doubling a digit is greater than 9, we subtract 9 from that result.
 We end up with:
 
 ```text
 036 226 458
 ```
 
-Sum the digits:
+We sum the digits:
 
 ```text
 0 + 3 + 6 + 2 + 2 + 6 + 4 + 5 + 8 = 36

--- a/exercises/luhn/instructions.md
+++ b/exercises/luhn/instructions.md
@@ -17,7 +17,6 @@ All other non-digit characters are disallowed.
 ```
 
 The first step of the Luhn algorithm is to double every second digit, starting from the rightmost (last) digit of the number and moving left.
-We will be doubling:
 
 ```text
 4539 3195 0343 6467
@@ -39,25 +38,32 @@ Then sum all digits, and if the sum is evenly divisible by 10, the original numb
 
 80 is evenly divisible by 10, so number `4539 3195 0343 6467` is valid!
 
-### Example 2: invalid credit card number
+### Example 2: invalid Canadian SIN
 
 ```text
-8273 1232 7352 0569
+066 123 468
 ```
 
-Double every second digit, and subtract 9 if the doubled digit exceeds 9.
+Double every second digit starting from the rightmost (last) digit of the number and moving left.
+
+```text
+066 123 478
+ ↑  ↑ ↑  ↑  (double these)
+```
+
+If the result of doubling a digit is greater than 9, subtract 9 from that result.
 We end up with:
 
 ```text
-7253 2262 5312 0539
+036 226 458
 ```
 
 Sum the digits:
 
 ```text
-7 + 2 + 5 + 3 + 2 + 2 + 6 + 2 + 5 + 3 + 1 + 2 + 0 + 5 + 3 + 9 = 57
+0 + 3 + 6 + 2 + 2 + 6 + 4 + 5 + 8 = 36
 ```
 
-57 is not evenly divisible by 10, so number `8273 1232 7352 0569` is not valid!
+36 is not evenly divisible by 10, so number `066 123 478` is not valid!
 
 [luhn]: https://en.wikipedia.org/wiki/Luhn_algorithm

--- a/exercises/luhn/instructions.md
+++ b/exercises/luhn/instructions.md
@@ -34,7 +34,7 @@ We end up with:
 Then sum all digits, and if the sum is evenly divisible by 10, the original number is valid.
 
 ```text
-8+5+6+9+6+1+9+5+0+3+8+3+3+4+3+7 = 80
+8 + 5 + 6 + 9 + 6 + 1 + 9 + 5 + 0 + 3 + 8 + 3 + 3 + 4 + 3 + 7 = 80
 ```
 
 80 is evenly divisible by 10, so number `4539 3195 0343 6467` is valid!
@@ -55,7 +55,7 @@ We end up with:
 Sum the digits:
 
 ```text
-7+2+5+3+2+2+6+2+5+3+1+2+0+5+3+9 = 57
+7 + 2 + 5 + 3 + 2 + 2 + 6 + 2 + 5 + 3 + 1 + 2 + 0 + 5 + 3 + 9 = 57
 ```
 
 57 is not evenly divisible by 10, so number `8273 1232 7352 0569` is not valid!

--- a/exercises/luhn/instructions.md
+++ b/exercises/luhn/instructions.md
@@ -10,7 +10,9 @@ Strings of length 1 or less are not valid.
 Spaces are allowed in the input, but they should be stripped before checking.
 All other non-digit characters are disallowed.
 
-### Example 1: valid credit card number
+## Examples
+
+### Valid credit card number
 
 ```text
 4539 3195 0343 6467
@@ -38,7 +40,7 @@ Then sum all digits, and if the sum is evenly divisible by 10, the original numb
 
 80 is evenly divisible by 10, so number `4539 3195 0343 6467` is valid!
 
-### Example 2: invalid Canadian SIN
+### Invalid Canadian SIN
 
 ```text
 066 123 468

--- a/exercises/luhn/instructions.md
+++ b/exercises/luhn/instructions.md
@@ -1,6 +1,6 @@
 # Instructions
 
-Determine whether a credit card number is valid according to the [Luhn formula][luhn].
+Determine whether a number is valid according to the [Luhn formula][luhn].
 
 The number will be provided as a string.
 
@@ -16,29 +16,28 @@ All other non-digit characters are disallowed.
 4539 3195 0343 6467
 ```
 
-The first step of the Luhn algorithm is to double every second digit, starting from the right.
-We will be doubling
+The first step of the Luhn algorithm is to double every second digit, starting from the rightmost (last) digit of the number and moving left.
+We will be doubling:
 
 ```text
 4539 3195 0343 6467
 ↑ ↑  ↑ ↑  ↑ ↑  ↑ ↑  (double these)
 ```
 
-If doubling the number results in a number greater than 9 then subtract 9 from the product.
-The results of our doubling:
+If the result of doubling a digit is greater than 9, subtract 9 from that result.
+We end up with:
 
 ```text
 8569 6195 0383 3437
 ```
 
-Then sum all of the digits:
+Then sum all digits, and if the sum is evenly divisible by 10, the original number is valid.
 
 ```text
 8+5+6+9+6+1+9+5+0+3+8+3+3+4+3+7 = 80
 ```
 
-If the sum is evenly divisible by 10, then the number is valid.
-This number is valid!
+80 is evenly divisible by 10, so number `4539 3195 0343 6467` is valid!
 
 ### Example 2: invalid credit card number
 
@@ -46,18 +45,19 @@ This number is valid!
 8273 1232 7352 0569
 ```
 
-Double the second digits, starting from the right
+Double every second digit, and subtract 9 if the doubled digit exceeds 9.
+We end up with:
 
 ```text
 7253 2262 5312 0539
 ```
 
-Sum the digits
+Sum the digits:
 
 ```text
 7+2+5+3+2+2+6+2+5+3+1+2+0+5+3+9 = 57
 ```
 
-57 is not evenly divisible by 10, so this number is not valid.
+57 is not evenly divisible by 10, so number `8273 1232 7352 0569` is not valid!
 
 [luhn]: https://en.wikipedia.org/wiki/Luhn_algorithm

--- a/exercises/luhn/introduction.md
+++ b/exercises/luhn/introduction.md
@@ -2,10 +2,10 @@
 
 At the Global Verification Authority, you've just been entrusted with a critical assignment.
 Across the city, from online purchases to secure logins, countless operations rely on the accuracy of numerical identifiers like credit card numbers, bank account numbers, transaction codes, and tracking IDs.
-The Luhn algorithm is a simple checksum formula used to ensure these numbers are valid and error-free.
+The Luhn algorithm is a simple checksum formula used to help identify mistyped numbers.
 
 A batch of identifiers has just arrived on your desk.
 All of them must pass the Luhn test to ensure they're legitimate.
-If any fail, they'll be flagged as invalid, preventing errors or fraud, such as incorrect transactions or unauthorized access.
+If any fail, they'll be flagged as invalid, preventing mistakes such as incorrect transactions or failed account verifications.
 
 Can you ensure this is done right? The integrity of many services depends on you.


### PR DESCRIPTION
Forum topic https://forum.exercism.org/t/luhn-fix-instructions/16242

Summary:

* Updated the instructions: "credit card numbers" was changed to "numbers"
* Removed references to fraud from the introduction. According to Wikipedia, the algorithm isn't used for fraud detection.
* Updated the headings: There is now a level 2 main heading called "Examples," with each example starting with a level 3 heading.
* The original examples both used valid/invalid credit card numbers. Since they featured the same type of numbers with an even number of digits, the second example was replaced with an invalid Canadian SIN that has nine digits to better demonstrate the algorithm.
* Refined the wording throughout the instructions to improve clarity.