### PR TITLE
Tweak language and formatting in `protein-translation/description.md`

### DIFF
--- a/exercises/protein-translation/description.md
+++ b/exercises/protein-translation/description.md
@@ -5,13 +5,13 @@ Translate RNA sequences into proteins.
 You can break an RNA strand into three-nucleotide sequences called codons and then translate them into amino acids to make a protein like so:
 
 | RNA         | Three-letter codons | Amino acids                             |
-|-------------|---------------------|-----------------------------------------|
+| ----------- | ------------------- | --------------------------------------- |
 | "AUGUUUUCU" | "AUG", "UUU", "UCU" | "Methionine", "Phenylalanine", "Serine" |
 
 There are also three STOP codons. If you encounter any of these codons, ignore the rest of the sequence — the protein is complete. For example, UAA is a STOP codon, so ignore any subsequent codons:
 
 | RNA               | Three-letter codons               | Amino acids                             |
-|-------------------|-----------------------------------|-----------------------------------------|
+| ----------------- | --------------------------------- | --------------------------------------- |
 | "AUGUUUUCUUAAAUG" | "AUG", "UUU", "UCU", "UAA", "AUG" | "Methionine", "Phenylalanine", "Serine" |
 
 (Note that the latter AUG is not translated into another methionine.)

--- a/exercises/protein-translation/description.md
+++ b/exercises/protein-translation/description.md
@@ -7,7 +7,7 @@ RNA can be broken into three-nucleotide sequences called codons, and then transl
 RNA: `"AUGUUUUCU"` => translates to
 
 Codons: `"AUG", "UUU", "UCU"`
-=> which become a protein with the following sequence =>
+=> which become a protein with the following sequence
 
 Protein: `"Methionine", "Phenylalanine", "Serine"`
 
@@ -15,9 +15,8 @@ There are 64 codons which in turn correspond to 20 amino acids; however, all of 
 If it works for one codon, the program should work for all of them.
 However, feel free to expand the list in the test suite to include them all.
 
-There are also three terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the protein is terminated.
-
-All subsequent codons after are ignored, like this:
+There are also three terminating codons (also known as _stop codons_); if any of these codons are encountered, all translation ends and the protein is terminated.
+All subsequent codons are ignored, like this:
 
 RNA: `"AUGUUUUCUUAAAUG"` =>
 

--- a/exercises/protein-translation/description.md
+++ b/exercises/protein-translation/description.md
@@ -2,29 +2,19 @@
 
 Translate RNA sequences into proteins.
 
-RNA can be broken into three-nucleotide sequences called codons, and then translated to a protein like so:
+You can break an RNA strand into three-nucleotide sequences called codons and then translate them into amino acids to make a protein like so:
 
-RNA: `"AUGUUUUCU"` => translates to
+| RNA         | Three-letter codons | Amino acids                             |
+|-------------|---------------------|-----------------------------------------|
+| "AUGUUUUCU" | "AUG", "UUU", "UCU" | "Methionine", "Phenylalanine", "Serine" |
 
-Codons: `"AUG", "UUU", "UCU"`
-=> which become a protein with the following sequence
+There are also three STOP codons. If you encounter any of these codons, ignore the rest of the sequence — the protein is complete. For example, UAA is a STOP codon, so ignore any subsequent codons:
 
-Protein: `"Methionine", "Phenylalanine", "Serine"`
+| RNA               | Three-letter codons               | Amino acids                             |
+|-------------------|-----------------------------------|-----------------------------------------|
+| "AUGUUUUCUUAAAUG" | "AUG", "UUU", "UCU", "UAA", "AUG" | "Methionine", "Phenylalanine", "Serine" |
 
-There are 64 codons which in turn correspond to 20 amino acids; however, all of the codon sequences and resulting amino acids are not important in this exercise.
-If it works for one codon, the program should work for all of them.
-However, feel free to expand the list in the test suite to include them all.
-
-There are also three terminating codons (also known as _stop codons_); if any of these codons are encountered, all translation ends and the protein is terminated.
-All subsequent codons are ignored, like this:
-
-RNA: `"AUGUUUUCUUAAAUG"` =>
-
-Codons: `"AUG", "UUU", "UCU", "UAA", "AUG"` =>
-
-Protein: `"Methionine", "Phenylalanine", "Serine"`
-
-Note the stop codon `"UAA"` terminates the translation and the final methionine is not translated into the protein sequence.
+(Note that the latter AUG is not translated into another methionine.)
 
 Below are the codons and resulting amino acids needed for the exercise.
 

--- a/exercises/protein-translation/description.md
+++ b/exercises/protein-translation/description.md
@@ -14,8 +14,9 @@ There are also three STOP codons. If you encounter any of these codons, ignore t
 | ----------------- | --------------------------------- | --------------------------------------- |
 | "AUGUUUUCUUAAAUG" | "AUG", "UUU", "UCU", "UAA", "AUG" | "Methionine", "Phenylalanine", "Serine" |
 
-(Note that the latter AUG is not translated into another methionine.)
+In other words, the latter AUG is not translated into another methionine here because it’s preceded by a STOP codon.
 
+There are 64 codons which in turn correspond to 20 amino acids; however, not all codons will be used in this exercise.
 Below are the codons and resulting amino acids needed for the exercise.
 
 | Codon              | Amino Acid    |


### PR DESCRIPTION
- Remove extraneous `=>` for consistency
- Remove redundant "after" (given "subsequent")
- Wikipedia just calls them "stop codons," not "STOP codons," but I italicized instead as a way to introduce a new term

Discussion on the forum is at: https://forum.exercism.org/t/tweak-language-and-formatting-in-protein-translation-description-md/17005/16