### PR TITLE
Remove contradictory description from `grep` blurb

### DIFF
--- a/exercises/grep/metadata.toml
+++ b/exercises/grep/metadata.toml
@@ -1,4 +1,4 @@
 title = "Grep"
-blurb = "Search a file for lines matching a regular expression pattern. Return the line number and contents of each matching line."
+blurb = "Search a file for lines matching a regular expression pattern."
 source = "Conversation with Nate Foster."
 source_url = "https://www.cs.cornell.edu/courses/cs3110/2014sp/hw/0/ps0.pdf"


### PR DESCRIPTION
https://forum.exercism.org/t/misleading-blurb-for-grep/53758

The second sentence contradicts two of the flags from the instructions and the test suite.