### PR TITLE
Add test for over-counting horizontal neighbors in Flower Field

### DIFF
--- a/exercises/flower-field/canonical-data.json
+++ b/exercises/flower-field/canonical-data.json
@@ -199,7 +199,7 @@
     },
     {
       "uuid": "6e4ac13a-3e43-4728-a2e3-3551d4b1a996",
-      "description": "over-counting horizontal neighbors",
+      "description": "multiple adjacent flowers",
       "property": "annotate",
       "input": {
         "garden": [" ** "]


### PR DESCRIPTION
This adds a single test case to catch implementations that overcount contiguous horizontal flowers (e.g., scanning chains instead of immediate neighbors). As discussed and approved in the forum thread: https://forum.exercism.org/t/flower-field-overcounting-horizontal-neighbors-issue/19774

The test uses the suggestion from @IsaacG: Input `[" ** "]`, Expected `["1**1"]`.

No vertical test added, as the buggy example doesn't fail there, and we agreed to keep tests non-exhaustive.

Thanks to @IsaacG, @SleeplessByte, and @mk-mxp for the feedback and consensus!