### PR TITLE
line-up: add test cases for ordinal numbers that are multiples of 11/12/13 and update the descriptions

### DIFF
--- a/exercises/line-up/canonical-data.json
+++ b/exercises/line-up/canonical-data.json
@@ -9,7 +9,7 @@
   "cases": [
     {
       "uuid": "7760d1b8-4864-4db4-953b-0fa7c047dbc0",
-      "description": "format smallest number 4 ending in th",
+      "description": "format smallest non-exceptional ordinal numeral 4",
       "property": "format",
       "input": {
         "name": "Gianna",
@@ -19,7 +19,7 @@
     },
     {
       "uuid": "e8b7c715-6baa-4f7b-8fb3-2fa48044ab7a",
-      "description": "format greatest single digit number 9 ending in th",
+      "description": "format greatest single digit non-exceptional ordinal numeral 9",
       "property": "format",
       "input": {
         "name": "Maarten",
@@ -29,7 +29,7 @@
     },
     {
       "uuid": "f370aae9-7ae7-4247-90ce-e8ff8c6934df",
-      "description": "format number 5 ending in th",
+      "description": "format non-exceptional ordinal numeral 5",
       "property": "format",
       "input": {
         "name": "Petronila",
@@ -39,7 +39,7 @@
     },
     {
       "uuid": "37f10dea-42a2-49de-bb92-0b690b677908",
-      "description": "format number 6 ending in th",
+      "description": "format non-exceptional ordinal numeral 6",
       "property": "format",
       "input": {
         "name": "Attakullakulla",
@@ -49,7 +49,7 @@
     },
     {
       "uuid": "d8dfb9a2-3a1f-4fee-9dae-01af3600054e",
-      "description": "format number 7 ending in th",
+      "description": "format non-exceptional ordinal numeral 7",
       "property": "format",
       "input": {
         "name": "Kate",
@@ -59,7 +59,7 @@
     },
     {
       "uuid": "505ec372-1803-42b1-9377-6934890fd055",
-      "description": "format number 8 ending in th",
+      "description": "format non-exceptional ordinal numeral 8",
       "property": "format",
       "input": {
         "name": "Maximiliano",
@@ -69,7 +69,7 @@
     },
     {
       "uuid": "8267072d-be1f-4f70-b34a-76b7557a47b9",
-      "description": "format number 1 ending in st",
+      "description": "format exceptional ordinal numeral 1",
       "property": "format",
       "input": {
         "name": "Mary",
@@ -79,7 +79,7 @@
     },
     {
       "uuid": "4d8753cb-0364-4b29-84b8-4374a4fa2e3f",
-      "description": "format number 2 ending in nd",
+      "description": "format exceptional ordinal numeral 2",
       "property": "format",
       "input": {
         "name": "Haruto",
@@ -89,7 +89,7 @@
     },
     {
       "uuid": "8d44c223-3a7e-4f48-a0ca-78e67bf98aa7",
-      "description": "format number 3 ending in rd",
+      "description": "format exceptional ordinal numeral 3",
       "property": "format",
       "input": {
         "name": "Henriette",
@@ -99,7 +99,7 @@
     },
     {
       "uuid": "6c4f6c88-b306-4f40-bc78-97cdd583c21a",
-      "description": "format smallest two digit number 10 ending in th",
+      "description": "format smallest two digit non-exceptional ordinal numeral 10",
       "property": "format",
       "input": {
         "name": "Alvarez",
@@ -109,7 +109,7 @@
     },
     {
       "uuid": "e257a43f-d2b1-457a-97df-25f0923fc62a",
-      "description": "format number 11 ending in th",
+      "description": "format non-exceptional ordinal numeral 11",
       "property": "format",
       "input": {
         "name": "Jacqueline",
@@ -119,7 +119,7 @@
     },
     {
       "uuid": "bb1db695-4d64-457f-81b8-4f5a2107e3f4",
-      "description": "format number 12 ending in th",
+      "description": "format non-exceptional ordinal numeral 12",
       "property": "format",
       "input": {
         "name": "Juan",
@@ -129,7 +129,7 @@
     },
     {
       "uuid": "60a3187c-9403-4835-97de-4f10ebfd63e2",
-      "description": "format number 13 ending in th",
+      "description": "format non-exceptional ordinal numeral 13",
       "property": "format",
       "input": {
         "name": "Patricia",
@@ -139,7 +139,7 @@
     },
     {
       "uuid": "2bdcebc5-c029-4874-b6cc-e9bec80d603a",
-      "description": "format number 21 ending in st",
+      "description": "format exceptional ordinal numeral 21",
       "property": "format",
       "input": {
         "name": "Washi",
@@ -149,7 +149,7 @@
     },
     {
       "uuid": "a98e2e22-ab41-4557-a7c2-efedc19c16da",
-      "description": "format number 22 multiple of 11 ending in nd",
+      "description": "format exceptional ordinal numeral 22 ending in nd even though it is a multiple of 11",
       "property": "format",
       "input": {
         "name": "Ingrid",
@@ -159,7 +159,7 @@
     },
     {
       "uuid": "ab45d2fb-e0ee-4016-b605-76917584db0a",
-      "description": "format number 33 multiple of 11 ending in rd",
+      "description": "format exceptional ordinal numeral 33 ending in rd even though it is a multiple of 11",
       "property": "format",
       "input": {
         "name": "Mario",
@@ -168,18 +168,8 @@
       "expected": "Mario, you are the 33rd customer we serve today. Thank you!"
     },
     {
-      "uuid": "3f6c408c-4331-42b6-bb6c-3ad0823e568a",
-      "description": "format number 44 multiple of 11 ending in th",
-      "property": "format",
-      "input": {
-        "name": "Ugo",
-        "number": 44
-      },
-      "expected": "Ugo, you are the 44th customer we serve today. Thank you!"
-    },
-    {
       "uuid": "c9243603-9f17-45b3-9a41-db9ebdbf08e1",
-      "description": "format number 52 multiple of 13 ending in nd",
+      "description": "format exceptional ordinal numeral 52 ending in nd even though it is a multiple of 13",
       "property": "format",
       "input": {
         "name": "Quentin",
@@ -189,7 +179,7 @@
     },
     {
       "uuid": "74ee2317-0295-49d2-baf0-d56bcefa14e3",
-      "description": "format number 62 ending in nd",
+      "description": "format exceptional ordinal numeral 62",
       "property": "format",
       "input": {
         "name": "Nayra",
@@ -198,8 +188,18 @@
       "expected": "Nayra, you are the 62nd customer we serve today. Thank you!"
     },
     {
+      "uuid": "3f6c408c-4331-42b6-bb6c-3ad0823e568a",
+      "description": "format non-exceptional ordinal numeral 72 ending in nd even though it is a multiple of 12",
+      "property": "format",
+      "input": {
+        "name": "Ugo",
+        "number": 72
+      },
+      "expected": "Ugo, you are the 72nd customer we serve today. Thank you!"
+    },
+    {
       "uuid": "8db52cd9-9689-413f-a812-6c36fcfd0d07",
-      "description": "format number 91 multiple of 13 ending in st",
+      "description": "format exceptional ordinal numeral 91 ending in st even though it is a multiple of 13",
       "property": "format",
       "input": {
         "name": "Boris",
@@ -209,7 +209,7 @@
     },
     {
       "uuid": "b37c332d-7f68-40e3-8503-e43cbd67a0c4",
-      "description": "format number 100 ending in th",
+      "description": "format exceptional ordinal numeral 100",
       "property": "format",
       "input": {
         "name": "John",
@@ -219,7 +219,7 @@
     },
     {
       "uuid": "0375f250-ce92-4195-9555-00e28ccc4d99",
-      "description": "format number 101 ending in st",
+      "description": "format exceptional ordinal numeral 101",
       "property": "format",
       "input": {
         "name": "Zeinab",
@@ -229,7 +229,7 @@
     },
     {
       "uuid": "0d8a4974-9a8a-45a4-aca7-a9fb473c9836",
-      "description": "format number 112 multiple of 12 ending in th",
+      "description": "format non-exceptional ordinal numeral 112",
       "property": "format",
       "input": {
         "name": "Knud",
@@ -239,7 +239,7 @@
     },
     {
       "uuid": "06b62efe-199e-4ce7-970d-4bf73945713f",
-      "description": "format number 123 ending in rd",
+      "description": "format exceptional ordinal numeral 123",
       "property": "format",
       "input": {
         "name": "Yma",
@@ -249,7 +249,7 @@
     },
     {
       "uuid": "6792c54e-59a7-4faf-839a-c4bb61014229",
-      "description": "format large number 972 multiple of 12 ending in nd",
+      "description": "format large number 972 ending in nd even though it is a multiple of 12",
       "property": "format",
       "input": {
         "name": "Elias",

--- a/exercises/line-up/canonical-data.json
+++ b/exercises/line-up/canonical-data.json
@@ -148,6 +148,46 @@
       "expected": "Washi, you are the 21st customer we serve today. Thank you!"
     },
     {
+      "uuid": "a98e2e22-ab41-4557-a7c2-efedc19c16da",
+      "description": "format exceptional ordinal numeral 22",
+      "property": "format",
+      "input": {
+        "name": "Ingrid",
+        "number": 22
+      },
+      "expected": "Ingrid, you are the 22nd customer we serve today. Thank you!"
+    },
+    {
+      "uuid": "ab45d2fb-e0ee-4016-b605-76917584db0a",
+      "description": "format exceptional ordinal numeral 33",
+      "property": "format",
+      "input": {
+        "name": "Mario",
+        "number": 33
+      },
+      "expected": "Mario, you are the 33rd customer we serve today. Thank you!"
+    },
+    {
+      "uuid": "3f6c408c-4331-42b6-bb6c-3ad0823e568a",
+      "description": "format non-exceptional ordinal numeral 44",
+      "property": "format",
+      "input": {
+        "name": "Ugo",
+        "number": 44
+      },
+      "expected": "Ugo, you are the 44th customer we serve today. Thank you!"
+    },
+    {
+      "uuid": "c9243603-9f17-45b3-9a41-db9ebdbf08e1",
+      "description": "format exceptional ordinal numeral 52",
+      "property": "format",
+      "input": {
+        "name": "Quentin",
+        "number": 52
+      },
+      "expected": "Quentin, you are the 52nd customer we serve today. Thank you!"
+    },
+    {
       "uuid": "74ee2317-0295-49d2-baf0-d56bcefa14e3",
       "description": "format exceptional ordinal numeral 62",
       "property": "format",
@@ -156,6 +196,16 @@
         "number": 62
       },
       "expected": "Nayra, you are the 62nd customer we serve today. Thank you!"
+    },
+    {
+      "uuid": "8db52cd9-9689-413f-a812-6c36fcfd0d07",
+      "description": "format exceptional ordinal numeral 91",
+      "property": "format",
+      "input": {
+        "name": "Boris",
+        "number": 91
+      },
+      "expected": "Boris, you are the 91st customer we serve today. Thank you!"
     },
     {
       "uuid": "b37c332d-7f68-40e3-8503-e43cbd67a0c4",

--- a/exercises/line-up/canonical-data.json
+++ b/exercises/line-up/canonical-data.json
@@ -9,7 +9,7 @@
   "cases": [
     {
       "uuid": "7760d1b8-4864-4db4-953b-0fa7c047dbc0",
-      "description": "format smallest non-exceptional ordinal numeral 4",
+      "description": "format smallest number 4 ending in th",
       "property": "format",
       "input": {
         "name": "Gianna",
@@ -19,7 +19,7 @@
     },
     {
       "uuid": "e8b7c715-6baa-4f7b-8fb3-2fa48044ab7a",
-      "description": "format greatest single digit non-exceptional ordinal numeral 9",
+      "description": "format greatest single digit number 9 ending in th",
       "property": "format",
       "input": {
         "name": "Maarten",
@@ -29,7 +29,7 @@
     },
     {
       "uuid": "f370aae9-7ae7-4247-90ce-e8ff8c6934df",
-      "description": "format non-exceptional ordinal numeral 5",
+      "description": "format number 5 ending in th",
       "property": "format",
       "input": {
         "name": "Petronila",
@@ -39,7 +39,7 @@
     },
     {
       "uuid": "37f10dea-42a2-49de-bb92-0b690b677908",
-      "description": "format non-exceptional ordinal numeral 6",
+      "description": "format number 6 ending in th",
       "property": "format",
       "input": {
         "name": "Attakullakulla",
@@ -49,7 +49,7 @@
     },
     {
       "uuid": "d8dfb9a2-3a1f-4fee-9dae-01af3600054e",
-      "description": "format non-exceptional ordinal numeral 7",
+      "description": "format number 7 ending in th",
       "property": "format",
       "input": {
         "name": "Kate",
@@ -59,7 +59,7 @@
     },
     {
       "uuid": "505ec372-1803-42b1-9377-6934890fd055",
-      "description": "format non-exceptional ordinal numeral 8",
+      "description": "format number 8 ending in th",
       "property": "format",
       "input": {
         "name": "Maximiliano",
@@ -69,7 +69,7 @@
     },
     {
       "uuid": "8267072d-be1f-4f70-b34a-76b7557a47b9",
-      "description": "format exceptional ordinal numeral 1",
+      "description": "format number 1 ending in st",
       "property": "format",
       "input": {
         "name": "Mary",
@@ -79,7 +79,7 @@
     },
     {
       "uuid": "4d8753cb-0364-4b29-84b8-4374a4fa2e3f",
-      "description": "format exceptional ordinal numeral 2",
+      "description": "format number 2 ending in nd",
       "property": "format",
       "input": {
         "name": "Haruto",
@@ -89,7 +89,7 @@
     },
     {
       "uuid": "8d44c223-3a7e-4f48-a0ca-78e67bf98aa7",
-      "description": "format exceptional ordinal numeral 3",
+      "description": "format number 3 ending in rd",
       "property": "format",
       "input": {
         "name": "Henriette",
@@ -99,7 +99,7 @@
     },
     {
       "uuid": "6c4f6c88-b306-4f40-bc78-97cdd583c21a",
-      "description": "format smallest two digit non-exceptional ordinal numeral 10",
+      "description": "format smallest two digit number 10 ending in th",
       "property": "format",
       "input": {
         "name": "Alvarez",
@@ -109,7 +109,7 @@
     },
     {
       "uuid": "e257a43f-d2b1-457a-97df-25f0923fc62a",
-      "description": "format non-exceptional ordinal numeral 11",
+      "description": "format number 11 ending in th",
       "property": "format",
       "input": {
         "name": "Jacqueline",
@@ -119,7 +119,7 @@
     },
     {
       "uuid": "bb1db695-4d64-457f-81b8-4f5a2107e3f4",
-      "description": "format non-exceptional ordinal numeral 12",
+      "description": "format number 12 ending in th",
       "property": "format",
       "input": {
         "name": "Juan",
@@ -129,7 +129,7 @@
     },
     {
       "uuid": "60a3187c-9403-4835-97de-4f10ebfd63e2",
-      "description": "format non-exceptional ordinal numeral 13",
+      "description": "format number 13 ending in th",
       "property": "format",
       "input": {
         "name": "Patricia",
@@ -139,7 +139,7 @@
     },
     {
       "uuid": "2bdcebc5-c029-4874-b6cc-e9bec80d603a",
-      "description": "format exceptional ordinal numeral 21",
+      "description": "format number 21 ending in st",
       "property": "format",
       "input": {
         "name": "Washi",
@@ -149,7 +149,7 @@
     },
     {
       "uuid": "a98e2e22-ab41-4557-a7c2-efedc19c16da",
-      "description": "format exceptional ordinal numeral 22",
+      "description": "format number 22 multiple of 11 ending in nd",
       "property": "format",
       "input": {
         "name": "Ingrid",
@@ -159,7 +159,7 @@
     },
     {
       "uuid": "ab45d2fb-e0ee-4016-b605-76917584db0a",
-      "description": "format exceptional ordinal numeral 33",
+      "description": "format number 33 multiple of 11 ending in rd",
       "property": "format",
       "input": {
         "name": "Mario",
@@ -169,7 +169,7 @@
     },
     {
       "uuid": "3f6c408c-4331-42b6-bb6c-3ad0823e568a",
-      "description": "format non-exceptional ordinal numeral 44",
+      "description": "format number 44 multiple of 11 ending in th",
       "property": "format",
       "input": {
         "name": "Ugo",
@@ -179,7 +179,7 @@
     },
     {
       "uuid": "c9243603-9f17-45b3-9a41-db9ebdbf08e1",
-      "description": "format exceptional ordinal numeral 52",
+      "description": "format number 52 multiple of 13 ending in nd",
       "property": "format",
       "input": {
         "name": "Quentin",
@@ -189,7 +189,7 @@
     },
     {
       "uuid": "74ee2317-0295-49d2-baf0-d56bcefa14e3",
-      "description": "format exceptional ordinal numeral 62",
+      "description": "format number 62 ending in nd",
       "property": "format",
       "input": {
         "name": "Nayra",
@@ -199,7 +199,7 @@
     },
     {
       "uuid": "8db52cd9-9689-413f-a812-6c36fcfd0d07",
-      "description": "format exceptional ordinal numeral 91",
+      "description": "format number 91 multiple of 13 ending in st",
       "property": "format",
       "input": {
         "name": "Boris",
@@ -209,7 +209,7 @@
     },
     {
       "uuid": "b37c332d-7f68-40e3-8503-e43cbd67a0c4",
-      "description": "format exceptional ordinal numeral 100",
+      "description": "format number 100 ending in th",
       "property": "format",
       "input": {
         "name": "John",
@@ -219,7 +219,7 @@
     },
     {
       "uuid": "0375f250-ce92-4195-9555-00e28ccc4d99",
-      "description": "format exceptional ordinal numeral 101",
+      "description": "format number 101 ending in st",
       "property": "format",
       "input": {
         "name": "Zeinab",
@@ -229,7 +229,7 @@
     },
     {
       "uuid": "0d8a4974-9a8a-45a4-aca7-a9fb473c9836",
-      "description": "format non-exceptional ordinal numeral 112",
+      "description": "format number 112 multiple of 12 ending in th",
       "property": "format",
       "input": {
         "name": "Knud",
@@ -239,13 +239,23 @@
     },
     {
       "uuid": "06b62efe-199e-4ce7-970d-4bf73945713f",
-      "description": "format exceptional ordinal numeral 123",
+      "description": "format number 123 ending in rd",
       "property": "format",
       "input": {
         "name": "Yma",
         "number": 123
       },
       "expected": "Yma, you are the 123rd customer we serve today. Thank you!"
+    },
+    {
+      "uuid": "6792c54e-59a7-4faf-839a-c4bb61014229",
+      "description": "format large number 972 multiple of 12 ending in nd",
+      "property": "format",
+      "input": {
+        "name": "Elias",
+        "number": 972
+      },
+      "expected": "Elias, you are the 972nd customer we serve today. Thank you!"
     }
   ]
 }


### PR DESCRIPTION
See discussion: http://forum.exercism.org/t/line-up-exercise-missing-test-case-for-ordinal-suffix-multiples-of-11-12-13-outside-the-teens-range-are-not-covered/67586

## Summary

Adds test cases for `line-up` covering ordinal numbers that are multiples of 11, 12, or 13 outside the 11–13 range itself.
It also reformulate the descriptions to be more explicit about what it's testing.

## Problem
### Uncovered multiples of 11, 12 and 13
The test suite for `line-up` does not include any numbers whose last two digits are a multiple of 11, 12, or 13 outside the 11–13 range itself (e.g. 22, 24, 33, 36, 44, 52, 60, 63, 65, 72, 78, 91, 96…).

This gap allows an incorrect implementation to pass. For example, a common bug is checking divisibility instead of range when handling the "teens" exception:

```js
if (last2 % 11 === 0 || last2 % 12 === 0 || last2 % 13 === 0) return `${number}th`;
```

This looks like it's meant to handle the 11th/12th/13th exception (and does, since 11%11=0, 12%12=0, 13%13=0), but it also incorrectly catches any other multiple of 11, 12, or 13 (such as 22, 33, 44, 52, 91) and returns "th" for them instead of the correct "nd"/"rd"/"st".

### Unclear descriptions
As proposed in the discussion, the descriptions weren't clear enough about what they're covering

## Changes

- Added 5 new test cases: 22, 33, 44, 52, 91, covering both the exceptional (nd/rd/st) cases that expose the bug and one non-exceptional (th) case as a regression check.
- Updated descriptions to specify if it's a multiple of 11, 12 or 13 and the expected suffix