### PR TITLE
state-of-tic-tac-toe: Add test cases for playing after a win

### DIFF
--- a/exercises/state-of-tic-tac-toe/canonical-data.json
+++ b/exercises/state-of-tic-tac-toe/canonical-data.json
@@ -409,6 +409,36 @@
           "expected": {
             "error": "Impossible board: game should have ended after the game was won"
           }
+        },
+        {
+          "uuid": "5a84757a-fc86-4328-aec9-a5759e6ed35d",
+          "description": "Invalid board: O kept playing after X wins",
+          "property": "gamestate",
+          "input": {
+            "board": [
+              "OO ",
+              "XXX",
+              " O "
+            ]
+          },
+          "expected": {
+            "error": "Impossible board: game should have ended after the game was won"
+          }
+        },
+        {
+          "uuid": "cf25543d-583a-4656-b9ab-f82dc00a4a02",
+          "description": "Invalid board: X kept playing after O wins",
+          "property": "gamestate",
+          "input": {
+            "board": [
+              "XX ",
+              "OOO",
+              " XX"
+            ]
+          },
+          "expected": {
+            "error": "Impossible board: game should have ended after the game was won"
+          }
         }
       ]
     }


### PR DESCRIPTION
Add two new canonical test cases to verify that an error is thrown when a player makes a move after the game has already been won:
- O kept playing after X wins
- X kept playing after O wins

See [forum thread](https://forum.exercism.org/t/proposal-adding-1-more-test-for-invalid-tic-tac-toe-state-where-x-wins-but-move-count-is-equal/19941/) for context.