### PR TITLE
Crypto Square: fix test case description

### DIFF
--- a/exercises/crypto-square/canonical-data.json
+++ b/exercises/crypto-square/canonical-data.json
@@ -66,6 +66,16 @@
     },
     {
       "uuid": "fbcb0c6d-4c39-4a31-83f6-c473baa6af80",
+      "description": "54 character plaintext results in 7 chunks, the last two with trailing spaces",
+      "property": "ciphertext",
+      "input": {
+        "plaintext": "If man was meant to stay on the ground, god would have given us roots."
+      },
+      "expected": "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau "
+    },
+    {
+      "uuid": "33fd914e-fa44-445b-8f38-ff8fbc9fe6e6",
+      "reimplements": "fbcb0c6d-4c39-4a31-83f6-c473baa6af80",
       "description": "54 character plaintext results in 8 chunks, the last two with trailing spaces",
       "property": "ciphertext",
       "input": {

--- a/exercises/crypto-square/canonical-data.json
+++ b/exercises/crypto-square/canonical-data.json
@@ -66,7 +66,7 @@
     },
     {
       "uuid": "fbcb0c6d-4c39-4a31-83f6-c473baa6af80",
-      "description": "54 character plaintext results in 7 chunks, the last two with trailing spaces",
+      "description": "54 character plaintext results in 8 chunks, the last two with trailing spaces",
       "property": "ciphertext",
       "input": {
         "plaintext": "If man was meant to stay on the ground, god would have given us roots."


### PR DESCRIPTION
54 character plaintext results in 8 chunks, not 7.

Discussed in https://forum.exercism.org/t/crypto-square-inaccurate-test-case-description/16878
