### PR TITLE
isbn-verifier: a check digit can only be one character

### DIFF
--- a/exercises/isbn-verifier/canonical-data.json
+++ b/exercises/isbn-verifier/canonical-data.json
@@ -69,6 +69,15 @@
       "expected": false
     },
     {
+      "uuid": "8005b57f-f194-44ee-88d2-a77ac4142591",
+      "description": "only one check digit is allowed",
+      "property": "isValid",
+      "input": {
+        "isbn": "3-598-21508-96"
+      },
+      "expected": false
+    },
+    {
       "uuid": "fdb14c99-4cf8-43c5-b06d-eb1638eff343",
       "description": "X is not substituted by the value 10",
       "property": "isValid",


### PR DESCRIPTION
A check digit can only be one character, even if the "sum" is divisible by eleven.

Given `3-598-21508-96`, suppose we take the weighted sum of the first 9 digits and then add _the remaining digits_ as the "check digit":

```sh
$ sh -c  'echo $(( (10*3 + 9*5 + 8*9 + 7*8 + 6*2 + 5*1 + 4*5 + 3*0 + 2*8 + 96) % 11 ))'
0
```
It should still be invalid for violating the description:

> The ISBN-10 format is 9 digits (0 to 9) plus one check character (either a digit or an X only).

Forum: http://forum.exercism.org/t/yet-another-isbn-edge-case-found/19787