### PR TITLE
swift-scheduling: add test for quarterly rollover off-by-one error

### DIFF
--- a/exercises/swift-scheduling/canonical-data.json
+++ b/exercises/swift-scheduling/canonical-data.json
@@ -168,6 +168,16 @@
         "description": "Q3"
       },
       "expected": "2023-09-29T08:00:00"
+    },
+    {
+      "uuid": "7c8f1616-be62-417e-bbd5-a60fa743eccc",
+      "description": "Q2 starting in the last month of the second quarter translates to the last workday of the second quarter of this year",
+      "property": "deliveryDate",
+      "input": {
+        "meetingStart": "2019-06-15T09:50:00",
+        "description": "Q2"
+      },
+      "expected": "2019-06-28T08:00:00"
     }
   ]
 }


### PR DESCRIPTION
Adds a test case for an off-by-one error where solutions incorrectly roll the delivery date to the next quarter/year when the meeting starts in the last month of the target quarter — even though it's still within that quarter.

meetingStart: 2019-06-15T09:50:00 (Q2)
expected deliveryDate: 2019-06-28T08:00:00 (last workday of Q2; June 30 is a Sunday)

Discussed and approved by maintainers here: https://forum.exercism.org/t/proposal-add-a-test-case-for-an-off-by-one-error-at-quarter-boundaries/65308