### PR TITLE
Remove generic link text from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ When creating a new exercise the design team needs to be informed so that a new 
 
 `canonical-data.json` for each exercise is checked for compliance against the [canonical-data.schema.json](canonical-data.schema.json).
 In order to run these tests, you will need to have `yarn` installed on your system.
-Install them from [here](https://yarnpkg.com/en/docs/install).
+Follow [the official Yarn installation directions](https://yarnpkg.com/en/docs/install).
 
 Install the required packages:
 


### PR DESCRIPTION
https://forum.exercism.org/t/fix-markdown-linter-issue-in-dot-dsl-readme/17733/8