### PR TITLE
Update `phone-number` instructions

### DIFF
--- a/exercises/phone-number/instructions.md
+++ b/exercises/phone-number/instructions.md
@@ -1,6 +1,6 @@
 # Instructions
 
-Clean up user-entered phone numbers so that they can be sent SMS messages.
+Clean up phone numbers so that they can be sent SMS messages.
 
 The **North American Numbering Plan (NANP)** is a telephone numbering system used by many countries in North America like the United States, Canada or Bermuda.
 All NANP-countries share the same international country code: `1`.


### PR DESCRIPTION
https://forum.exercism.org/t/phone-number-instructions-are-confusing/16865
In the introduction, we reference users submitting phone numbers that need to be cleaned up. However, in the instructions, user-entered reads like these numbers are coming from standard input, which would be a track-specific implementation detail. Removing this piece doesn't make the instructions less clear.