### PR TITLE
[ISBN Verifier] Error in tests

### DIFF
--- a/exercises/isbn-verifier/canonical-data.json
+++ b/exercises/isbn-verifier/canonical-data.json
@@ -69,6 +69,15 @@
       "expected": false
     },
     {
+      "uuid": "fdb14c99-4cf8-43c5-b06d-eb1638eff343",
+      "description": "X is not substituted by the value 10",
+      "property": "isValid",
+      "input": {
+        "isbn": "3-598-2X507-5"
+      },
+      "expected": false
+    },
+    {
       "uuid": "f6294e61-7e79-46b3-977b-f48789a4945b",
       "description": "valid isbn without separating dashes",
       "property": "isValid",


### PR DESCRIPTION
Check if the `X` character is only the verification digit

PR according to [this](https://forum.exercism.org/t/isbn-verifier-error-in-tests-that-check-if-the-x-character-is-only-the-verification-digit/19639) topic.

Resolve exercism/python#4014
