### PR TITLE
Modified the description of resister-color-trio

### DIFF
--- a/exercises/resistor-color-trio/description.md
+++ b/exercises/resistor-color-trio/description.md
@@ -31,7 +31,7 @@ For the exercise it doesn't matter what ohms really are.
 For example:
 
 - orange-orange-black would be 33 and no zeros, which becomes 33 ohms.
-- orange-orange-red would be 33 and 2 zeros, which becomes 3300 ohms.
+- orange-orange-brown would be 33 and 1 zero, which becomes 330 ohms.
 - orange-orange-orange would be 33 and 3 zeros, which becomes 33000 ohms.
 
 (If Math is your thing, you may want to think of the zeros as exponents of 10.


### PR DESCRIPTION
Per the [discussion](http://forum.exercism.org/t/resister-color-trio-exercise-may-need-clarification/17391) in the forum, an example in the problem description of the resister-color-trio exercise has been replaced.