### PR TITLE
Triangle: explicitly exclude degenerate triangles

### DIFF
--- a/exercises/triangle/description.md
+++ b/exercises/triangle/description.md
@@ -14,7 +14,7 @@ A _scalene_ triangle has all sides of different lengths.
 For a shape to be a triangle at all, all sides have to be of length > 0, and the sum of the lengths of any two sides must be greater than or equal to the length of the third side.
 
 ~~~~exercism/note
-We opted to not include degenerate triangles (triangles that violate these rules) in the tests to keep things simpler.
+We opted to not include tests for degenerate triangles (triangles that violate these rules) to keep things simpler.
 You may handle those situations if you wish to do so, or safely ignore them.
 ~~~~
 

--- a/exercises/triangle/description.md
+++ b/exercises/triangle/description.md
@@ -13,6 +13,11 @@ A _scalene_ triangle has all sides of different lengths.
 
 For a shape to be a triangle at all, all sides have to be of length > 0, and the sum of the lengths of any two sides must be greater than or equal to the length of the third side.
 
+~~~~exercism/note
+We opted to not include degenerate triangles (triangles that violate these rules) in the tests to keep things simpler.
+You may handle those situations if you wish to do so, or safely ignore them.
+~~~~
+
 In equations:
 
 Let `a`, `b`, and `c` be sides of the triangle.


### PR DESCRIPTION
Make the description explicit about degenerate triangles. See [forum thread](https://forum.exercism.org/t/triangle-tests-dont-cover-the-case-where-a-b-c-degenerate-triangle/18754/).