### PR TITLE
Clarify `line-up` rules

### DIFF
--- a/exercises/line-up/instructions.md
+++ b/exercises/line-up/instructions.md
@@ -5,9 +5,9 @@ Yaʻqūb expects to use numbers from 1 up to 999.
 
 Rules:
 
-- Numbers ending in 1 (except for 11) → `"st"`
-- Numbers ending in 2 (except for 12) → `"nd"`
-- Numbers ending in 3 (except for 13) → `"rd"`
+- Numbers ending in 1 (unless ending in 11) → `"st"`
+- Numbers ending in 2 (unless ending in 12) → `"nd"`
+- Numbers ending in 3 (unless ending in 13) → `"rd"`
 - All other numbers → `"th"`
 
 Examples:


### PR DESCRIPTION
Initially mentioned in https://github.com/exercism/problem-specifications/pull/2595#discussion_r2406055132 but separately discussed in https://forum.exercism.org/t/clarify-rule-exclusions-for-line-up, the rules for Line Up aren't clear on whether only the numbers 11, 12, and 13 are excluded or all numbers ending in 11, 12, or 13. This PR clarifies that the later interpretation is correct.