### PR TITLE
link-checker: find replacement for 403 url

### DIFF
--- a/exercises/perfect-numbers/metadata.toml
+++ b/exercises/perfect-numbers/metadata.toml
@@ -1,4 +1,4 @@
 title = "Perfect Numbers"
 blurb = "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers."
 source = "Taken from Chapter 2 of Functional Thinking by Neal Ford."
-source_url = "https://www.oreilly.com/library/view/functional-thinking/9781449365509/"
+source_url = "https://nealford.com/books/functionalthinking.html"


### PR DESCRIPTION
Fixes check failure in #2669
