### PR TITLE
Correct displayed number in `eliuds-eggs`

### DIFF
--- a/exercises/eliuds-eggs/introduction.md
+++ b/exercises/eliuds-eggs/introduction.md
@@ -58,7 +58,7 @@ The position information encoding is calculated as follows:
 
 ### Decimal number on the display
 
-16
+8
 
 ### Actual eggs in the coop
 


### PR DESCRIPTION
See https://forum.exercism.org/t/incorrect-base-10-value-in-eliuds-eggs-example-2/16007/2.